### PR TITLE
arm: align three more sp-producing sites found by auditing (#33)

### DIFF
--- a/bdos/proc.c
+++ b/bdos/proc.c
@@ -56,7 +56,19 @@ PD      *run;           /* ptr to PD for current process */
  * internal variables
  */
 
+/*
+ * common supervisor stack for all processes: every trap #1 call from every
+ * process runs its BDOS-side C code on this stack (see other_sp in
+ * proc_go() and its use in gouser(), bdos/arch/arm/rwa.S). On ARM, AAPCS
+ * requires sp to be 8-byte aligned at every public interface, which gcc's
+ * auto-vectorizer (-mfpu=neon-vfpv4) relies on, but a plain WORD array
+ * carries no alignment guarantee beyond the compiler's incidental default.
+ */
+#if ARCH_ARM
+static WORD    supstk[SUPSIZ] __attribute__((aligned(8)));
+#else
 static WORD    supstk[SUPSIZ]; /* common sup stack for all processes */
+#endif
 static jmp_buf bakbuf;         /* longjmp buffer */
 
 
@@ -364,6 +376,20 @@ static void init_pd_fields(PD *p, char *tail, long max, char *envptr)
     /* memory values */
     p->p_lowtpa = (BYTE *)p;               /*  M01.01.06   */
     p->p_hitpa  = (BYTE *)p  +  max;       /*  M01.01.06   */
+#if ARCH_ARM
+    /*
+     * p_hitpa becomes the actual initial user-mode sp of any process
+     * launched from this PD: proc_go()'s gouser_stack is unwound entirely
+     * by gouser() (bdos/arch/arm/rwa.S), landing sp at exactly p_hitpa, not
+     * at a gouser_stack-relative offset. AAPCS requires sp to be 8-byte
+     * aligned at every public interface, which gcc's auto-vectorizer
+     * (-mfpu=neon-vfpv4) relies on, but the free-memory allocator this
+     * pointer comes from (alloc_tpa()/ffit()/getmpb()) only guarantees
+     * 4-byte alignment. Round down; losing at most 7 bytes of TPA is
+     * harmless.
+     */
+    p->p_hitpa = (BYTE *)((ULONG)p->p_hitpa & ~7UL);
+#endif
     p->p_xdta = (DTA *) p->p_cmdlin;       /* default p_xdta is p_cmdlin */
     p->p_env = envptr;
 

--- a/emutos.ld
+++ b/emutos.ld
@@ -194,6 +194,14 @@ SECTIONS
      */
     .stack : LMA_AT(.stack)
     {
+        /* _stktop is shared by _biosmain and by every ARM exception mode's
+         * initial sp (IRQ/ABT/UND/SVC/FIQ; see each machine's startup.S).
+         * AAPCS requires sp to be 8-byte aligned at every public interface,
+         * which gcc's auto-vectorizer (-mfpu=neon-vfpv4) relies on, but
+         * nothing otherwise constrains where the preceding .bss section
+         * happens to end, so force it here.
+         */
+        . = ALIGN(8);
         _stkbot = .;
         . += 32K;
         _stktop = .;


### PR DESCRIPTION
## Summary

Fixes #33, a follow-up audit to #31/#32 per that issue's own scope note that properly fixing this class of bug means auditing every place that produces an address later used as `sp`, not just the one already found.

Three more sites had no 8-byte alignment guarantee, all currently *incidentally* aligned in the shipped configs — exactly the situation that made #31 a Heisenbug, since any future unrelated code change could flip one and silently reintroduce a Data Abort, this time with a much broader blast radius than the AES-only crash #32 fixed:

- **`p_hitpa`** (`bdos/proc.c`): tracing `gouser()`'s `ldmfd`+`rfefd` unwind (`bdos/arch/arm/rwa.S`) shows this becomes the *actual* initial user-mode `sp` of every process launched via `Pexec()` on ARM, not just the AES. The BDOS free-memory allocator only guarantees 4-byte alignment (`ffit()`/`getmpb()`/`balloc_stram()` all round/assert to 4). Rounded down at the point `p_hitpa` is computed; losing at most 7 bytes of TPA is harmless.
- **`supstk`** (`bdos/proc.c`): the shared supervisor-mode stack every process's every trap #1 call runs its BDOS-side C code on. Was a plain `WORD` array with no alignment attribute.
- **`_stktop`** (`emutos.ld`): the kernel's own C-runtime/interrupt stack, shared by `_biosmain` and every ARM exception mode's initial `sp` (IRQ/ABT/UND/SVC/FIQ) on both raspi and virt-arm. Had no `ALIGN(8)` before `_stkbot`, so it depended on wherever the preceding `.bss` section happened to end.

A fourth candidate (`gemusp` in `aes/arch/arm/gemstart.S`) was investigated and deprioritized — see #33 for why.

## Test plan

- [x] virt-arm: rebuilt, booted in QEMU — still reaches the desktop's event loop (`AES: EMUDESK: evnt_multi()`), no Data Abort
- [x] rpi2: builds and links cleanly
- [x] m68k (atari192): `bdos/proc.c`'s `#if ARCH_ARM` guard compiles as a correct no-op there (hit the same unrelated pre-existing ICE in this environment's `m68k-atari-mintelf-gcc` on `bios/xbios.c` already confirmed present on a clean `master` checkout during #32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpRgAJuYg3EFcQvZAyCE9U