### PR TITLE
bios: replace EmuTOS block logo with pTOS

### DIFF
--- a/bios/initinfo.c
+++ b/bios/initinfo.c
@@ -54,6 +54,13 @@
 #define INFO_LENGTH 40      /* width of info lines (must fit in low-rez) */
 #define LOGO_LENGTH 23      /* must equal length of strings in pTOS logo */
 
+/*
+ * number of lines printed by initinfo() apart from the logo, used to centre
+ * the screen vertically; see initinfo() for the breakdown.  Lines that are
+ * only printed in specific cases are added to initinfo_height there.
+ */
+#define INITINFO_BASE_HEIGHT 14
+
 /* allowed values for Mxalloc mode: (defined in mem.h) */
 #define MX_STRAM 0
 #define MX_TTRAM 1
@@ -259,7 +266,12 @@ static void cprintf_bytesize(ULONG bytes)
 WORD initinfo(ULONG *pshiftbits)
 {
     int screen_height = linea_vars.v_cel_my + 1;
-    int initinfo_height = 20; /* Define ENABLE_KDEBUG to guess correct value */
+    /*
+     * The lines that are always printed: the logo, two separators of two
+     * lines each, six 'pair' lines, two messages, a blank line, and the
+     * final inverse line.  Define ENABLE_KDEBUG to check the total.
+     */
+    int initinfo_height = LOGO_HEIGHT + INITINFO_BASE_HEIGHT;
     int top_margin;
 #ifdef ENABLE_KDEBUG
     int actual_initinfo_height;

--- a/bios/initinfo.c
+++ b/bios/initinfo.c
@@ -64,13 +64,14 @@
 extern long total_alt_ram(void); /* in bdos/umem.c */
 #endif
 
-#define LOGO_HEIGHT 5
+#define LOGO_HEIGHT 6
 static char const logo[LOGO_HEIGHT][LOGO_LENGTH+1] =
     { "77777777777  777   7777",
-      "1111    7   7   7 7    ",
-      "1   1   7   7   7  777 ",
-      "1111    7   7   7     7",
-      "1       7    777  7777 " };
+      "        7   7   7 7    ",
+      "1111    7   7   7  777 ",
+      "1   1   7   7   7     7",
+      "1111    7    777  7777 ",
+      "1                      " };
 
 /* Print n spaces */
 static void print_spaces(WORD n)
@@ -258,7 +259,7 @@ static void cprintf_bytesize(ULONG bytes)
 WORD initinfo(ULONG *pshiftbits)
 {
     int screen_height = linea_vars.v_cel_my + 1;
-    int initinfo_height = 19; /* Define ENABLE_KDEBUG to guess correct value */
+    int initinfo_height = 20; /* Define ENABLE_KDEBUG to guess correct value */
     int top_margin;
 #ifdef ENABLE_KDEBUG
     int actual_initinfo_height;

--- a/bios/initinfo.c
+++ b/bios/initinfo.c
@@ -52,7 +52,7 @@
 /*==== Defines ============================================================*/
 
 #define INFO_LENGTH 40      /* width of info lines (must fit in low-rez) */
-#define LOGO_LENGTH 34      /* must equal length of strings in EmuTOS logo */
+#define LOGO_LENGTH 23      /* must equal length of strings in pTOS logo */
 
 /* allowed values for Mxalloc mode: (defined in mem.h) */
 #define MX_STRAM 0
@@ -66,11 +66,11 @@ extern long total_alt_ram(void); /* in bdos/umem.c */
 
 #define LOGO_HEIGHT 5
 static char const logo[LOGO_HEIGHT][LOGO_LENGTH+1] =
-    { "11111111111 7777777777  777   7777",
-      "1                  7   7   7 7    ",
-      "1111   1 1  1   1  7   7   7  777 ",
-      "1     1 1 1 1   1  7   7   7     7",
-      "11111 1   1  111   7    777  7777 " };
+    { "77777777777  777   7777",
+      "1111    7   7   7 7    ",
+      "1   1   7   7   7  777 ",
+      "1111    7   7   7     7",
+      "1       7    777  7777 " };
 
 /* Print n spaces */
 static void print_spaces(WORD n)
@@ -299,7 +299,7 @@ WORD initinfo(ULONG *pshiftbits)
     /* Centre the logo horizontally */
     left_margin = (SCREEN_WIDTH-LOGO_LENGTH) / 2;
 
-    /* Now print the EmuTOS Logo */
+    /* Now print the pTOS Logo */
     for (i = 0; i < ARRAY_SIZE(logo); i++)
         print_art(logo[i]);
 


### PR DESCRIPTION
The startup info screen still drew the "EmuTOS" block graphic, which the
rebranding missed. Redraw it as "pTOS": a lowercase 'p' in colour 1 under
the overhanging bar of the 'T', followed by TOS in colour 7, reusing the
letter shapes and two-tone scheme of the original.

Shrink LOGO_LENGTH from 34 to 23 to match the new strings so the logo
still centres correctly.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014sLNaqV1hPcp52qzvsNsd1