### PR TITLE
arm-virt: fix AES process-0 stack misalignment, resolve gsx_init() Data Abort

### DIFF
--- a/aes/arch/arm/gemstart.S
+++ b/aes/arch/arm/gemstart.S
@@ -116,6 +116,11 @@ aes_restart:
         ldr     sp, =_D // D is a badly named global variable containing all the global gem vars
         add     sp, sp, r0
 
+        // Enforce AAPCS's 8-byte stack alignment before entering C: see the
+        // comment on the equivalent "bic sp, sp, #7" in _accdesk_start below
+        // for why THEGLO/UDA's own alignment isn't a strong enough guarantee.
+        bic     sp, sp, #7
+
         // go in C
         bl      _gem_main
 
@@ -145,6 +150,15 @@ _accdesk_start:
         ldr     sp, =_D
         ldr     sp, [sp, UDA_SPSUPER]   // use AES process 0 stack
 
+        // u_spsuper is not guaranteed to still be 8-byte aligned here: _dos_exec
+        // (below) temporarily rewrites it from its own live sp minus a fixed
+        // offset to guard against reentrancy, and that live sp reflects wherever
+        // gem_main()'s call depth happened to be at the Pexec() call site. gcc's
+        // auto-vectorizer (-mfpu=neon-vfpv4) requires AAPCS's 8-byte stack
+        // alignment for NEON/VFP loads of local variables and will Data Abort if
+        // it doesn't hold, so enforce it here at the point of use rather than
+        // trying to keep every upstream contributor aligned.
+        bic     sp, sp, #7
 
         ldr     r3, [r11, #PD_p_tlen]       // calc memory required
         ldr     r2, [r11, #PD_p_dlen]

--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -132,8 +132,25 @@ extern void accdesk_start(void) NORETURN;   /* see gemstart.S */
 LONG init_p0_stkptr(void)
 {
     UDA *u = &D.g_int[0].a_uda;
+    ULONG *stack_top = &u->u_supstk + 1;
 
-    u->u_spsuper = &u->u_supstk + 1;
+#if ARCH_ARM
+    /*
+     * ARM requires the stack pointer to be 8-byte aligned at every public
+     * interface (AAPCS), and gcc's auto-vectorizer (-mfpu=neon-vfpv4) relies
+     * on that invariant for NEON/VFP loads and stores of local variables,
+     * faulting with a Data Abort if it doesn't hold. THEGLO (D), which this
+     * stack lives at the end of, carries no alignment guarantee beyond the
+     * plain 4-byte alignment of its LONG members, so round the computed
+     * stack top down to the nearest 8-byte boundary. This is the stack used
+     * both by gem_main() itself and, via u_spsuper, by the accessory/desktop
+     * process spawned from it (see _accdesk_start in gemstart.S), so gsx_init()
+     * inherits whatever alignment is set up here.
+     */
+    stack_top = (ULONG *)((ULONG)stack_top & ~7UL);
+#endif
+
+    u->u_spsuper = stack_top;
 
     return (char *)u->u_spsuper - (char *)u;
 }


### PR DESCRIPTION
## Summary

Fixes #31. `gsx_init()` was crashing on a NEON `vld1.64 {d8-d9}, [sp :64]` stack load (Data Abort) because AES process 0's supervisor stack pointer isn't guaranteed 8-byte aligned, which AAPCS requires and gcc's auto-vectorizer (`-mfpu=neon-vfpv4`) relies on.

- `init_p0_stkptr()` (`aes/geminit.c`) computes that stack top from the global `THEGLO` struct, which carries no alignment guarantee beyond the plain 4-byte alignment of its `LONG` members.
- Worse: `_dos_exec`'s reentrancy guard (`aes/arch/arm/gemstart.S`) later *rewrites* the same field from its own live `sp` minus a fixed offset — a value that depends on wherever `gem_main()`'s call depth happened to be at the `Pexec()` call site, so its alignment shifts unpredictably with unrelated code changes. That's the value `_accdesk_start` actually loads to run the accessory/desktop process, which is what calls `gsx_init()`, so fixing only `init_p0_stkptr()` wasn't sufficient on its own.

This is a third, previously unidentified instance of the same class of bug already fixed twice during #25/#30 (`vbl_list`, `tosvars.ld` sysvars layout).

## Fix

Enforce 8-byte alignment at the two points where this value is actually loaded into `sp` (`_ui_start` and `_accdesk_start` in `gemstart.S`), plus align the computation in `init_p0_stkptr()` itself as defense in depth.

## Test plan

- [x] virt-arm: rebuilt, booted in QEMU (`qemu-system-arm -M virt -cpu cortex-a7 -m 128`) — no more Data Abort, boot reaches the desktop's event loop (`AES: EMUDESK: evnt_multi()`), stable over repeated/longer runs
- [x] rpi2: builds and links cleanly
- [x] m68k (atari192): change is `#if ARCH_ARM`-guarded / in ARM-only asm, no-op there (hit an unrelated pre-existing ICE in this environment's `m68k-atari-mintelf-gcc` toolchain on `bios/xbios.c`, confirmed present on a clean `master` checkout too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpRgAJuYg3EFcQvZAyCE9U