### PR TITLE
Shared virtio-input keyboard/mouse driver for the QEMU virt ports

### DIFF
--- a/bios/Kconfig
+++ b/bios/Kconfig
@@ -166,6 +166,16 @@ config CONF_WITH_VIRTIO_BLK
 	  virtio-mmio transport. Devices appear as a new disk bus,
 	  partitioned the same way as ACSI/IDE/SD devices.
 
+config CONF_WITH_VIRTIO_INPUT
+	bool "virtio-input keyboard/mouse driver"
+	depends on CONF_WITH_VIRTIO
+	default y
+	help
+	  Keyboard and mouse/tablet driver for virtio-input devices found on
+	  the virtio-mmio transport, for the QEMU virt-arm/virt-m68k boards.
+	  No effect without a virtio-keyboard-device / virtio-tablet-device /
+	  virtio-mouse-device on the QEMU command line.
+
 config CONF_WITH_FDC
 	bool "Floppy disk controller support"
 	depends on CONF_ATARI_HARDWARE && CONF_WITH_MFP && CONF_WITH_YM2149

--- a/bios/arch/arm/aciaemu.c
+++ b/bios/arch/arm/aciaemu.c
@@ -121,9 +121,17 @@ void midivec( UBYTE data );
 void kbdvec( UBYTE data );
 static void _dummy_p(UBYTE *unused) { UNUSED(unused); }
 static void _dummy_c(UBYTE unused) { UNUSED(unused); }
+static void _dummy_w(WORD unused) { UNUSED(unused); }
 
 void init_acia_vecs(void)
 {
+    // mousexvec must never be NULL: mouse drivers call it from interrupt
+    // context for the extra buttons, possibly before the VDI has started
+    // and installed its own handler (and it is never installed at all in a
+    // boot without the VDI).  The m68k version of this file has the same
+    // contract, with just_rts as the initial value.
+    mousexvec = _dummy_w;
+
     kbdvecs.mousevec = _dummy_p;
     _kbdvec = kbdvec;
     kbdvecs.midivec = midivec;

--- a/bios/bios.c
+++ b/bios/bios.c
@@ -112,6 +112,10 @@ extern void setup_68040_pmmu(void);
 extern void usb_init(void); /* found in usb.h */
 #endif
 
+#if CONF_WITH_VIRTIO_INPUT
+extern void virtio_input_init(void); /* found in virtio_input.h */
+#endif
+
 /*==== Declarations =======================================================*/
 
 /* Drive specific declarations */
@@ -451,6 +455,11 @@ static void bios_init(void)
         KDEBUG(("usb_init()\n"));
         usb_init();
     KDEBUG(("after usb_init()\n"));
+#endif
+#if CONF_WITH_VIRTIO_INPUT
+        KDEBUG(("virtio_input_init()\n"));
+        virtio_input_init();
+    KDEBUG(("after virtio_input_init()\n"));
 #endif
 
     /* Now we can enable the interrupts.

--- a/bios/build.mk
+++ b/bios/build.mk
@@ -43,7 +43,7 @@ obj-$(MACHINE_VIRT_M68K) += goldfish_tty.o goldfish_pic.o goldfish_rtc.o goldfis
 
 obj-$(CONF_WITH_VIRTIO_BLK) += virtio_blk.o
 
-obj-$(CONF_WITH_VIRTIO_INPUT) += virtio_input.o
+obj-$(CONF_WITH_VIRTIO_INPUT) += virtio_input.o virtio_input_keytbl.o
 
 # Fonts.  A multi-language image needs the fonts of every charset, a
 # single-country one only those of its own charset.  See country.mk.

--- a/bios/build.mk
+++ b/bios/build.mk
@@ -43,6 +43,8 @@ obj-$(MACHINE_VIRT_M68K) += goldfish_tty.o goldfish_pic.o goldfish_rtc.o goldfis
 
 obj-$(CONF_WITH_VIRTIO_BLK) += virtio_blk.o
 
+obj-$(CONF_WITH_VIRTIO_INPUT) += virtio_input.o
+
 # Fonts.  A multi-language image needs the fonts of every charset, a
 # single-country one only those of its own charset.  See country.mk.
 obj-y += $(FONTOBJ)

--- a/bios/virtio_input.c
+++ b/bios/virtio_input.c
@@ -6,7 +6,7 @@
  * option any later version.  See doc/license.txt for details.
  */
 
-/*#define ENABLE_KDEBUG*/
+#define ENABLE_KDEBUG
 
 #include "config.h"
 
@@ -71,10 +71,19 @@ static UBYTE virtio_input_cfg_query(ULONG base, UBYTE select, UBYTE subsel)
 static void virtio_input_read_absinfo(ULONG base, UBYTE axis, LONG *out_min, LONG *out_max)
 {
     volatile ULONG *data = (volatile ULONG *)(base + VIRTIO_INPUT_CFG_DATA);
+    UBYTE size;
 
-    virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_ABS_INFO, axis);
-    *out_min = (LONG)le2cpu32(data[0]);
-    *out_max = (LONG)le2cpu32(data[1]);
+    size = virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_ABS_INFO, axis);
+    if (size > 0)
+    {
+        *out_min = (LONG)le2cpu32(data[0]);
+        *out_max = (LONG)le2cpu32(data[1]);
+    }
+    else
+    {
+        *out_min = 0;
+        *out_max = 0;
+    }
 }
 
 void virtio_input_init(void)
@@ -93,18 +102,13 @@ void virtio_input_init(void)
         if (!virtio_probe(base, VIRTIO_INPUT_DEVICE_ID, &probe_dev))
             continue;
 
-        if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_KEY) != 0)
-        {
-            if (virtio_input_kbd_present)
-            {
-                KDEBUG(("virtio_input_init: slot %d is another keyboard, ignored\n", slot));
-                continue;
-            }
-            virtio_input_kbd_dev = probe_dev;
-            virtio_input_kbd_present = TRUE;
-            KDEBUG(("virtio_input_init: keyboard at slot %d (base 0x%08lx)\n", slot, base));
-        }
-        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_ABS) != 0)
+        /* EV_ABS/EV_REL are checked before EV_KEY: QEMU's virtio-tablet-device
+         * and virtio-mouse-device both also report nonzero EV_KEY size (for
+         * their button codes), so an EV_KEY-first check would misclassify
+         * them as a second keyboard and never detect the pointer. No real
+         * keyboard reports motion capability, so "EV_KEY set, EV_ABS/EV_REL
+         * not" is what actually identifies a keyboard. */
+        if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_ABS) != 0)
         {
             if (virtio_input_ptr_present)
             {
@@ -131,6 +135,17 @@ void virtio_input_init(void)
             virtio_input_ptr_is_abs = FALSE;
             virtio_input_ptr_present = TRUE;
             KDEBUG(("virtio_input_init: mouse at slot %d (base 0x%08lx)\n", slot, base));
+        }
+        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_KEY) != 0)
+        {
+            if (virtio_input_kbd_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another keyboard, ignored\n", slot));
+                continue;
+            }
+            virtio_input_kbd_dev = probe_dev;
+            virtio_input_kbd_present = TRUE;
+            KDEBUG(("virtio_input_init: keyboard at slot %d (base 0x%08lx)\n", slot, base));
         }
         else
         {

--- a/bios/virtio_input.c
+++ b/bios/virtio_input.c
@@ -13,6 +13,7 @@
 #if CONF_WITH_VIRTIO_INPUT
 
 #include "portab.h"
+#include "asm.h"
 #include "kprint.h"
 #include "endian.h"
 #include "virtio.h"
@@ -276,14 +277,49 @@ static void virtio_input_setup_eventq(VIRTIO_DEV *dev, struct virtio_input_event
     virtio_notify(dev);
 }
 
+/* Everything this driver dispatches into -- bios/ikbd.c's kbd_int(), and the
+ * VDI/AES chain behind call_mousevec() (vdi/arch/m68k/vdi_entry.S's
+ * mouse_int(), then the AES's far_bcha()/far_mcha() in
+ * aes/arch/m68k/gemdosif.S) -- is written on the assumption that it cannot be
+ * interrupted by the system timer tick.  On every other m68k machine that
+ * holds for free: mouse and key packets arrive from the IKBD interrupt at the
+ * same IPL as the tick (both are IPL 6 on the Atari -- ACIA and MFP timer C),
+ * so the two paths can never nest.  aes/gemdisp.c's forkq() states the
+ * requirement outright ("q a fork process, enter with ints OFF"), and both
+ * far_mcha() and the AES's own tick routine _tikcod call it; those two also
+ * switch to private stacks whose saved stack pointer lives in a single global
+ * slot each (gstksave/tstksave, aes/arch/m68k/gemdosif.S), which likewise only
+ * works if they cannot interrupt one another.
+ *
+ * QEMU's m68k virt board gives no such guarantee.  The virtio-mmio slots hang
+ * off Goldfish PIC instances 1-4, which hw/intc/m68k_irqc.c takes at CPU
+ * autovector levels 2-5 -- all *below* the Goldfish RTC on instance 5, whose
+ * level 6 drives EmuTOS's 200 Hz tick.  So the tick preempts this dispatch
+ * mid-flight and re-enters forkq(), corrupting the AES fork queue (fpt/fpcnt
+ * and D.g_fpdx[]) until the dispatcher calls a garbage f_code.
+ *
+ * Masking to IPL 7 for the duration of the dispatch restores the mutual
+ * exclusion those handlers require.  No tick is lost by it: the Goldfish RTC's
+ * interrupt line stays asserted until goldfish_rtc_service() acknowledges it,
+ * so a tick raised while we are masked is simply taken on the way out.
+ *
+ * Nothing is needed on ARM, where the CPU masks IRQs on exception entry.
+ */
 static void virtio_input_drain(VIRTIO_DEV *dev, struct virtio_input_event *buf, VIRTIO_INPUT_ROLE role)
 {
     UWORD idx;
     ULONG len;
     UWORD type, code;
     ULONG value;
+#if defined(MACHINE_VIRT_M68K)
+    WORD saved_sr;
+#endif
 
     virtio_handle_interrupt(dev);
+
+#if defined(MACHINE_VIRT_M68K)
+    saved_sr = set_sr(0x2700);
+#endif
 
     while (virtio_pop_used(dev, &idx, &len))
     {
@@ -330,6 +366,10 @@ static void virtio_input_drain(VIRTIO_DEV *dev, struct virtio_input_event *buf, 
                          (ULONG)sizeof(buf[idx]), VIRTIO_DESC_F_WRITE, 0);
         virtio_submit(dev, idx);
     }
+
+#if defined(MACHINE_VIRT_M68K)
+    set_sr(saved_sr);
+#endif
 
     virtio_notify(dev);
 }

--- a/bios/virtio_input.c
+++ b/bios/virtio_input.c
@@ -317,7 +317,7 @@ static void virtio_input_setup_eventq(VIRTIO_DEV *dev, struct virtio_input_event
  */
 static void virtio_input_drain(VIRTIO_DEV *dev, struct virtio_input_event *buf, VIRTIO_INPUT_ROLE role)
 {
-    UWORD idx;
+    ULONG idx;
     ULONG len;
     UWORD type, code;
     ULONG value;
@@ -339,7 +339,7 @@ static void virtio_input_drain(VIRTIO_DEV *dev, struct virtio_input_event *buf, 
          * descriptor slot to rewrite), so just drop it. */
         if (idx >= VIRTIO_QUEUE_SIZE)
         {
-            KDEBUG(("virtio_input: bad descriptor index %u from used ring, dropped\n", idx));
+            KDEBUG(("virtio_input: bad descriptor index %lu from used ring, dropped\n", idx));
             continue;
         }
 
@@ -372,9 +372,9 @@ static void virtio_input_drain(VIRTIO_DEV *dev, struct virtio_input_event *buf, 
             }
         }
 
-        virtio_desc_set(dev, idx, (ULONG)&buf[idx] + dev->phys_offset,
+        virtio_desc_set(dev, (UWORD)idx, (ULONG)&buf[idx] + dev->phys_offset,
                          (ULONG)sizeof(buf[idx]), VIRTIO_DESC_F_WRITE, 0);
-        virtio_submit(dev, idx);
+        virtio_submit(dev, (UWORD)idx);
     }
 
 #if defined(MACHINE_VIRT_M68K)

--- a/bios/virtio_input.c
+++ b/bios/virtio_input.c
@@ -90,8 +90,20 @@ struct virtio_input_event
     ULONG value;
 };
 
-static struct virtio_input_event virtio_input_kbd_buf[VIRTIO_QUEUE_SIZE];
-static struct virtio_input_event virtio_input_ptr_buf[VIRTIO_QUEUE_SIZE];
+/* Each event buffer gets a cache-line-aligned span of its own, following
+ * bios/virtio_blk.c's status-slot precedent: the per-entry
+ * invalidate_data_cache() in virtio_input_drain() (needed to see the
+ * device's fresh write past whatever the CPU had cached) is a pure
+ * invalidate, so a driver static sharing a line with these would silently
+ * lose its pending CPU writes on every input interrupt.  The alignment also
+ * guarantees no entry straddles a line boundary, which would leave part of
+ * it uninvalidated and hence read back stale.  An array of VIRTIO_QUEUE_SIZE
+ * 8-byte events is a whole number of 64-byte lines, so no trailing pad is
+ * needed. */
+static struct virtio_input_event virtio_input_kbd_buf[VIRTIO_QUEUE_SIZE]
+        __attribute__((aligned(VIRTIO_CACHE_LINE)));
+static struct virtio_input_event virtio_input_ptr_buf[VIRTIO_QUEUE_SIZE]
+        __attribute__((aligned(VIRTIO_CACHE_LINE)));
 
 #define VIRTIO_INPUT_KEY_AUTOREPEAT  2
 #define VIRTIO_INPUT_KEY_RELEASED    0x80   /* mirrors ikbd.c's private
@@ -275,22 +287,43 @@ static void virtio_input_drain(VIRTIO_DEV *dev, struct virtio_input_event *buf, 
 
     while (virtio_pop_used(dev, &idx, &len))
     {
-        (void)len;
+        /* Never trust the device's descriptor index as an array subscript:
+         * a malformed one would index outside buf[] and the descriptor
+         * table.  Such an entry can't be recycled either (we have no valid
+         * descriptor slot to rewrite), so just drop it. */
+        if (idx >= VIRTIO_QUEUE_SIZE)
+        {
+            KDEBUG(("virtio_input: bad descriptor index %u from used ring, dropped\n", idx));
+            continue;
+        }
+
 #if ARCH_ARM
         invalidate_data_cache(&buf[idx], sizeof(buf[idx]));
 #endif
-        type  = le2cpu16(buf[idx].type);
-        code  = le2cpu16(buf[idx].code);
-        value = le2cpu32(buf[idx].value);
 
-        if (role == VIRTIO_INPUT_ROLE_KEYBOARD)
+        /* A short write means the device didn't produce a whole event;
+         * decoding it would read fields it never filled in.  The buffer is
+         * still ours, so it gets recycled below either way. */
+        if (len < (ULONG)sizeof(buf[idx]))
         {
-            if (type == EV_KEY)
-                virtio_input_handle_key(code, value);
+            KDEBUG(("virtio_input: short event, %ld of %ld bytes, ignored\n",
+                    len, (LONG)sizeof(buf[idx])));
         }
         else
         {
-            virtio_input_handle_pointer(type, code, value);
+            type  = le2cpu16(buf[idx].type);
+            code  = le2cpu16(buf[idx].code);
+            value = le2cpu32(buf[idx].value);
+
+            if (role == VIRTIO_INPUT_ROLE_KEYBOARD)
+            {
+                if (type == EV_KEY)
+                    virtio_input_handle_key(code, value);
+            }
+            else
+            {
+                virtio_input_handle_pointer(type, code, value);
+            }
         }
 
         virtio_desc_set(dev, idx, (ULONG)&buf[idx] + dev->phys_offset,

--- a/bios/virtio_input.c
+++ b/bios/virtio_input.c
@@ -17,16 +17,24 @@
 #include "endian.h"
 #include "virtio.h"
 #include "virtio_input.h"
+#include "ikbd.h"
+#include "virtio_input_keytbl.h"
 
 #if defined(MACHINE_VIRT_ARM)
 #include "virt_memmap.h"
+#include "virt_pic.h"
 #define VIRTIO_MMIO_BASE    VIRT_VIRTIO_MMIO_BASE
 #define VIRTIO_MMIO_STRIDE  VIRT_VIRTIO_MMIO_STRIDE
 #define VIRTIO_MMIO_COUNT   VIRT_VIRTIO_MMIO_COUNT
 #elif defined(MACHINE_VIRT_M68K)
+#include "goldfish_pic.h"
 #define VIRTIO_MMIO_BASE    0xff010000UL
 #define VIRTIO_MMIO_STRIDE  0x200UL
 #define VIRTIO_MMIO_COUNT   128
+#endif
+
+#if ARCH_ARM
+extern void invalidate_data_cache(void *start, long size);
 #endif
 
 #define VIRTIO_INPUT_DEVICE_ID  18
@@ -57,6 +65,45 @@ static BOOL virtio_input_ptr_is_abs;      /* TRUE: tablet (EV_ABS), FALSE: mouse
 static LONG virtio_input_abs_min_x, virtio_input_abs_max_x;
 static LONG virtio_input_abs_min_y, virtio_input_abs_max_y;
 
+/* Wire format of one eventq entry (virtio-input spec 5.8.6.2): 8 bytes,
+ * every field little-endian regardless of guest endianness. */
+struct virtio_input_event
+{
+    UWORD type;
+    UWORD code;
+    ULONG value;
+};
+
+static struct virtio_input_event virtio_input_kbd_buf[VIRTIO_QUEUE_SIZE];
+static struct virtio_input_event virtio_input_ptr_buf[VIRTIO_QUEUE_SIZE];
+
+#define VIRTIO_INPUT_KEY_AUTOREPEAT  2
+#define VIRTIO_INPUT_KEY_RELEASED    0x80   /* mirrors ikbd.c's private
+                                              * KEY_RELEASED bit, which
+                                              * isn't exported via ikbd.h */
+
+typedef enum { VIRTIO_INPUT_ROLE_KEYBOARD, VIRTIO_INPUT_ROLE_POINTER } VIRTIO_INPUT_ROLE;
+
+static void virtio_input_handle_key(UWORD code, ULONG value)
+{
+    UBYTE scancode;
+
+    if (value == VIRTIO_INPUT_KEY_AUTOREPEAT)
+        return;   /* bios/ikbd.c's kb_timerc_int() already owns repeat timing */
+
+    if (code >= VIRTIO_INPUT_KEYTBL_SIZE || virtio_input_keytbl[code] == 0)
+    {
+        KDEBUG(("virtio_input: no scancode for evdev KEY code %u\n", code));
+        return;
+    }
+
+    scancode = virtio_input_keytbl[code];
+    if (value == 0)
+        scancode |= VIRTIO_INPUT_KEY_RELEASED;
+
+    kbd_int(scancode);
+}
+
 /* Writes select/subsel, returns the "size" byte -- nonzero means the
  * device supports that (select, subsel) query. */
 static UBYTE virtio_input_cfg_query(ULONG base, UBYTE select, UBYTE subsel)
@@ -86,11 +133,79 @@ static void virtio_input_read_absinfo(ULONG base, UBYTE axis, LONG *out_min, LON
     }
 }
 
+static void virtio_input_setup_eventq(VIRTIO_DEV *dev, struct virtio_input_event *buf)
+{
+    UWORD i;
+
+    for (i = 0; i < VIRTIO_QUEUE_SIZE; i++)
+    {
+        virtio_desc_set(dev, i, (ULONG)&buf[i] + dev->phys_offset,
+                         (ULONG)sizeof(buf[i]), VIRTIO_DESC_F_WRITE, 0);
+        virtio_submit(dev, i);
+    }
+    virtio_notify(dev);
+}
+
+static void virtio_input_drain(VIRTIO_DEV *dev, struct virtio_input_event *buf, VIRTIO_INPUT_ROLE role)
+{
+    UWORD idx;
+    ULONG len;
+    UWORD type, code;
+    ULONG value;
+
+    virtio_handle_interrupt(dev);
+
+    while (virtio_pop_used(dev, &idx, &len))
+    {
+        (void)len;
+#if ARCH_ARM
+        invalidate_data_cache(&buf[idx], sizeof(buf[idx]));
+#endif
+        type  = le2cpu16(buf[idx].type);
+        code  = le2cpu16(buf[idx].code);
+        value = le2cpu32(buf[idx].value);
+
+        if (role == VIRTIO_INPUT_ROLE_KEYBOARD)
+        {
+            if (type == EV_KEY)
+                virtio_input_handle_key(code, value);
+        }
+        /* VIRTIO_INPUT_ROLE_POINTER: dispatch added in Task 3 */
+
+        virtio_desc_set(dev, idx, (ULONG)&buf[idx] + dev->phys_offset,
+                         (ULONG)sizeof(buf[idx]), VIRTIO_DESC_F_WRITE, 0);
+        virtio_submit(dev, idx);
+    }
+
+    virtio_notify(dev);
+}
+
+static void virtio_input_kbd_isr(void)
+{
+    virtio_input_drain(&virtio_input_kbd_dev, virtio_input_kbd_buf, VIRTIO_INPUT_ROLE_KEYBOARD);
+}
+
+static void virtio_input_ptr_isr(void)
+{
+    virtio_input_drain(&virtio_input_ptr_dev, virtio_input_ptr_buf, VIRTIO_INPUT_ROLE_POINTER);
+}
+
+static void virtio_input_connect_irq(WORD slot, PFVOID handler)
+{
+#if defined(MACHINE_VIRT_ARM)
+    virt_connect_irq(VIRT_VIRTIO_IRQ_BASE + slot, handler);
+#elif defined(MACHINE_VIRT_M68K)
+    goldfish_pic_connect_irq((WORD)(1 + slot / 32), (WORD)(slot % 32), handler);
+#endif
+}
+
 void virtio_input_init(void)
 {
     WORD slot;
     ULONG base;
     VIRTIO_DEV probe_dev;
+
+    virtio_input_keytbl_init();
 
     virtio_input_kbd_present = FALSE;
     virtio_input_ptr_present = FALSE;
@@ -115,10 +230,23 @@ void virtio_input_init(void)
                 KDEBUG(("virtio_input_init: slot %d is another pointer, ignored\n", slot));
                 continue;
             }
+
             virtio_input_ptr_dev = probe_dev;
             virtio_input_ptr_is_abs = TRUE;
+#if defined(MACHINE_VIRT_ARM)
+            virtio_input_ptr_dev.phys_offset = VIRT_RAM_BASE;
+#elif defined(MACHINE_VIRT_M68K)
+            virtio_input_ptr_dev.phys_offset = 0;
+#endif
+            if (!virtio_setup_queue(&virtio_input_ptr_dev))
+            {
+                KDEBUG(("virtio_input_init: slot %d tablet queue setup failed\n", slot));
+                continue;
+            }
             virtio_input_read_absinfo(base, ABS_X, &virtio_input_abs_min_x, &virtio_input_abs_max_x);
             virtio_input_read_absinfo(base, ABS_Y, &virtio_input_abs_min_y, &virtio_input_abs_max_y);
+            virtio_input_connect_irq(slot, virtio_input_ptr_isr);
+            virtio_input_setup_eventq(&virtio_input_ptr_dev, virtio_input_ptr_buf);
             virtio_input_ptr_present = TRUE;
             KDEBUG(("virtio_input_init: tablet at slot %d (base 0x%08lx, x %ld..%ld, y %ld..%ld)\n",
                     slot, base, virtio_input_abs_min_x, virtio_input_abs_max_x,
@@ -131,8 +259,21 @@ void virtio_input_init(void)
                 KDEBUG(("virtio_input_init: slot %d is another pointer, ignored\n", slot));
                 continue;
             }
+
             virtio_input_ptr_dev = probe_dev;
             virtio_input_ptr_is_abs = FALSE;
+#if defined(MACHINE_VIRT_ARM)
+            virtio_input_ptr_dev.phys_offset = VIRT_RAM_BASE;
+#elif defined(MACHINE_VIRT_M68K)
+            virtio_input_ptr_dev.phys_offset = 0;
+#endif
+            if (!virtio_setup_queue(&virtio_input_ptr_dev))
+            {
+                KDEBUG(("virtio_input_init: slot %d mouse queue setup failed\n", slot));
+                continue;
+            }
+            virtio_input_connect_irq(slot, virtio_input_ptr_isr);
+            virtio_input_setup_eventq(&virtio_input_ptr_dev, virtio_input_ptr_buf);
             virtio_input_ptr_present = TRUE;
             KDEBUG(("virtio_input_init: mouse at slot %d (base 0x%08lx)\n", slot, base));
         }
@@ -143,7 +284,20 @@ void virtio_input_init(void)
                 KDEBUG(("virtio_input_init: slot %d is another keyboard, ignored\n", slot));
                 continue;
             }
+
             virtio_input_kbd_dev = probe_dev;
+#if defined(MACHINE_VIRT_ARM)
+            virtio_input_kbd_dev.phys_offset = VIRT_RAM_BASE;
+#elif defined(MACHINE_VIRT_M68K)
+            virtio_input_kbd_dev.phys_offset = 0;
+#endif
+            if (!virtio_setup_queue(&virtio_input_kbd_dev))
+            {
+                KDEBUG(("virtio_input_init: slot %d keyboard queue setup failed\n", slot));
+                continue;
+            }
+            virtio_input_connect_irq(slot, virtio_input_kbd_isr);
+            virtio_input_setup_eventq(&virtio_input_kbd_dev, virtio_input_kbd_buf);
             virtio_input_kbd_present = TRUE;
             KDEBUG(("virtio_input_init: keyboard at slot %d (base 0x%08lx)\n", slot, base));
         }

--- a/bios/virtio_input.c
+++ b/bios/virtio_input.c
@@ -268,6 +268,16 @@ static void virtio_input_setup_eventq(VIRTIO_DEV *dev, struct virtio_input_event
 {
     UWORD i;
 
+#if ARCH_ARM
+    /* Invalidate before the first submission: if the BSS clear at boot left
+     * dirty cache lines over these buffers, a later natural eviction could
+     * write stale zeros back over an event the device has already DMA'd in,
+     * racing ahead of the ISR's own invalidate_data_cache() call in
+     * virtio_input_drain() below. Not needed on m68k, which has no data
+     * cache in this port. */
+    invalidate_data_cache(buf, (long)sizeof(struct virtio_input_event) * VIRTIO_QUEUE_SIZE);
+#endif
+
     for (i = 0; i < VIRTIO_QUEUE_SIZE; i++)
     {
         virtio_desc_set(dev, i, (ULONG)&buf[i] + dev->phys_offset,

--- a/bios/virtio_input.c
+++ b/bios/virtio_input.c
@@ -183,6 +183,13 @@ static void virtio_input_handle_pointer(UWORD type, UWORD code, ULONG raw_value)
         break;
 
     case EV_REL:
+        /* (WORD)value truncates rather than clamps a delta outside
+         * [-32768, 32767]; accepted rather than fixed. QEMU's virtio-mouse
+         * derives REL_X/REL_Y from per-poll host mouse motion, which is
+         * single-digit to low-hundreds, orders of magnitude under the
+         * truncation point. Worst case is one wrong-direction jump,
+         * self-corrected by the next event -- no crash, no persistent
+         * state damage (unlike the ABS path, this keeps no accumulator). */
         if (code == REL_X)
             virtio_input_send_mouse_delta((WORD)value, 0);
         else if (code == REL_Y)

--- a/bios/virtio_input.c
+++ b/bios/virtio_input.c
@@ -18,7 +18,9 @@
 #include "virtio.h"
 #include "virtio_input.h"
 #include "ikbd.h"
+#include "tosvars.h"
 #include "virtio_input_keytbl.h"
+#include "lineavars.h"
 
 #if defined(MACHINE_VIRT_ARM)
 #include "virt_memmap.h"
@@ -57,6 +59,20 @@ extern void invalidate_data_cache(void *start, long size);
 #define ABS_X  0x00
 #define ABS_Y  0x01
 
+#define REL_X  0x00
+#define REL_Y  0x01
+
+#define BTN_LEFT    0x110
+#define BTN_RIGHT   0x111
+#define BTN_MIDDLE  0x112
+
+#define VIRTIO_INPUT_MOUSE_LEFT   0x02   /* MOUSE_REL_POS_REPORT button bits -- see
+                                           * bios/ikbd.c's private LEFT_BUTTON_DOWN/
+                                           * RIGHT_BUTTON_DOWN #defines, confirmed also
+                                           * by usb/udd_mouse.c's identical packet[0]
+                                           * construction */
+#define VIRTIO_INPUT_MOUSE_RIGHT  0x01
+
 static VIRTIO_DEV virtio_input_kbd_dev;
 static VIRTIO_DEV virtio_input_ptr_dev;
 static BOOL virtio_input_kbd_present;
@@ -83,6 +99,108 @@ static struct virtio_input_event virtio_input_ptr_buf[VIRTIO_QUEUE_SIZE];
                                               * isn't exported via ikbd.h */
 
 typedef enum { VIRTIO_INPUT_ROLE_KEYBOARD, VIRTIO_INPUT_ROLE_POINTER } VIRTIO_INPUT_ROLE;
+
+static UBYTE virtio_input_ptr_buttons;
+static BOOL virtio_input_x_valid, virtio_input_y_valid;   /* have we seen a baseline EV_ABS sample yet? */
+static LONG virtio_input_last_scaled_x, virtio_input_last_scaled_y;
+
+/* Sends one or more 3-byte IKBD relative-mouse packets covering (dx, dy),
+ * chunking into signed-byte-range steps if either component overflows
+ * it. Always sends at least one packet (even (0, 0), for button-only
+ * changes), since the ST always reports current button state alongside
+ * whatever motion happened. */
+static void virtio_input_send_mouse_delta(WORD dx, WORD dy)
+{
+    UBYTE packet[3];
+    WORD step_x, step_y;
+
+    do
+    {
+        step_x = (dx > 127) ? 127 : (dx < -128) ? -128 : dx;
+        step_y = (dy > 127) ? 127 : (dy < -128) ? -128 : dy;
+
+        packet[0] = (UBYTE)(0xf8 | virtio_input_ptr_buttons);
+        packet[1] = (UBYTE)step_x;
+        packet[2] = (UBYTE)step_y;
+        call_mousevec(packet);
+
+        dx = (WORD)(dx - step_x);
+        dy = (WORD)(dy - step_y);
+    } while (dx != 0 || dy != 0);
+}
+
+static LONG virtio_input_scale_abs(LONG value, LONG min, LONG max, WORD screen_max)
+{
+    if (max <= min)
+        return 0;
+    return (value - min) * (LONG)screen_max / (max - min);
+}
+
+static void virtio_input_handle_pointer(UWORD type, UWORD code, ULONG raw_value)
+{
+    LONG value = (LONG)raw_value;
+
+    switch (type)
+    {
+    case EV_KEY:
+        switch (code)
+        {
+        case BTN_LEFT:
+            if (value)
+                virtio_input_ptr_buttons |= VIRTIO_INPUT_MOUSE_LEFT;
+            else
+                virtio_input_ptr_buttons &= ~VIRTIO_INPUT_MOUSE_LEFT;
+            virtio_input_send_mouse_delta(0, 0);
+            break;
+        case BTN_RIGHT:
+            if (value)
+                virtio_input_ptr_buttons |= VIRTIO_INPUT_MOUSE_RIGHT;
+            else
+                virtio_input_ptr_buttons &= ~VIRTIO_INPUT_MOUSE_RIGHT;
+            virtio_input_send_mouse_delta(0, 0);
+            break;
+        case BTN_MIDDLE:
+            /* No 3rd button bit in the relative-mouse packet; matches
+             * usb/udd_mouse.c's handling of its own 3rd button. */
+            mousexvec(value ? 0x37 : 0xb7);
+            break;
+        default:
+            break;
+        }
+        break;
+
+    case EV_REL:
+        if (code == REL_X)
+            virtio_input_send_mouse_delta((WORD)value, 0);
+        else if (code == REL_Y)
+            virtio_input_send_mouse_delta(0, (WORD)value);
+        break;
+
+    case EV_ABS:
+        if (code == ABS_X)
+        {
+            LONG scaled = virtio_input_scale_abs(value, virtio_input_abs_min_x, virtio_input_abs_max_x,
+                                                  (WORD)(linea_vars.V_REZ_HZ - 1));
+            if (virtio_input_x_valid)
+                virtio_input_send_mouse_delta((WORD)(scaled - virtio_input_last_scaled_x), 0);
+            virtio_input_last_scaled_x = scaled;
+            virtio_input_x_valid = TRUE;
+        }
+        else if (code == ABS_Y)
+        {
+            LONG scaled = virtio_input_scale_abs(value, virtio_input_abs_min_y, virtio_input_abs_max_y,
+                                                  (WORD)(linea_vars.V_REZ_VT - 1));
+            if (virtio_input_y_valid)
+                virtio_input_send_mouse_delta(0, (WORD)(scaled - virtio_input_last_scaled_y));
+            virtio_input_last_scaled_y = scaled;
+            virtio_input_y_valid = TRUE;
+        }
+        break;
+
+    default:
+        break;   /* EV_SYN and anything else: nothing to do per-event */
+    }
+}
 
 static void virtio_input_handle_key(UWORD code, ULONG value)
 {
@@ -170,7 +288,10 @@ static void virtio_input_drain(VIRTIO_DEV *dev, struct virtio_input_event *buf, 
             if (type == EV_KEY)
                 virtio_input_handle_key(code, value);
         }
-        /* VIRTIO_INPUT_ROLE_POINTER: dispatch added in Task 3 */
+        else
+        {
+            virtio_input_handle_pointer(type, code, value);
+        }
 
         virtio_desc_set(dev, idx, (ULONG)&buf[idx] + dev->phys_offset,
                          (ULONG)sizeof(buf[idx]), VIRTIO_DESC_F_WRITE, 0);

--- a/bios/virtio_input.c
+++ b/bios/virtio_input.c
@@ -1,0 +1,146 @@
+/*
+ * virtio_input.c - virtio-input keyboard/mouse driver for the QEMU
+ * virt-arm/virt-m68k boards
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+/*#define ENABLE_KDEBUG*/
+
+#include "config.h"
+
+#if CONF_WITH_VIRTIO_INPUT
+
+#include "portab.h"
+#include "kprint.h"
+#include "endian.h"
+#include "virtio.h"
+#include "virtio_input.h"
+
+#if defined(MACHINE_VIRT_ARM)
+#include "virt_memmap.h"
+#define VIRTIO_MMIO_BASE    VIRT_VIRTIO_MMIO_BASE
+#define VIRTIO_MMIO_STRIDE  VIRT_VIRTIO_MMIO_STRIDE
+#define VIRTIO_MMIO_COUNT   VIRT_VIRTIO_MMIO_COUNT
+#elif defined(MACHINE_VIRT_M68K)
+#define VIRTIO_MMIO_BASE    0xff010000UL
+#define VIRTIO_MMIO_STRIDE  0x200UL
+#define VIRTIO_MMIO_COUNT   128
+#endif
+
+#define VIRTIO_INPUT_DEVICE_ID  18
+
+/* Config space, at offset 0x100 from the device's mmio base (virtio-input
+ * spec 5.8.5): select/subsel pick a query, size says how many bytes of
+ * the union at +0x08 the device filled in (0 == "not supported"). */
+#define VIRTIO_INPUT_CFG_SELECT  0x100
+#define VIRTIO_INPUT_CFG_SUBSEL  0x101
+#define VIRTIO_INPUT_CFG_SIZE    0x102
+#define VIRTIO_INPUT_CFG_DATA    0x108
+
+#define VIRTIO_INPUT_CFG_EV_BITS   0x11
+#define VIRTIO_INPUT_CFG_ABS_INFO  0x12
+
+#define EV_KEY  0x01
+#define EV_REL  0x02
+#define EV_ABS  0x03
+
+#define ABS_X  0x00
+#define ABS_Y  0x01
+
+static VIRTIO_DEV virtio_input_kbd_dev;
+static VIRTIO_DEV virtio_input_ptr_dev;
+static BOOL virtio_input_kbd_present;
+static BOOL virtio_input_ptr_present;
+static BOOL virtio_input_ptr_is_abs;      /* TRUE: tablet (EV_ABS), FALSE: mouse (EV_REL) */
+static LONG virtio_input_abs_min_x, virtio_input_abs_max_x;
+static LONG virtio_input_abs_min_y, virtio_input_abs_max_y;
+
+/* Writes select/subsel, returns the "size" byte -- nonzero means the
+ * device supports that (select, subsel) query. */
+static UBYTE virtio_input_cfg_query(ULONG base, UBYTE select, UBYTE subsel)
+{
+    volatile UBYTE *cfg = (volatile UBYTE *)base;
+
+    cfg[VIRTIO_INPUT_CFG_SELECT] = select;
+    cfg[VIRTIO_INPUT_CFG_SUBSEL] = subsel;
+    return cfg[VIRTIO_INPUT_CFG_SIZE];
+}
+
+static void virtio_input_read_absinfo(ULONG base, UBYTE axis, LONG *out_min, LONG *out_max)
+{
+    volatile ULONG *data = (volatile ULONG *)(base + VIRTIO_INPUT_CFG_DATA);
+
+    virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_ABS_INFO, axis);
+    *out_min = (LONG)le2cpu32(data[0]);
+    *out_max = (LONG)le2cpu32(data[1]);
+}
+
+void virtio_input_init(void)
+{
+    WORD slot;
+    ULONG base;
+    VIRTIO_DEV probe_dev;
+
+    virtio_input_kbd_present = FALSE;
+    virtio_input_ptr_present = FALSE;
+
+    for (slot = 0; slot < VIRTIO_MMIO_COUNT; slot++)
+    {
+        base = VIRTIO_MMIO_BASE + (ULONG)slot * VIRTIO_MMIO_STRIDE;
+
+        if (!virtio_probe(base, VIRTIO_INPUT_DEVICE_ID, &probe_dev))
+            continue;
+
+        if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_KEY) != 0)
+        {
+            if (virtio_input_kbd_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another keyboard, ignored\n", slot));
+                continue;
+            }
+            virtio_input_kbd_dev = probe_dev;
+            virtio_input_kbd_present = TRUE;
+            KDEBUG(("virtio_input_init: keyboard at slot %d (base 0x%08lx)\n", slot, base));
+        }
+        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_ABS) != 0)
+        {
+            if (virtio_input_ptr_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another pointer, ignored\n", slot));
+                continue;
+            }
+            virtio_input_ptr_dev = probe_dev;
+            virtio_input_ptr_is_abs = TRUE;
+            virtio_input_read_absinfo(base, ABS_X, &virtio_input_abs_min_x, &virtio_input_abs_max_x);
+            virtio_input_read_absinfo(base, ABS_Y, &virtio_input_abs_min_y, &virtio_input_abs_max_y);
+            virtio_input_ptr_present = TRUE;
+            KDEBUG(("virtio_input_init: tablet at slot %d (base 0x%08lx, x %ld..%ld, y %ld..%ld)\n",
+                    slot, base, virtio_input_abs_min_x, virtio_input_abs_max_x,
+                    virtio_input_abs_min_y, virtio_input_abs_max_y));
+        }
+        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_REL) != 0)
+        {
+            if (virtio_input_ptr_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another pointer, ignored\n", slot));
+                continue;
+            }
+            virtio_input_ptr_dev = probe_dev;
+            virtio_input_ptr_is_abs = FALSE;
+            virtio_input_ptr_present = TRUE;
+            KDEBUG(("virtio_input_init: mouse at slot %d (base 0x%08lx)\n", slot, base));
+        }
+        else
+        {
+            KDEBUG(("virtio_input_init: slot %d has no recognized role, ignored\n", slot));
+        }
+    }
+
+    KDEBUG(("virtio_input_init: keyboard %s, pointer %s\n",
+            virtio_input_kbd_present ? "present" : "absent",
+            virtio_input_ptr_present ? (virtio_input_ptr_is_abs ? "present (tablet)" : "present (mouse)") : "absent"));
+}
+
+#endif /* CONF_WITH_VIRTIO_INPUT */

--- a/bios/virtio_input.c
+++ b/bios/virtio_input.c
@@ -6,7 +6,7 @@
  * option any later version.  See doc/license.txt for details.
  */
 
-#define ENABLE_KDEBUG
+/*#define ENABLE_KDEBUG*/
 
 #include "config.h"
 

--- a/bios/virtio_input.c
+++ b/bios/virtio_input.c
@@ -91,16 +91,17 @@ struct virtio_input_event
     ULONG value;
 };
 
-/* Each event buffer gets a cache-line-aligned span of its own, following
- * bios/virtio_blk.c's status-slot precedent: the per-entry
+/* Each event buffer -- the whole VIRTIO_QUEUE_SIZE-entry array, not each
+ * individual entry -- is aligned to its own cache-line-aligned span,
+ * following bios/virtio_blk.c's status-slot precedent: the per-entry
  * invalidate_data_cache() in virtio_input_drain() (needed to see the
  * device's fresh write past whatever the CPU had cached) is a pure
- * invalidate, so a driver static sharing a line with these would silently
- * lose its pending CPU writes on every input interrupt.  The alignment also
- * guarantees no entry straddles a line boundary, which would leave part of
- * it uninvalidated and hence read back stale.  An array of VIRTIO_QUEUE_SIZE
- * 8-byte events is a whole number of 64-byte lines, so no trailing pad is
- * needed. */
+ * invalidate, so a driver static sharing a line with the array would
+ * silently lose its pending CPU writes on every input interrupt.  Aligning
+ * the array's base also guarantees no individual entry straddles a line
+ * boundary (which would leave part of it uninvalidated and hence read back
+ * stale), since an 8-byte event size divides evenly into a 64-byte line:
+ * every entry starts and ends within a single line, never spanning two. */
 static struct virtio_input_event virtio_input_kbd_buf[VIRTIO_QUEUE_SIZE]
         __attribute__((aligned(VIRTIO_CACHE_LINE)));
 static struct virtio_input_event virtio_input_ptr_buf[VIRTIO_QUEUE_SIZE]

--- a/bios/virtio_input.h
+++ b/bios/virtio_input.h
@@ -1,0 +1,19 @@
+/*
+ * virtio_input.h - virtio-input keyboard/mouse driver for the QEMU
+ * virt-arm/virt-m68k boards
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+#ifndef VIRTIO_INPUT_H
+#define VIRTIO_INPUT_H
+
+#include "portab.h"
+
+#if CONF_WITH_VIRTIO_INPUT
+
+void virtio_input_init(void);
+
+#endif /* CONF_WITH_VIRTIO_INPUT */
+
+#endif /* VIRTIO_INPUT_H */

--- a/bios/virtio_input_keytbl.c
+++ b/bios/virtio_input_keytbl.c
@@ -33,6 +33,14 @@ void virtio_input_keytbl_init(void)
     for (i = 1; i <= VIRTIO_INPUT_KEYTBL_IDENTITY_MAX; i++)
         virtio_input_keytbl[i] = (UBYTE)i;
 
+    /* KEY_KPASTERISK (keypad *) is the one evdev code in the identity range
+     * above whose Atari scancode (0x37) has a special, non-key meaning:
+     * bios/ikbd.c reads it as "mouse button 3" and routes it to mousexvec()
+     * instead of normal key handling. The numeric keypad is out of scope for
+     * this driver, so drop this one code back to 0 (unmapped) rather than
+     * letting it fire a phantom middle-click. */
+    virtio_input_keytbl[55] = 0;
+
     /* Navigation cluster: evdev numbers these from the AT "E0-prefixed"
      * extended set, which doesn't line up with the identity block above.
      * Atari's IKBD has its own fixed codes for the same keys (see

--- a/bios/virtio_input_keytbl.c
+++ b/bios/virtio_input_keytbl.c
@@ -1,0 +1,61 @@
+/*
+ * virtio_input_keytbl.c - evdev KEY_* to Atari IKBD scancode table
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+#include "config.h"
+
+#if CONF_WITH_VIRTIO_INPUT
+
+#include "portab.h"
+#include "string.h"
+#include "virtio_input_keytbl.h"
+
+UBYTE virtio_input_keytbl[VIRTIO_INPUT_KEYTBL_SIZE];
+
+/* evdev KEY_* codes 1 (KEY_ESC) through 68 (KEY_F10) number the entire
+ * main alphanumeric block -- letters, digits, punctuation, Tab, Enter,
+ * Backspace, Space, both Shifts, Ctrl, Alt, Caps Lock, F1-F10 -- using
+ * the exact same IBM PC XT Scan Code Set 1 numbering the Atari ST's own
+ * IKBD scancodes are built on (confirmed against bios/keyb_us.h's
+ * keytbl_us_norm[], which is indexed by Atari scancode: e.g. index 30 is
+ * 'a', and evdev's KEY_A is also 30). So this range is a straight
+ * identity mapping; only keys outside it need an explicit override. */
+#define VIRTIO_INPUT_KEYTBL_IDENTITY_MAX 68
+
+void virtio_input_keytbl_init(void)
+{
+    WORD i;
+
+    memset(virtio_input_keytbl, 0, sizeof(virtio_input_keytbl));
+
+    for (i = 1; i <= VIRTIO_INPUT_KEYTBL_IDENTITY_MAX; i++)
+        virtio_input_keytbl[i] = (UBYTE)i;
+
+    /* Navigation cluster: evdev numbers these from the AT "E0-prefixed"
+     * extended set, which doesn't line up with the identity block above.
+     * Atari's IKBD has its own fixed codes for the same keys (see
+     * bios/ikbd.c's private KEY_HOME/KEY_UPARROW/KEY_LTARROW/KEY_RTARROW/
+     * KEY_DNARROW/KEY_INSERT/KEY_DELETE #defines -- duplicated here as
+     * literals since those macros aren't exported via ikbd.h). */
+    virtio_input_keytbl[102] = 0x47;   /* KEY_HOME   -> KEY_HOME    */
+    virtio_input_keytbl[103] = 0x48;   /* KEY_UP     -> KEY_UPARROW */
+    virtio_input_keytbl[105] = 0x4b;   /* KEY_LEFT   -> KEY_LTARROW */
+    virtio_input_keytbl[106] = 0x4d;   /* KEY_RIGHT  -> KEY_RTARROW */
+    virtio_input_keytbl[108] = 0x50;   /* KEY_DOWN   -> KEY_DNARROW */
+    virtio_input_keytbl[110] = 0x52;   /* KEY_INSERT -> KEY_INSERT  */
+    virtio_input_keytbl[111] = 0x53;   /* KEY_DELETE -> KEY_DELETE  */
+
+    /* The ST keyboard has one physical Ctrl and one Alt key; map both
+     * evdev left/right variants onto them (the identity loop above
+     * already covered KEY_LEFTCTRL==29 and KEY_LEFTALT==56). */
+    virtio_input_keytbl[97]  = 0x1d;   /* KEY_RIGHTCTRL -> KEY_CTRL */
+    virtio_input_keytbl[100] = 0x38;   /* KEY_RIGHTALT  -> KEY_ALT  */
+
+    /* Out of scope for this driver (see design doc): numeric keypad,
+     * F11+, multimedia keys, Meta/Super. Left at 0 (unmapped, i.e.
+     * KDEBUG-logged and dropped by virtio_input.c, not "scancode 0"). */
+}
+
+#endif /* CONF_WITH_VIRTIO_INPUT */

--- a/bios/virtio_input_keytbl.h
+++ b/bios/virtio_input_keytbl.h
@@ -1,0 +1,22 @@
+/*
+ * virtio_input_keytbl.h - evdev KEY_* to Atari IKBD scancode table
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+#ifndef VIRTIO_INPUT_KEYTBL_H
+#define VIRTIO_INPUT_KEYTBL_H
+
+#include "portab.h"
+
+#define VIRTIO_INPUT_KEYTBL_SIZE 256
+
+/* Indexed by evdev KEY_* code (linux/input-event-codes.h). 0 means "no
+ * Atari scancode for this key" -- callers must treat that as a miss, not
+ * press the resulting scancode 0 (not a valid IKBD code anyway).
+ * Populated once by virtio_input_keytbl_init(); read-only after that. */
+extern UBYTE virtio_input_keytbl[VIRTIO_INPUT_KEYTBL_SIZE];
+
+void virtio_input_keytbl_init(void);
+
+#endif /* VIRTIO_INPUT_KEYTBL_H */

--- a/docs/superpowers/plans/2026-08-02-virtio-input-driver.md
+++ b/docs/superpowers/plans/2026-08-02-virtio-input-driver.md
@@ -243,18 +243,13 @@ void virtio_input_init(void)
         if (!virtio_probe(base, VIRTIO_INPUT_DEVICE_ID, &probe_dev))
             continue;
 
-        if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_KEY) != 0)
-        {
-            if (virtio_input_kbd_present)
-            {
-                KDEBUG(("virtio_input_init: slot %d is another keyboard, ignored\n", slot));
-                continue;
-            }
-            virtio_input_kbd_dev = probe_dev;
-            virtio_input_kbd_present = TRUE;
-            KDEBUG(("virtio_input_init: keyboard at slot %d (base 0x%08lx)\n", slot, base));
-        }
-        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_ABS) != 0)
+        /* EV_ABS/EV_REL are checked before EV_KEY: QEMU's virtio-tablet-device
+         * and virtio-mouse-device both also report nonzero EV_KEY size (for
+         * their button codes), so an EV_KEY-first check would misclassify
+         * them as a second keyboard and never detect the pointer. No real
+         * keyboard reports motion capability, so "EV_KEY set, EV_ABS/EV_REL
+         * not" is what actually identifies a keyboard. */
+        if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_ABS) != 0)
         {
             if (virtio_input_ptr_present)
             {
@@ -281,6 +276,17 @@ void virtio_input_init(void)
             virtio_input_ptr_is_abs = FALSE;
             virtio_input_ptr_present = TRUE;
             KDEBUG(("virtio_input_init: mouse at slot %d (base 0x%08lx)\n", slot, base));
+        }
+        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_KEY) != 0)
+        {
+            if (virtio_input_kbd_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another keyboard, ignored\n", slot));
+                continue;
+            }
+            virtio_input_kbd_dev = probe_dev;
+            virtio_input_kbd_present = TRUE;
+            KDEBUG(("virtio_input_init: keyboard at slot %d (base 0x%08lx)\n", slot, base));
         }
         else
         {
@@ -671,31 +677,13 @@ void virtio_input_init(void)
         if (!virtio_probe(base, VIRTIO_INPUT_DEVICE_ID, &probe_dev))
             continue;
 
-        if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_KEY) != 0)
-        {
-            if (virtio_input_kbd_present)
-            {
-                KDEBUG(("virtio_input_init: slot %d is another keyboard, ignored\n", slot));
-                continue;
-            }
-
-            virtio_input_kbd_dev = probe_dev;
-#if defined(MACHINE_VIRT_ARM)
-            virtio_input_kbd_dev.phys_offset = VIRT_RAM_BASE;
-#elif defined(MACHINE_VIRT_M68K)
-            virtio_input_kbd_dev.phys_offset = 0;
-#endif
-            if (!virtio_setup_queue(&virtio_input_kbd_dev))
-            {
-                KDEBUG(("virtio_input_init: slot %d keyboard queue setup failed\n", slot));
-                continue;
-            }
-            virtio_input_connect_irq(slot, virtio_input_kbd_isr);
-            virtio_input_setup_eventq(&virtio_input_kbd_dev, virtio_input_kbd_buf);
-            virtio_input_kbd_present = TRUE;
-            KDEBUG(("virtio_input_init: keyboard at slot %d (base 0x%08lx)\n", slot, base));
-        }
-        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_ABS) != 0)
+        /* EV_ABS/EV_REL are checked before EV_KEY: QEMU's virtio-tablet-device
+         * and virtio-mouse-device both also report nonzero EV_KEY size (for
+         * their button codes), so an EV_KEY-first check would misclassify
+         * them as a second keyboard and never detect the pointer. No real
+         * keyboard reports motion capability, so "EV_KEY set, EV_ABS/EV_REL
+         * not" is what actually identifies a keyboard. */
+        if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_ABS) != 0)
         {
             if (virtio_input_ptr_present)
             {
@@ -748,6 +736,30 @@ void virtio_input_init(void)
             virtio_input_setup_eventq(&virtio_input_ptr_dev, virtio_input_ptr_buf);
             virtio_input_ptr_present = TRUE;
             KDEBUG(("virtio_input_init: mouse at slot %d (base 0x%08lx)\n", slot, base));
+        }
+        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_KEY) != 0)
+        {
+            if (virtio_input_kbd_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another keyboard, ignored\n", slot));
+                continue;
+            }
+
+            virtio_input_kbd_dev = probe_dev;
+#if defined(MACHINE_VIRT_ARM)
+            virtio_input_kbd_dev.phys_offset = VIRT_RAM_BASE;
+#elif defined(MACHINE_VIRT_M68K)
+            virtio_input_kbd_dev.phys_offset = 0;
+#endif
+            if (!virtio_setup_queue(&virtio_input_kbd_dev))
+            {
+                KDEBUG(("virtio_input_init: slot %d keyboard queue setup failed\n", slot));
+                continue;
+            }
+            virtio_input_connect_irq(slot, virtio_input_kbd_isr);
+            virtio_input_setup_eventq(&virtio_input_kbd_dev, virtio_input_kbd_buf);
+            virtio_input_kbd_present = TRUE;
+            KDEBUG(("virtio_input_init: keyboard at slot %d (base 0x%08lx)\n", slot, base));
         }
         else
         {

--- a/docs/superpowers/plans/2026-08-02-virtio-input-driver.md
+++ b/docs/superpowers/plans/2026-08-02-virtio-input-driver.md
@@ -1,0 +1,1074 @@
+# Shared virtio-input keyboard/mouse driver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a virtio-input consumer on top of the existing virtio-mmio transport (`util/virtio.c`) so both QEMU `virt` boards (ARM and m68k) get a working keyboard and mouse/tablet, feeding the same `kbd_int()`/`call_mousevec()` BIOS entry points the real IKBD ACIA path and the raspi USB HID mouse driver already use.
+
+**Architecture:** `bios/virtio_input.c` discovers virtio-input devices (device ID 18, shared by keyboard/mouse/tablet) by probing every virtio-mmio slot and reading config-space capability bits to tell the roles apart. Each registered device gets its own eventq (queue 0) pre-loaded with 8 device-writable receive buffers; a per-role interrupt handler drains completed buffers via a new transport primitive, `virtio_pop_used()`, translates each `struct virtio_input_event`, and dispatches it — keyboard events through `kbd_int()`, pointer events (both `EV_REL` mice and `EV_ABS` tablets) through `call_mousevec()`/`mousexvec()` — then immediately resubmits the buffer. `bios/virtio_input_keytbl.c` holds the evdev-KEY_*-to-Atari-scancode table.
+
+**Tech Stack:** C90/gnu90 freestanding (no libc), m68k and ARM GNU cross assemblers. No host-side test framework exists for this codebase — verification is build success plus booting the actual image under QEMU and reading `KDEBUG` serial output and, for the pointer, an actual human moving the mouse over the QEMU display window (there is no way to inject input events from inside the guest, so unlike `virtio_blk`'s self-contained read/write self-test, the pointer path cannot be verified by an agent alone — see Task 3's testing note).
+
+## Global Constraints
+
+- Design doc: `docs/superpowers/specs/2026-08-02-virtio-input-driver-design.md`. Follow it; this plan only fills in the exact code.
+- C90 with GNU extensions (`-std=gnu90`): all declarations at the top of a block. Match the surrounding file's comment style (`/* */`).
+- 4-space indentation, no tabs, in `.c`/`.h`. Run `make gitready` before every commit.
+- Use `portab.h` types (`WORD`, `LONG`, `UBYTE`, `UWORD`, `ULONG`, `BOOL`, `PFVOID`) — never bare `int`/`long`.
+- Every multi-byte virtio-mmio register, virtqueue field, or `struct virtio_input_event` field is little-endian by spec, regardless of guest endianness. Always go through `include/endian.h` (`le2cpu32`/`cpu2le32`/`le2cpu16`/`cpu2le16`); never read/write a multi-byte field directly.
+- Every virtio-input device shares device ID **18** (unlike virtio-blk's ID 2) — `virtio_probe()` alone cannot tell keyboard/mouse/tablet apart; role comes from querying config space (offset `0x100` from the device's mmio base: `select`/`subsel`/`size` bytes at `+0x00`/`+0x01`/`+0x02`, data at `+0x08`).
+- `VIRTIO_QUEUE_SIZE` is 8 (from `util/virtio.h`) — the eventq is fully pre-populated with 8 device-writable receive buffers at init and kept full by resubmitting each buffer right after it's drained.
+- `KEY_RELEASED` (`0x80`) is `#define`d privately inside `bios/ikbd.c` and not exported via `ikbd.h` — `virtio_input.c` must define its own copy of this bit, it cannot `#include` ikbd.c's.
+- No `Initmous()` call and no IKBD hardware command of any kind — bypass the real chip entirely and call `call_mousevec()`/`mousexvec()` directly, exactly as `usb/udd_mouse.c` already does for the raspi USB mouse.
+- ARM `virt` boots with D-cache on; every eventq receive buffer needs `invalidate_data_cache()` (from `bios/processor.h`) after the device completes it and before the CPU reads it. m68k `virt` boots with caches off — those calls must stay `#if ARCH_ARM`-only (`virtio_notify()` already flushes the descriptor table/avail ring itself; consumers only need to invalidate their own data buffers after completion, exactly as `virtio_blk_rw()` does for `status`/`sectbuf`).
+- Any shared-tree file this plan touches (`bios/bios.c`, `bios/Kconfig`, `bios/build.mk`, `util/virtio.c`, `util/virtio.h`) compiles for **every** machine, not just the two virt boards — new code must be `#if CONF_WITH_VIRTIO_INPUT`-gated so it fully disappears on Atari/Amiga/ColdFire/raspi builds.
+- `util/` code must not `#include` any `bios/` header — `virtio_pop_used()` only touches `VIRTIO_DEV`'s own ring fields, no bios dependency needed.
+
+---
+
+## Task 1: Transport extension + build wiring + device discovery
+
+**Files:**
+- Modify: `util/virtio.h` — add `pop_idx` field to `VIRTIO_DEV`, declare `virtio_pop_used()`
+- Modify: `util/virtio.c` — initialize `pop_idx`, implement `virtio_pop_used()`
+- Create: `bios/virtio_input.h`
+- Create: `bios/virtio_input.c` (discovery only for this task — no queue setup, no interrupts, no event dispatch)
+- Modify: `bios/Kconfig` — add `CONF_WITH_VIRTIO_INPUT`
+- Modify: `bios/build.mk` — add `obj-$(CONF_WITH_VIRTIO_INPUT) += virtio_input.o`
+- Modify: `bios/bios.c` — call `virtio_input_init()` right after the existing `usb_init()` call
+
+**Interfaces:**
+- Produces (from `util/virtio.h`, used by Task 2):
+  ```c
+  BOOL virtio_pop_used(VIRTIO_DEV *dev, UWORD *out_index, ULONG *out_len);
+  ```
+- Produces (from `bios/virtio_input.h`, used by `bios/bios.c` and Tasks 2-3): `void virtio_input_init(void);`
+
+- [ ] **Step 1: Add `pop_idx` and `virtio_pop_used()` to `util/virtio.h`**
+
+Modify the `VIRTIO_DEV` struct (currently ending with `last_used_idx`/`done`):
+
+```c
+    UWORD last_used_idx;    /* used->idx last consumed by virtio_handle_interrupt() */
+    UWORD pop_idx;          /* used->idx last consumed by virtio_pop_used() -- independent
+                             * of last_used_idx: that one tracks "did anything complete"
+                             * for a single synchronous waiter (virtio_blk's model), this
+                             * one tracks "which entries has the caller actually drained"
+                             * for a queue that keeps several buffers in flight at once
+                             * (virtio-input's eventq). */
+    volatile BOOL done;     /* set by virtio_handle_interrupt(), cleared by virtio_submit() */
+} __attribute__((aligned(16))) VIRTIO_DEV;
+```
+
+Add the declaration after `virtio_handle_interrupt()`'s:
+
+```c
+/* Drains one not-yet-consumed used-ring entry: returns TRUE and fills
+ * *out_index (the descriptor index the device completed) and *out_len
+ * (bytes the device wrote/read), advancing past it; returns FALSE once
+ * the caller has caught up with dev->used.idx. Call this after
+ * virtio_handle_interrupt() has run (so dev->used is fresh). Unlike
+ * dev->done, which a single synchronous waiter clears by re-submitting,
+ * this lets a caller that keeps several buffers in flight (like
+ * virtio-input's eventq) drain them all in one interrupt. */
+BOOL virtio_pop_used(VIRTIO_DEV *dev, UWORD *out_index, ULONG *out_len);
+```
+
+- [ ] **Step 2: Implement `virtio_pop_used()` in `util/virtio.c`**
+
+In `virtio_probe()`, next to the existing `dev->last_used_idx = 0;`:
+
+```c
+    dev->base = base;
+    dev->phys_offset = 0;
+    dev->last_used_idx = 0;
+    dev->pop_idx = 0;
+    dev->done = FALSE;
+    return TRUE;
+```
+
+Add the new function after `virtio_handle_interrupt()`:
+
+```c
+BOOL virtio_pop_used(VIRTIO_DEV *dev, UWORD *out_index, ULONG *out_len)
+{
+    UWORD slot;
+
+    if (dev->pop_idx == le2cpu16(dev->used.idx))
+        return FALSE;
+
+    slot = dev->pop_idx % VIRTIO_QUEUE_SIZE;
+    *out_index = (UWORD)le2cpu32(dev->used.ring[slot].id);
+    *out_len = le2cpu32(dev->used.ring[slot].len);
+    dev->pop_idx++;
+
+    return TRUE;
+}
+```
+
+- [ ] **Step 3: Add the Kconfig option**
+
+Modify `bios/Kconfig`, inserting right after the `CONF_WITH_VIRTIO_BLK` block (after its closing blank line, before `config CONF_WITH_FDC`):
+
+```
+config CONF_WITH_VIRTIO_INPUT
+	bool "virtio-input keyboard/mouse driver"
+	depends on CONF_WITH_VIRTIO
+	default y
+	help
+	  Keyboard and mouse/tablet driver for virtio-input devices found on
+	  the virtio-mmio transport, for the QEMU virt-arm/virt-m68k boards.
+	  No effect without a virtio-keyboard-device / virtio-tablet-device /
+	  virtio-mouse-device on the QEMU command line.
+```
+
+- [ ] **Step 4: Write `bios/virtio_input.h`**
+
+```c
+/*
+ * virtio_input.h - virtio-input keyboard/mouse driver for the QEMU
+ * virt-arm/virt-m68k boards
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+#ifndef VIRTIO_INPUT_H
+#define VIRTIO_INPUT_H
+
+#include "portab.h"
+
+#if CONF_WITH_VIRTIO_INPUT
+
+void virtio_input_init(void);
+
+#endif /* CONF_WITH_VIRTIO_INPUT */
+
+#endif /* VIRTIO_INPUT_H */
+```
+
+- [ ] **Step 5: Write `bios/virtio_input.c` (discovery only)**
+
+```c
+/*
+ * virtio_input.c - virtio-input keyboard/mouse driver for the QEMU
+ * virt-arm/virt-m68k boards
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+/*#define ENABLE_KDEBUG*/
+
+#include "config.h"
+
+#if CONF_WITH_VIRTIO_INPUT
+
+#include "portab.h"
+#include "kprint.h"
+#include "endian.h"
+#include "virtio.h"
+#include "virtio_input.h"
+
+#if defined(MACHINE_VIRT_ARM)
+#include "virt_memmap.h"
+#define VIRTIO_MMIO_BASE    VIRT_VIRTIO_MMIO_BASE
+#define VIRTIO_MMIO_STRIDE  VIRT_VIRTIO_MMIO_STRIDE
+#define VIRTIO_MMIO_COUNT   VIRT_VIRTIO_MMIO_COUNT
+#elif defined(MACHINE_VIRT_M68K)
+#define VIRTIO_MMIO_BASE    0xff010000UL
+#define VIRTIO_MMIO_STRIDE  0x200UL
+#define VIRTIO_MMIO_COUNT   128
+#endif
+
+#define VIRTIO_INPUT_DEVICE_ID  18
+
+/* Config space, at offset 0x100 from the device's mmio base (virtio-input
+ * spec 5.8.5): select/subsel pick a query, size says how many bytes of
+ * the union at +0x08 the device filled in (0 == "not supported"). */
+#define VIRTIO_INPUT_CFG_SELECT  0x100
+#define VIRTIO_INPUT_CFG_SUBSEL  0x101
+#define VIRTIO_INPUT_CFG_SIZE    0x102
+#define VIRTIO_INPUT_CFG_DATA    0x108
+
+#define VIRTIO_INPUT_CFG_EV_BITS   0x11
+#define VIRTIO_INPUT_CFG_ABS_INFO  0x12
+
+#define EV_KEY  0x01
+#define EV_REL  0x02
+#define EV_ABS  0x03
+
+#define ABS_X  0x00
+#define ABS_Y  0x01
+
+static VIRTIO_DEV virtio_input_kbd_dev;
+static VIRTIO_DEV virtio_input_ptr_dev;
+static BOOL virtio_input_kbd_present;
+static BOOL virtio_input_ptr_present;
+static BOOL virtio_input_ptr_is_abs;      /* TRUE: tablet (EV_ABS), FALSE: mouse (EV_REL) */
+static LONG virtio_input_abs_min_x, virtio_input_abs_max_x;
+static LONG virtio_input_abs_min_y, virtio_input_abs_max_y;
+
+/* Writes select/subsel, returns the "size" byte -- nonzero means the
+ * device supports that (select, subsel) query. */
+static UBYTE virtio_input_cfg_query(ULONG base, UBYTE select, UBYTE subsel)
+{
+    volatile UBYTE *cfg = (volatile UBYTE *)base;
+
+    cfg[VIRTIO_INPUT_CFG_SELECT] = select;
+    cfg[VIRTIO_INPUT_CFG_SUBSEL] = subsel;
+    return cfg[VIRTIO_INPUT_CFG_SIZE];
+}
+
+static void virtio_input_read_absinfo(ULONG base, UBYTE axis, LONG *out_min, LONG *out_max)
+{
+    volatile ULONG *data = (volatile ULONG *)(base + VIRTIO_INPUT_CFG_DATA);
+
+    virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_ABS_INFO, axis);
+    *out_min = (LONG)le2cpu32(data[0]);
+    *out_max = (LONG)le2cpu32(data[1]);
+}
+
+void virtio_input_init(void)
+{
+    WORD slot;
+    ULONG base;
+    VIRTIO_DEV probe_dev;
+
+    virtio_input_kbd_present = FALSE;
+    virtio_input_ptr_present = FALSE;
+
+    for (slot = 0; slot < VIRTIO_MMIO_COUNT; slot++)
+    {
+        base = VIRTIO_MMIO_BASE + (ULONG)slot * VIRTIO_MMIO_STRIDE;
+
+        if (!virtio_probe(base, VIRTIO_INPUT_DEVICE_ID, &probe_dev))
+            continue;
+
+        if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_KEY) != 0)
+        {
+            if (virtio_input_kbd_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another keyboard, ignored\n", slot));
+                continue;
+            }
+            virtio_input_kbd_dev = probe_dev;
+            virtio_input_kbd_present = TRUE;
+            KDEBUG(("virtio_input_init: keyboard at slot %d (base 0x%08lx)\n", slot, base));
+        }
+        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_ABS) != 0)
+        {
+            if (virtio_input_ptr_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another pointer, ignored\n", slot));
+                continue;
+            }
+            virtio_input_ptr_dev = probe_dev;
+            virtio_input_ptr_is_abs = TRUE;
+            virtio_input_read_absinfo(base, ABS_X, &virtio_input_abs_min_x, &virtio_input_abs_max_x);
+            virtio_input_read_absinfo(base, ABS_Y, &virtio_input_abs_min_y, &virtio_input_abs_max_y);
+            virtio_input_ptr_present = TRUE;
+            KDEBUG(("virtio_input_init: tablet at slot %d (base 0x%08lx, x %ld..%ld, y %ld..%ld)\n",
+                    slot, base, virtio_input_abs_min_x, virtio_input_abs_max_x,
+                    virtio_input_abs_min_y, virtio_input_abs_max_y));
+        }
+        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_REL) != 0)
+        {
+            if (virtio_input_ptr_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another pointer, ignored\n", slot));
+                continue;
+            }
+            virtio_input_ptr_dev = probe_dev;
+            virtio_input_ptr_is_abs = FALSE;
+            virtio_input_ptr_present = TRUE;
+            KDEBUG(("virtio_input_init: mouse at slot %d (base 0x%08lx)\n", slot, base));
+        }
+        else
+        {
+            KDEBUG(("virtio_input_init: slot %d has no recognized role, ignored\n", slot));
+        }
+    }
+
+    KDEBUG(("virtio_input_init: keyboard %s, pointer %s\n",
+            virtio_input_kbd_present ? "present" : "absent",
+            virtio_input_ptr_present ? (virtio_input_ptr_is_abs ? "present (tablet)" : "present (mouse)") : "absent"));
+}
+
+#endif /* CONF_WITH_VIRTIO_INPUT */
+```
+
+- [ ] **Step 6: Wire `bios/build.mk`**
+
+Modify `bios/build.mk`, adding a new line right after `obj-$(CONF_WITH_VIRTIO_BLK) += virtio_blk.o`:
+
+```make
+obj-$(CONF_WITH_VIRTIO_INPUT) += virtio_input.o
+```
+
+- [ ] **Step 7: Call `virtio_input_init()` from `bios/bios.c`**
+
+Modify `bios/bios.c`. Add the extern declaration right after the existing `CONF_WITH_USB` block (after its `#endif`, around line 112):
+
+```c
+#if CONF_WITH_VIRTIO_INPUT
+extern void virtio_input_init(void); /* found in virtio_input.h */
+#endif
+```
+
+Add the call right after the existing `usb_init()` block (matching its exact indentation):
+
+```c
+#if CONF_WITH_USB
+        KDEBUG(("usb_init()\n"));
+        usb_init();
+    KDEBUG(("after usb_init()\n"));
+#endif
+#if CONF_WITH_VIRTIO_INPUT
+        KDEBUG(("virtio_input_init()\n"));
+        virtio_input_init();
+    KDEBUG(("after virtio_input_init()\n"));
+#endif
+```
+
+- [ ] **Step 8: Verify portability — build a non-virt config**
+
+```bash
+make distclean
+make rpi2_defconfig && make -j"$(nproc)" 2>&1 | tail -20
+```
+
+Expected: builds with no new warnings/errors (`CONF_WITH_VIRTIO_INPUT` is `0` here, since `rpi2` sets neither `MACHINE_VIRT_ARM` nor `MACHINE_VIRT_M68K`, so none of the new code compiles in).
+
+- [ ] **Step 9: Build and boot-test discovery on ARM**
+
+```bash
+make distclean
+make virt-arm_defconfig
+grep ENABLE_KDEBUG obj/autoconf.h   # confirm it's off by default; edit bios/virtio_input.c's
+                                    # "/*#define ENABLE_KDEBUG*/" to enable tracing for this test
+make -j"$(nproc)"
+qemu-system-arm -M virt -cpu cortex-a7 -kernel <image-from-the-"is-ready"-line> \
+  -global virtio-mmio.force-legacy=false \
+  -serial stdio -d guest_errors \
+  -device virtio-keyboard-device -device virtio-tablet-device
+```
+
+(`-global virtio-mmio.force-legacy=false` is required — this QEMU's `virt` board defaults virtio-mmio transports to legacy/version-1, which `virtio_probe()` correctly rejects since it's modern/version-2 only.)
+
+Expected KDEBUG output includes `virtio_input_init: keyboard at slot N ...`, `virtio_input_init: tablet at slot M ... x 0..32767, y 0..32767` (exact min/max come from QEMU's own virtio-tablet-device emulation), and `virtio_input_init: keyboard present, pointer present (tablet)`. This confirms the config-space role-detection logic works against real QEMU device emulation, independent of the queue/interrupt code Task 2 adds.
+
+- [ ] **Step 10: Repeat on m68k**
+
+```bash
+make distclean
+make virt-m68k_defconfig && make -j"$(nproc)"
+qemu-system-m68k -M virt -m 128 -cpu m68020 -kernel <image> \
+  -serial stdio -d guest_errors \
+  -device virtio-keyboard-device -device virtio-tablet-device
+```
+
+Expected: same KDEBUG output pattern as Step 9 (slot numbers may differ).
+
+- [ ] **Step 11: `make gitready` and commit**
+
+```bash
+make gitready
+git add util/virtio.h util/virtio.c bios/virtio_input.h bios/virtio_input.c \
+        bios/Kconfig bios/build.mk bios/bios.c
+git commit -m "virtio-input: add transport draining primitive and device discovery"
+git push
+```
+
+---
+
+## Task 2: Eventq lifecycle + keyboard event pipeline
+
+**Files:**
+- Create: `bios/virtio_input_keytbl.h`, `bios/virtio_input_keytbl.c`
+- Modify: `bios/build.mk` — add `virtio_input_keytbl.o` to the existing line
+- Modify: `bios/virtio_input.c` — add eventq setup/draining, IRQ wiring, and `EV_KEY` dispatch; pointer events are drained but not yet translated (Task 3)
+
+**Interfaces:**
+- Consumes: `virtio_pop_used()` (Task 1); `virt_connect_irq(int irq, PFVOID handler)` (`bios/machine/virt-arm/virt_pic.h`, existing); `goldfish_pic_connect_irq(WORD pic_index, WORD bit, PFVOID handler)` (`bios/machine/virt-m68k/goldfish_pic.h`, existing); `kbd_int(UBYTE scancode)` (`bios/ikbd.h`, existing).
+- Produces (from `bios/virtio_input_keytbl.h`, used by `virtio_input.c` only):
+  ```c
+  #define VIRTIO_INPUT_KEYTBL_SIZE 256
+  extern UBYTE virtio_input_keytbl[VIRTIO_INPUT_KEYTBL_SIZE];
+  void virtio_input_keytbl_init(void);
+  ```
+
+- [ ] **Step 1: Write `bios/virtio_input_keytbl.h`**
+
+```c
+/*
+ * virtio_input_keytbl.h - evdev KEY_* to Atari IKBD scancode table
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+#ifndef VIRTIO_INPUT_KEYTBL_H
+#define VIRTIO_INPUT_KEYTBL_H
+
+#include "portab.h"
+
+#define VIRTIO_INPUT_KEYTBL_SIZE 256
+
+/* Indexed by evdev KEY_* code (linux/input-event-codes.h). 0 means "no
+ * Atari scancode for this key" -- callers must treat that as a miss, not
+ * press the resulting scancode 0 (not a valid IKBD code anyway).
+ * Populated once by virtio_input_keytbl_init(); read-only after that. */
+extern UBYTE virtio_input_keytbl[VIRTIO_INPUT_KEYTBL_SIZE];
+
+void virtio_input_keytbl_init(void);
+
+#endif /* VIRTIO_INPUT_KEYTBL_H */
+```
+
+- [ ] **Step 2: Write `bios/virtio_input_keytbl.c`**
+
+```c
+/*
+ * virtio_input_keytbl.c - evdev KEY_* to Atari IKBD scancode table
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+#include "config.h"
+
+#if CONF_WITH_VIRTIO_INPUT
+
+#include "portab.h"
+#include "string.h"
+#include "virtio_input_keytbl.h"
+
+UBYTE virtio_input_keytbl[VIRTIO_INPUT_KEYTBL_SIZE];
+
+/* evdev KEY_* codes 1 (KEY_ESC) through 68 (KEY_F10) number the entire
+ * main alphanumeric block -- letters, digits, punctuation, Tab, Enter,
+ * Backspace, Space, both Shifts, Ctrl, Alt, Caps Lock, F1-F10 -- using
+ * the exact same IBM PC XT Scan Code Set 1 numbering the Atari ST's own
+ * IKBD scancodes are built on (confirmed against bios/keyb_us.h's
+ * keytbl_us_norm[], which is indexed by Atari scancode: e.g. index 30 is
+ * 'a', and evdev's KEY_A is also 30). So this range is a straight
+ * identity mapping; only keys outside it need an explicit override. */
+#define VIRTIO_INPUT_KEYTBL_IDENTITY_MAX 68
+
+void virtio_input_keytbl_init(void)
+{
+    WORD i;
+
+    memset(virtio_input_keytbl, 0, sizeof(virtio_input_keytbl));
+
+    for (i = 1; i <= VIRTIO_INPUT_KEYTBL_IDENTITY_MAX; i++)
+        virtio_input_keytbl[i] = (UBYTE)i;
+
+    /* Navigation cluster: evdev numbers these from the AT "E0-prefixed"
+     * extended set, which doesn't line up with the identity block above.
+     * Atari's IKBD has its own fixed codes for the same keys (see
+     * bios/ikbd.c's private KEY_HOME/KEY_UPARROW/KEY_LTARROW/KEY_RTARROW/
+     * KEY_DNARROW/KEY_INSERT/KEY_DELETE #defines -- duplicated here as
+     * literals since those macros aren't exported via ikbd.h). */
+    virtio_input_keytbl[102] = 0x47;   /* KEY_HOME   -> KEY_HOME    */
+    virtio_input_keytbl[103] = 0x48;   /* KEY_UP     -> KEY_UPARROW */
+    virtio_input_keytbl[105] = 0x4b;   /* KEY_LEFT   -> KEY_LTARROW */
+    virtio_input_keytbl[106] = 0x4d;   /* KEY_RIGHT  -> KEY_RTARROW */
+    virtio_input_keytbl[108] = 0x50;   /* KEY_DOWN   -> KEY_DNARROW */
+    virtio_input_keytbl[110] = 0x52;   /* KEY_INSERT -> KEY_INSERT  */
+    virtio_input_keytbl[111] = 0x53;   /* KEY_DELETE -> KEY_DELETE  */
+
+    /* The ST keyboard has one physical Ctrl and one Alt key; map both
+     * evdev left/right variants onto them (the identity loop above
+     * already covered KEY_LEFTCTRL==29 and KEY_LEFTALT==56). */
+    virtio_input_keytbl[97]  = 0x1d;   /* KEY_RIGHTCTRL -> KEY_CTRL */
+    virtio_input_keytbl[100] = 0x38;   /* KEY_RIGHTALT  -> KEY_ALT  */
+
+    /* Out of scope for this driver (see design doc): numeric keypad,
+     * F11+, multimedia keys, Meta/Super. Left at 0 (unmapped, i.e.
+     * KDEBUG-logged and dropped by virtio_input.c, not "scancode 0"). */
+}
+
+#endif /* CONF_WITH_VIRTIO_INPUT */
+```
+
+- [ ] **Step 3: Wire the new file into `bios/build.mk`**
+
+Change the line added in Task 1:
+
+```make
+obj-$(CONF_WITH_VIRTIO_INPUT) += virtio_input.o virtio_input_keytbl.o
+```
+
+- [ ] **Step 4: Extend `bios/virtio_input.c` — includes, arch-specific IRQ setup, eventq buffers**
+
+Add to the includes (after `#include "virtio_input.h"`):
+
+```c
+#include "ikbd.h"
+#include "virtio_input_keytbl.h"
+```
+
+Replace the arch-specific block (from Task 1) to also pull in the PIC headers, since IRQ connect is now used:
+
+```c
+#if defined(MACHINE_VIRT_ARM)
+#include "virt_memmap.h"
+#include "virt_pic.h"
+#define VIRTIO_MMIO_BASE    VIRT_VIRTIO_MMIO_BASE
+#define VIRTIO_MMIO_STRIDE  VIRT_VIRTIO_MMIO_STRIDE
+#define VIRTIO_MMIO_COUNT   VIRT_VIRTIO_MMIO_COUNT
+#elif defined(MACHINE_VIRT_M68K)
+#include "goldfish_pic.h"
+#define VIRTIO_MMIO_BASE    0xff010000UL
+#define VIRTIO_MMIO_STRIDE  0x200UL
+#define VIRTIO_MMIO_COUNT   128
+#endif
+
+#if ARCH_ARM
+extern void invalidate_data_cache(void *start, long size);
+#endif
+```
+
+Add the wire-format event struct and per-device receive buffers, right after the existing `static LONG virtio_input_abs_min_y, virtio_input_abs_max_y;` line:
+
+```c
+/* Wire format of one eventq entry (virtio-input spec 5.8.6.2): 8 bytes,
+ * every field little-endian regardless of guest endianness. */
+struct virtio_input_event
+{
+    UWORD type;
+    UWORD code;
+    ULONG value;
+};
+
+static struct virtio_input_event virtio_input_kbd_buf[VIRTIO_QUEUE_SIZE];
+static struct virtio_input_event virtio_input_ptr_buf[VIRTIO_QUEUE_SIZE];
+
+#define VIRTIO_INPUT_KEY_AUTOREPEAT  2
+#define VIRTIO_INPUT_KEY_RELEASED    0x80   /* mirrors ikbd.c's private
+                                              * KEY_RELEASED bit, which
+                                              * isn't exported via ikbd.h */
+
+typedef enum { VIRTIO_INPUT_ROLE_KEYBOARD, VIRTIO_INPUT_ROLE_POINTER } VIRTIO_INPUT_ROLE;
+```
+
+- [ ] **Step 5: Add the keyboard dispatch function**
+
+Add right after the `struct virtio_input_event`/buffer declarations:
+
+```c
+static void virtio_input_handle_key(UWORD code, ULONG value)
+{
+    UBYTE scancode;
+
+    if (value == VIRTIO_INPUT_KEY_AUTOREPEAT)
+        return;   /* bios/ikbd.c's kb_timerc_int() already owns repeat timing */
+
+    if (code >= VIRTIO_INPUT_KEYTBL_SIZE || virtio_input_keytbl[code] == 0)
+    {
+        KDEBUG(("virtio_input: no scancode for evdev KEY code %u\n", code));
+        return;
+    }
+
+    scancode = virtio_input_keytbl[code];
+    if (value == 0)
+        scancode |= VIRTIO_INPUT_KEY_RELEASED;
+
+    kbd_int(scancode);
+}
+```
+
+(Pointer dispatch is added in Task 3; for now the drain loop below just skips those events.)
+
+- [ ] **Step 6: Add eventq setup and the shared drain routine**
+
+```c
+static void virtio_input_setup_eventq(VIRTIO_DEV *dev, struct virtio_input_event *buf)
+{
+    UWORD i;
+
+    for (i = 0; i < VIRTIO_QUEUE_SIZE; i++)
+    {
+        virtio_desc_set(dev, i, (ULONG)&buf[i] + dev->phys_offset,
+                         (ULONG)sizeof(buf[i]), VIRTIO_DESC_F_WRITE, 0);
+        virtio_submit(dev, i);
+    }
+    virtio_notify(dev);
+}
+
+static void virtio_input_drain(VIRTIO_DEV *dev, struct virtio_input_event *buf, VIRTIO_INPUT_ROLE role)
+{
+    UWORD idx;
+    ULONG len;
+    UWORD type, code;
+    ULONG value;
+
+    virtio_handle_interrupt(dev);
+
+    while (virtio_pop_used(dev, &idx, &len))
+    {
+        (void)len;
+#if ARCH_ARM
+        invalidate_data_cache(&buf[idx], sizeof(buf[idx]));
+#endif
+        type  = le2cpu16(buf[idx].type);
+        code  = le2cpu16(buf[idx].code);
+        value = le2cpu32(buf[idx].value);
+
+        if (role == VIRTIO_INPUT_ROLE_KEYBOARD)
+        {
+            if (type == EV_KEY)
+                virtio_input_handle_key(code, value);
+        }
+        /* VIRTIO_INPUT_ROLE_POINTER: dispatch added in Task 3 */
+
+        virtio_desc_set(dev, idx, (ULONG)&buf[idx] + dev->phys_offset,
+                         (ULONG)sizeof(buf[idx]), VIRTIO_DESC_F_WRITE, 0);
+        virtio_submit(dev, idx);
+    }
+
+    virtio_notify(dev);
+}
+
+static void virtio_input_kbd_isr(void)
+{
+    virtio_input_drain(&virtio_input_kbd_dev, virtio_input_kbd_buf, VIRTIO_INPUT_ROLE_KEYBOARD);
+}
+
+static void virtio_input_ptr_isr(void)
+{
+    virtio_input_drain(&virtio_input_ptr_dev, virtio_input_ptr_buf, VIRTIO_INPUT_ROLE_POINTER);
+}
+
+static void virtio_input_connect_irq(WORD slot, PFVOID handler)
+{
+#if defined(MACHINE_VIRT_ARM)
+    virt_connect_irq(VIRT_VIRTIO_IRQ_BASE + slot, handler);
+#elif defined(MACHINE_VIRT_M68K)
+    goldfish_pic_connect_irq((WORD)(1 + slot / 32), (WORD)(slot % 32), handler);
+#endif
+}
+```
+
+- [ ] **Step 7: Extend `virtio_input_init()` to set up queues and IRQs**
+
+Replace the whole function body with (this supersedes Task 1's version — the discovery logic is unchanged, each branch now also configures the queue, connects the IRQ, and fills the eventq):
+
+```c
+void virtio_input_init(void)
+{
+    WORD slot;
+    ULONG base;
+    VIRTIO_DEV probe_dev;
+
+    virtio_input_keytbl_init();
+
+    virtio_input_kbd_present = FALSE;
+    virtio_input_ptr_present = FALSE;
+
+    for (slot = 0; slot < VIRTIO_MMIO_COUNT; slot++)
+    {
+        base = VIRTIO_MMIO_BASE + (ULONG)slot * VIRTIO_MMIO_STRIDE;
+
+        if (!virtio_probe(base, VIRTIO_INPUT_DEVICE_ID, &probe_dev))
+            continue;
+
+        if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_KEY) != 0)
+        {
+            if (virtio_input_kbd_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another keyboard, ignored\n", slot));
+                continue;
+            }
+
+            virtio_input_kbd_dev = probe_dev;
+#if defined(MACHINE_VIRT_ARM)
+            virtio_input_kbd_dev.phys_offset = VIRT_RAM_BASE;
+#elif defined(MACHINE_VIRT_M68K)
+            virtio_input_kbd_dev.phys_offset = 0;
+#endif
+            if (!virtio_setup_queue(&virtio_input_kbd_dev))
+            {
+                KDEBUG(("virtio_input_init: slot %d keyboard queue setup failed\n", slot));
+                continue;
+            }
+            virtio_input_connect_irq(slot, virtio_input_kbd_isr);
+            virtio_input_setup_eventq(&virtio_input_kbd_dev, virtio_input_kbd_buf);
+            virtio_input_kbd_present = TRUE;
+            KDEBUG(("virtio_input_init: keyboard at slot %d (base 0x%08lx)\n", slot, base));
+        }
+        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_ABS) != 0)
+        {
+            if (virtio_input_ptr_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another pointer, ignored\n", slot));
+                continue;
+            }
+
+            virtio_input_ptr_dev = probe_dev;
+            virtio_input_ptr_is_abs = TRUE;
+#if defined(MACHINE_VIRT_ARM)
+            virtio_input_ptr_dev.phys_offset = VIRT_RAM_BASE;
+#elif defined(MACHINE_VIRT_M68K)
+            virtio_input_ptr_dev.phys_offset = 0;
+#endif
+            if (!virtio_setup_queue(&virtio_input_ptr_dev))
+            {
+                KDEBUG(("virtio_input_init: slot %d tablet queue setup failed\n", slot));
+                continue;
+            }
+            virtio_input_read_absinfo(base, ABS_X, &virtio_input_abs_min_x, &virtio_input_abs_max_x);
+            virtio_input_read_absinfo(base, ABS_Y, &virtio_input_abs_min_y, &virtio_input_abs_max_y);
+            virtio_input_connect_irq(slot, virtio_input_ptr_isr);
+            virtio_input_setup_eventq(&virtio_input_ptr_dev, virtio_input_ptr_buf);
+            virtio_input_ptr_present = TRUE;
+            KDEBUG(("virtio_input_init: tablet at slot %d (base 0x%08lx, x %ld..%ld, y %ld..%ld)\n",
+                    slot, base, virtio_input_abs_min_x, virtio_input_abs_max_x,
+                    virtio_input_abs_min_y, virtio_input_abs_max_y));
+        }
+        else if (virtio_input_cfg_query(base, VIRTIO_INPUT_CFG_EV_BITS, EV_REL) != 0)
+        {
+            if (virtio_input_ptr_present)
+            {
+                KDEBUG(("virtio_input_init: slot %d is another pointer, ignored\n", slot));
+                continue;
+            }
+
+            virtio_input_ptr_dev = probe_dev;
+            virtio_input_ptr_is_abs = FALSE;
+#if defined(MACHINE_VIRT_ARM)
+            virtio_input_ptr_dev.phys_offset = VIRT_RAM_BASE;
+#elif defined(MACHINE_VIRT_M68K)
+            virtio_input_ptr_dev.phys_offset = 0;
+#endif
+            if (!virtio_setup_queue(&virtio_input_ptr_dev))
+            {
+                KDEBUG(("virtio_input_init: slot %d mouse queue setup failed\n", slot));
+                continue;
+            }
+            virtio_input_connect_irq(slot, virtio_input_ptr_isr);
+            virtio_input_setup_eventq(&virtio_input_ptr_dev, virtio_input_ptr_buf);
+            virtio_input_ptr_present = TRUE;
+            KDEBUG(("virtio_input_init: mouse at slot %d (base 0x%08lx)\n", slot, base));
+        }
+        else
+        {
+            KDEBUG(("virtio_input_init: slot %d has no recognized role, ignored\n", slot));
+        }
+    }
+
+    KDEBUG(("virtio_input_init: keyboard %s, pointer %s\n",
+            virtio_input_kbd_present ? "present" : "absent",
+            virtio_input_ptr_present ? (virtio_input_ptr_is_abs ? "present (tablet)" : "present (mouse)") : "absent"));
+}
+```
+
+- [ ] **Step 8: Verify portability — build a non-virt config**
+
+```bash
+make distclean
+make rpi2_defconfig && make -j"$(nproc)" 2>&1 | tail -20
+```
+
+Expected: builds cleanly, same as Task 1 Step 8.
+
+- [ ] **Step 9: Build and interactively test typing on ARM**
+
+```bash
+make distclean
+make virt-arm_defconfig && make -j"$(nproc)"
+qemu-system-arm -M virt -cpu cortex-a7 -kernel <image> \
+  -global virtio-mmio.force-legacy=false \
+  -serial stdio -d guest_errors \
+  -device virtio-keyboard-device -device virtio-tablet-device
+```
+
+Once booted to the desktop, use the QEMU monitor (`Ctrl-Alt-2`, or `-monitor stdio` if you'd rather keep the serial console on `stdio`) to send a key:
+
+```
+(qemu) sendkey a
+```
+
+Expected: the letter appears wherever keyboard input is expected in the running desktop (e.g. typed into a text field), and if `ENABLE_KDEBUG` is on, no `no scancode for evdev KEY code` line appears for ordinary letters/digits. This part of the test does not need a human at the display — `sendkey` is scriptable — so it can be driven by an agent.
+
+- [ ] **Step 10: Repeat on m68k**
+
+```bash
+make distclean
+make virt-m68k_defconfig && make -j"$(nproc)"
+qemu-system-m68k -M virt -m 128 -cpu m68020 -kernel <image> \
+  -serial stdio -d guest_errors -monitor stdio \
+  -device virtio-keyboard-device -device virtio-tablet-device
+```
+
+Same `sendkey` check as Step 9.
+
+- [ ] **Step 11: `make gitready` and commit**
+
+```bash
+make gitready
+git add bios/virtio_input_keytbl.h bios/virtio_input_keytbl.c bios/build.mk bios/virtio_input.c
+git commit -m "virtio-input: add eventq draining and keyboard event dispatch"
+git push
+```
+
+---
+
+## Task 3: Pointer event pipeline (mouse + tablet) + docs
+
+**Files:**
+- Modify: `bios/virtio_input.c` — add `EV_REL`/`EV_ABS`/button dispatch, replacing the "dispatch added in Task 3" placeholder in `virtio_input_drain()`
+- Modify: `readme.md` — add virtio-input examples to both `virt` boards' QEMU invocations
+
+**Interfaces:**
+- Consumes: `call_mousevec(UBYTE *packet)`, `mousexvec` (`bios/ikbd.h`, existing); `linea_vars.V_REZ_HZ`/`V_REZ_VT` (`bios/lineavars.h`, existing).
+
+- [ ] **Step 1: Add pointer includes and constants**
+
+Add to `bios/virtio_input.c`'s includes (after `#include "virtio_input_keytbl.h"`):
+
+```c
+#include "lineavars.h"
+```
+
+Add near the other evdev constants (`EV_KEY`/`EV_REL`/`EV_ABS`/`ABS_X`/`ABS_Y`):
+
+```c
+#define REL_X  0x00
+#define REL_Y  0x01
+
+#define BTN_LEFT    0x110
+#define BTN_RIGHT   0x111
+#define BTN_MIDDLE  0x112
+
+#define VIRTIO_INPUT_MOUSE_LEFT   0x02   /* MOUSE_REL_POS_REPORT button bits -- see
+                                           * bios/ikbd.c's private LEFT_BUTTON_DOWN/
+                                           * RIGHT_BUTTON_DOWN #defines, confirmed also
+                                           * by usb/udd_mouse.c's identical packet[0]
+                                           * construction */
+#define VIRTIO_INPUT_MOUSE_RIGHT  0x01
+```
+
+- [ ] **Step 2: Add pointer state and the packet-sending helper**
+
+Add right after Task 2's `typedef enum { VIRTIO_INPUT_ROLE_KEYBOARD, VIRTIO_INPUT_ROLE_POINTER } VIRTIO_INPUT_ROLE;` line:
+
+```c
+static UBYTE virtio_input_ptr_buttons;
+static BOOL virtio_input_x_valid, virtio_input_y_valid;   /* have we seen a baseline EV_ABS sample yet? */
+static LONG virtio_input_last_scaled_x, virtio_input_last_scaled_y;
+
+/* Sends one or more 3-byte IKBD relative-mouse packets covering (dx, dy),
+ * chunking into signed-byte-range steps if either component overflows
+ * it. Always sends at least one packet (even (0, 0), for button-only
+ * changes), since the ST always reports current button state alongside
+ * whatever motion happened. */
+static void virtio_input_send_mouse_delta(WORD dx, WORD dy)
+{
+    UBYTE packet[3];
+    WORD step_x, step_y;
+
+    do
+    {
+        step_x = (dx > 127) ? 127 : (dx < -128) ? -128 : dx;
+        step_y = (dy > 127) ? 127 : (dy < -128) ? -128 : dy;
+
+        packet[0] = (UBYTE)(0xf8 | virtio_input_ptr_buttons);
+        packet[1] = (UBYTE)step_x;
+        packet[2] = (UBYTE)step_y;
+        call_mousevec(packet);
+
+        dx = (WORD)(dx - step_x);
+        dy = (WORD)(dy - step_y);
+    } while (dx != 0 || dy != 0);
+}
+
+static LONG virtio_input_scale_abs(LONG value, LONG min, LONG max, WORD screen_max)
+{
+    if (max <= min)
+        return 0;
+    return (value - min) * (LONG)screen_max / (max - min);
+}
+```
+
+- [ ] **Step 3: Add the pointer dispatch function**
+
+Add right after `virtio_input_scale_abs()`:
+
+```c
+static void virtio_input_handle_pointer(UWORD type, UWORD code, ULONG raw_value)
+{
+    LONG value = (LONG)raw_value;
+
+    switch (type)
+    {
+    case EV_KEY:
+        switch (code)
+        {
+        case BTN_LEFT:
+            if (value)
+                virtio_input_ptr_buttons |= VIRTIO_INPUT_MOUSE_LEFT;
+            else
+                virtio_input_ptr_buttons &= ~VIRTIO_INPUT_MOUSE_LEFT;
+            virtio_input_send_mouse_delta(0, 0);
+            break;
+        case BTN_RIGHT:
+            if (value)
+                virtio_input_ptr_buttons |= VIRTIO_INPUT_MOUSE_RIGHT;
+            else
+                virtio_input_ptr_buttons &= ~VIRTIO_INPUT_MOUSE_RIGHT;
+            virtio_input_send_mouse_delta(0, 0);
+            break;
+        case BTN_MIDDLE:
+            /* No 3rd button bit in the relative-mouse packet; matches
+             * usb/udd_mouse.c's handling of its own 3rd button. */
+            mousexvec(value ? 0x37 : 0xb7);
+            break;
+        default:
+            break;
+        }
+        break;
+
+    case EV_REL:
+        if (code == REL_X)
+            virtio_input_send_mouse_delta((WORD)value, 0);
+        else if (code == REL_Y)
+            virtio_input_send_mouse_delta(0, (WORD)value);
+        break;
+
+    case EV_ABS:
+        if (code == ABS_X)
+        {
+            LONG scaled = virtio_input_scale_abs(value, virtio_input_abs_min_x, virtio_input_abs_max_x,
+                                                  (WORD)(linea_vars.V_REZ_HZ - 1));
+            if (virtio_input_x_valid)
+                virtio_input_send_mouse_delta((WORD)(scaled - virtio_input_last_scaled_x), 0);
+            virtio_input_last_scaled_x = scaled;
+            virtio_input_x_valid = TRUE;
+        }
+        else if (code == ABS_Y)
+        {
+            LONG scaled = virtio_input_scale_abs(value, virtio_input_abs_min_y, virtio_input_abs_max_y,
+                                                  (WORD)(linea_vars.V_REZ_VT - 1));
+            if (virtio_input_y_valid)
+                virtio_input_send_mouse_delta(0, (WORD)(scaled - virtio_input_last_scaled_y));
+            virtio_input_last_scaled_y = scaled;
+            virtio_input_y_valid = TRUE;
+        }
+        break;
+
+    default:
+        break;   /* EV_SYN and anything else: nothing to do per-event */
+    }
+}
+```
+
+- [ ] **Step 4: Wire the dispatch into `virtio_input_drain()`**
+
+In `bios/virtio_input.c`, replace the comment placeholder inside `virtio_input_drain()`:
+
+```c
+        if (role == VIRTIO_INPUT_ROLE_KEYBOARD)
+        {
+            if (type == EV_KEY)
+                virtio_input_handle_key(code, value);
+        }
+        /* VIRTIO_INPUT_ROLE_POINTER: dispatch added in Task 3 */
+```
+
+with:
+
+```c
+        if (role == VIRTIO_INPUT_ROLE_KEYBOARD)
+        {
+            if (type == EV_KEY)
+                virtio_input_handle_key(code, value);
+        }
+        else
+        {
+            virtio_input_handle_pointer(type, code, value);
+        }
+```
+
+- [ ] **Step 5: Update `readme.md`**
+
+Modify `readme.md`. After the existing ARM `virt` "To also attach a virtio-blk disk" example, add:
+
+```
+To also attach virtio-input keyboard and tablet devices:
+
+    qemu-system-arm -M virt -cpu cortex-a7 -m 128 -kernel virt-arm.elf -d guest_errors -serial stdio \
+      -global virtio-mmio.force-legacy=false \
+      -device virtio-keyboard-device -device virtio-tablet-device
+```
+
+After the equivalent m68k `virt` example, add:
+
+```
+To also attach virtio-input keyboard and tablet devices:
+
+    qemu-system-m68k -M virt -m 128 -cpu m68020 -kernel virt-m68k.elf -d guest_errors -serial stdio \
+      -global virtio-mmio.force-legacy=false \
+      -device virtio-keyboard-device -device virtio-tablet-device
+```
+
+- [ ] **Step 6: Verify portability — build a non-virt config**
+
+```bash
+make distclean
+make rpi2_defconfig && make -j"$(nproc)" 2>&1 | tail -20
+```
+
+Expected: builds cleanly.
+
+- [ ] **Step 7: Build and test the keyboard regression on ARM**
+
+```bash
+make distclean
+make virt-arm_defconfig && make -j"$(nproc)"
+qemu-system-arm -M virt -cpu cortex-a7 -kernel <image> \
+  -global virtio-mmio.force-legacy=false \
+  -serial stdio -d guest_errors -monitor stdio \
+  -device virtio-keyboard-device -device virtio-tablet-device
+```
+
+`(qemu) sendkey a` — expected: same as Task 2 Step 9, confirming the pointer changes didn't regress the keyboard path.
+
+- [ ] **Step 8: Interactive pointer test (human required)**
+
+This step cannot be driven by an agent alone — QEMU only emits absolute tablet coordinates in response to real host mouse movement over its display window, and there is no way to inject that from inside the guest or via the monitor. Ask a human to:
+
+1. Boot the same image with a graphical QEMU window open (not `-nographic`; a plain `qemu-system-arm -M virt ... -device virtio-tablet-device` without `-serial stdio -display none` will pop up a window).
+2. Move the host mouse over the QEMU display window and confirm the guest cursor tracks it 1:1, with no drift after repeated movement across the screen (this specifically exercises the `ABS_INFO`-based scaling math in `virtio_input_scale_abs()`).
+3. Click left and right mouse buttons and confirm they register in the guest (e.g. in the desktop's file selector or a running application).
+
+Expected: cursor tracks smoothly, clicks register. If there's drift, double check `virtio_input_abs_min_x/max_x`/`min_y/max_y` (logged at boot in Task 1's KDEBUG output) against `linea_vars.V_REZ_HZ`/`V_REZ_VT` for the resolution actually in use.
+
+- [ ] **Step 9: Repeat the keyboard regression check on m68k**
+
+```bash
+make distclean
+make virt-m68k_defconfig && make -j"$(nproc)"
+qemu-system-m68k -M virt -m 128 -cpu m68020 -kernel <image> \
+  -serial stdio -d guest_errors -monitor stdio \
+  -device virtio-keyboard-device -device virtio-tablet-device
+```
+
+`(qemu) sendkey a` as before. The interactive pointer test (Step 8) is optional to repeat here since the pointer logic is entirely shared, machine-independent code — the ARM confirmation is sufficient unless something m68k-specific (e.g. `phys_offset`) is suspected.
+
+- [ ] **Step 10: `make gitready` and commit**
+
+```bash
+make gitready
+git add bios/virtio_input.c readme.md
+git commit -m "virtio-input: add mouse/tablet event dispatch"
+git push
+```
+
+- [ ] **Step 11: Mark the PR ready for review**
+
+Only after Step 8's human pointer test has actually passed:
+
+```bash
+gh pr ready
+```
+
+(Per this repo's workflow, the user merges the PR themselves once satisfied — do not merge or force-push it.)

--- a/docs/superpowers/specs/2026-08-02-virtio-input-driver-design.md
+++ b/docs/superpowers/specs/2026-08-02-virtio-input-driver-design.md
@@ -90,14 +90,23 @@ them by ID, so `virtio_input_init()`:
 2. For each match, reads config space to determine role, via the
    select/subsel/size/data window at offset `0x100` from the device's mmio
    base (per the virtio-input spec):
-   - Write `select = 0x11` (`EV_BITS`), `subsel = 0x01` (`EV_KEY`), read
-     `size`. Nonzero → this device has keys → keyboard role.
-   - Otherwise write `subsel = 0x03` (`EV_ABS`), read `size`. Nonzero → this
-     device reports absolute position → tablet role (preferred pointer).
+   - Write `select = 0x11` (`EV_BITS`), `subsel = 0x03` (`EV_ABS`), read
+     `size`. Nonzero → this device reports absolute position → tablet role
+     (preferred pointer).
    - Otherwise write `subsel = 0x02` (`EV_REL`), read `size`. Nonzero → this
      device reports relative motion → mouse role.
+   - Otherwise write `subsel = 0x01` (`EV_KEY`), read `size`. Nonzero → this
+     device has keys and no motion capability → keyboard role.
    - Zero size on all three → unrecognized role; the slot is probed but not
      registered (`KDEBUG`-logged and skipped).
+
+   **Note (found during Task 1 review, confirmed live against QEMU):** `EV_KEY`
+   must be checked *last*, not first. QEMU's `virtio-tablet-device` (and
+   `virtio-mouse-device`) report nonzero `EV_KEY` size too, for their button
+   codes — a keyboard-first check misclassifies them as a second keyboard and
+   drops the pointer entirely. Checking `EV_ABS`/`EV_REL` first is safe because
+   no real keyboard reports motion capability, so "has `EV_KEY` and neither
+   `EV_ABS` nor `EV_REL`" is what actually means "keyboard."
 3. The first match of each role is registered; a second device of an
    already-filled role is `KDEBUG`-logged and left unregistered — no
    multi-keyboard/multi-pointer support (YAGNI: QEMU command lines for this

--- a/docs/superpowers/specs/2026-08-02-virtio-input-driver-design.md
+++ b/docs/superpowers/specs/2026-08-02-virtio-input-driver-design.md
@@ -1,0 +1,242 @@
+# Shared virtio-input keyboard/mouse driver for the QEMU virt ports — design
+
+GitHub tracking issue: #38. Depends on #29 (shared virtio-mmio transport
+driver, landed). Reference: `docs/superpowers/specs/2026-07-31-virtio-mmio-driver-design.md`
+for the transport this builds on, and
+`docs/superpowers/specs/2026-07-30-qemu-virt-support-design.md` for the two
+boards' overall shape.
+
+## Scope & goal
+
+QEMU's `virt` machine (both ARM and m68k) has no PS/2 controller or
+ACIA-attached keyboard: input arrives as virtio-input devices
+(`virtio-keyboard-device`, `virtio-tablet-device`, `virtio-mouse-device`) on
+the virtio-mmio bus. This adds a driver that:
+
+- Discovers virtio-input devices on the virtio-mmio transport and identifies
+  their role (keyboard vs. pointer) from config-space capability bits.
+- Parses `struct virtio_input_event` off the device's eventq.
+- Translates evdev key/button/motion codes into Atari IKBD scancodes and
+  mouse packets.
+- Feeds those into the existing, already machine-independent IKBD entry
+  points in `bios/ikbd.c`: `kbd_int(UBYTE scancode)` and
+  `call_mousevec(UBYTE *packet)` — the same integration pattern
+  `usb/udd_mouse.c` already uses for the raspi port's USB HID mouse.
+
+In scope: one keyboard, one pointer device (virtio-tablet-device preferred,
+virtio-mouse-device also supported — see "Mouse event handling"). Out of
+scope: LED/status feedback (statusq), multiple keyboards or pointers,
+joysticks, any device role beyond keyboard/mouse/tablet.
+
+## Layout
+
+```
+bios/virtio_input.c, bios/virtio_input.h        -- new: device discovery,
+                                                    event translation, IKBD glue
+bios/virtio_input_keytbl.c, bios/virtio_input_keytbl.h
+                                                 -- new: evdev KEY_* -> Atari
+                                                    scancode table
+util/virtio.c, util/virtio.h                    -- extended: virtio_pop_used()
+```
+
+Placed in `bios/`, not `util/` as issue #38's text loosely suggested.
+`virtio_blk.c` sets the actual precedent here: it too is CPU-independent, but
+lives in `bios/` because its glue (`disk.c` bus integration) is
+bios-specific. The same applies here, more so — `kbd_int()`/`call_mousevec()`
+(`bios/ikbd.h`) and the screen-resolution globals
+(`linea_vars.V_REZ_HZ`/`V_REZ_VT`, `include/lineavars.h`) this driver needs
+are all bios-only, and nothing under `util/` today includes any bios header.
+`util/virtio.c` remains the shared, machine-neutral transport; only the one
+small addition described below goes there.
+
+The keyboard translation table is split into its own file/pair
+(`virtio_input_keytbl.c`/`.h`) purely to keep `virtio_input.c` (device
+discovery, event loop, packet building) readable — the table itself is a
+large, static, mostly-mechanical array with no logic.
+
+## Kconfig
+
+In `bios/Kconfig`, alongside `CONF_WITH_VIRTIO_BLK`:
+
+```
+config CONF_WITH_VIRTIO_INPUT
+	bool "virtio-input keyboard/mouse driver"
+	depends on CONF_WITH_VIRTIO
+	default y
+	help
+	  Keyboard and mouse/tablet driver for virtio-input devices found on
+	  the virtio-mmio transport, for the QEMU virt-arm/virt-m68k boards.
+	  No effect without a virtio-keyboard-device / virtio-tablet-device /
+	  virtio-mouse-device on the QEMU command line.
+```
+
+Defaults to `y` under `CONF_WITH_VIRTIO`, same reasoning as
+`CONF_WITH_VIRTIO_BLK`: if nothing matching is on the command line, the probe
+loop simply finds no devices. No `configs/*_defconfig` changes expected.
+
+Called from `bios/bios.c`, right after the existing `usb_init()` call (same
+structural spot: after `kbd_init()` has set up the scancode/ASCII tables,
+before interrupts are enabled), guarded by `#if CONF_WITH_VIRTIO_INPUT`.
+
+## Device discovery
+
+Unlike virtio-blk (device ID 2), every virtio-input device — keyboard, mouse,
+*and* tablet — shares device ID **18**. `virtio_probe()` can't distinguish
+them by ID, so `virtio_input_init()`:
+
+1. Scans every virtio-mmio slot (same `VIRTIO_MMIO_BASE`/`_STRIDE`/`_COUNT`
+   per-board constants `virtio_blk.c` already defines, reused here) calling
+   `virtio_probe(base, 18, &dev)`.
+2. For each match, reads config space to determine role, via the
+   select/subsel/size/data window at offset `0x100` from the device's mmio
+   base (per the virtio-input spec):
+   - Write `select = 0x11` (`EV_BITS`), `subsel = 0x01` (`EV_KEY`), read
+     `size`. Nonzero → this device has keys → keyboard role.
+   - Otherwise write `subsel = 0x03` (`EV_ABS`), read `size`. Nonzero → this
+     device reports absolute position → tablet role (preferred pointer).
+   - Otherwise write `subsel = 0x02` (`EV_REL`), read `size`. Nonzero → this
+     device reports relative motion → mouse role.
+   - Zero size on all three → unrecognized role; the slot is probed but not
+     registered (`KDEBUG`-logged and skipped).
+3. The first match of each role is registered; a second device of an
+   already-filled role is `KDEBUG`-logged and left unregistered — no
+   multi-keyboard/multi-pointer support (YAGNI: QEMU command lines for this
+   port specify at most one of each).
+4. For a registered tablet, `ABS_INFO` (`select = 0x12`, `subsel = 0x00` for
+   `ABS_X`, `0x01` for `ABS_Y`) is queried once at init for each axis's
+   `min`/`max`, stored for use when scaling motion (see below).
+
+Each registered device gets `virtio_setup_queue()` called on queue 0 (the
+eventq) exactly as `virtio_blk_init()` does; virtio-input's second queue
+(statusq, queue 1) is out of scope (no LED feedback) and is never configured.
+
+## Transport extension: draining the eventq
+
+`virtio_blk`'s use of the transport is request/response: one descriptor
+chain in flight at a time, waited on synchronously, so `dev->done` as a
+single boolean is sufficient. virtio-input's eventq is the opposite shape:
+the driver pre-populates all `VIRTIO_QUEUE_SIZE` (8) descriptors as
+device-writable receive buffers up front, and the device fills them
+asynchronously as events occur — potentially several between one interrupt
+and the next. A boolean can't say how many or which.
+
+Rather than have `virtio_input.c` reach into `VIRTIO_DEV`'s ring fields
+directly (breaking the encapsulation `virtio_blk.c` already respects), add
+one primitive to `util/virtio.c`/`.h`:
+
+```c
+/* Returns the descriptor index of the next unconsumed used-ring entry (and
+ * its length in *out_len) and advances past it, or returns FALSE if the
+ * driver has caught up with the device. Companion to virtio_submit(): the
+ * caller resubmits the same (or another) descriptor once it has drained the
+ * buffer's contents. */
+BOOL virtio_pop_used(VIRTIO_DEV *dev, UWORD *out_index, ULONG *out_len);
+```
+
+This is a genuinely shared transport-level addition, not input-specific —
+any future streaming virtio device (e.g. virtio-net) would need the same
+capability — so it belongs alongside the existing transport API rather than
+being duplicated per-consumer.
+
+### Eventq buffer lifecycle
+
+At init, `virtio_input.c` allocates 8 static `struct virtio_input_event`
+buffers (8 bytes each: `UWORD type; UWORD code; ULONG value;`, all
+little-endian on the wire) per registered device, submits all 8 descriptors
+(device-writable, `VIRTIO_DESC_F_WRITE`), and notifies once.
+
+On interrupt: `virtio_handle_interrupt()` (unchanged) sets `dev->done`. The
+device's interrupt handler then loops `virtio_pop_used()`, and for each
+completed buffer: decodes the event (`le2cpu16`/`le2cpu32`), translates and
+dispatches it (see below), then immediately resubmits that same descriptor
+(same buffer, still device-writable) so the device always has empty slots
+available. No dynamic allocation — matches this port's boot-time-only
+initialization model.
+
+IRQ wiring reuses `virt_connect_irq()`/`goldfish_pic_connect_irq()` exactly
+as `virtio_blk_connect_irq()` does today, one ISR per registered role
+(keyboard, pointer).
+
+## Keyboard event handling
+
+`virtio_input_keytbl.c` provides a static table indexed by evdev `KEY_*`
+code, mapping to the corresponding Atari ST make scancode. Coverage: standard
+alpha/numeric/function/modifier/cursor keys — matching what this port's
+existing keyboard language tables (`bios/lang/`) support; no multimedia or
+exotic keys.
+
+On each `EV_KEY` event (`event.type == EV_KEY`, i.e. `0x01`):
+
+- `event.value == 2` (autorepeat): ignored. `bios/ikbd.c`'s own
+  `kb_timerc_int()` already owns repeat timing; re-injecting the OS's own
+  repeat events would double up with it.
+- `event.value == 0` (release) or `1` (press): look up `event.code` in the
+  table. A hit calls `kbd_int(scancode | (value == 0 ? KEY_RELEASED : 0))`.
+  A miss is `KDEBUG`-logged and dropped — there is no sane fallback scancode
+  for a key this port doesn't know about.
+
+## Mouse event handling
+
+Both tablet and relative-mouse devices resolve to the same output primitive:
+`call_mousevec()` with a 3-byte IKBD relative-mouse packet
+(`0xF8 | buttons`, `dx`, `dy`), following `usb/udd_mouse.c`'s precedent
+exactly. No `Initmous()` call and no IKBD hardware commands of any kind —
+there is no real IKBD chip here to configure; bypassing it (as the USB mouse
+driver already does for the raspi port) is the correct integration point,
+not a shortcut, since the real chip's own "absolute mode" is an internal
+detail that still reports over the wire as relative deltas.
+
+- **`EV_REL` (virtio-mouse):** `REL_X`/`REL_Y` (`event.code` `0x00`/`0x01`)
+  carry small per-event deltas already. Each delta is clamped to signed-byte
+  range; in the rare case a single event's value overflows it, it is split
+  across multiple packets (a packet with `dx`/`dy` at the clamp limit,
+  repeated) rather than silently truncated.
+- **`EV_ABS` (virtio-tablet):** `ABS_X`/`ABS_Y` (`event.code` `0x00`/`0x01`)
+  carry absolute positions in the device's own coordinate space (typically
+  `0..32767`, from the `ABS_INFO` min/max queried at init — independent of
+  screen resolution). Each new value is scaled into current screen-pixel
+  space using `linea_vars.V_REZ_HZ`/`V_REZ_VT` and the queried min/max, then
+  a delta is computed against the last scaled position (tracked per-device
+  in a static), clamped/chunked into signed-byte range exactly as for the
+  relative case, and sent the same way.
+- **Buttons (`EV_KEY` with `BTN_LEFT`/`BTN_RIGHT`/`BTN_MIDDLE` codes on a
+  pointer device):** map into the packet's button bits the same way
+  `usb/udd_mouse.c` does. QEMU's virtio-tablet/mouse expose no more than
+  these three buttons and no wheel, so — unlike the USB mouse driver, which
+  also handles a wheel and a 4th/5th button via `mousexvec()` — there is
+  nothing further to wire up.
+
+## Build system wiring
+
+```make
+# bios/build.mk
+obj-$(CONF_WITH_VIRTIO_INPUT) += virtio_input.o virtio_input_keytbl.o
+```
+
+`util/build.mk` needs no changes: `virtio.o` is already built under
+`CONF_WITH_VIRTIO`, which `CONF_WITH_VIRTIO_INPUT` depends on.
+
+`readme.md` gains `-device virtio-keyboard-device` / `-device
+virtio-tablet-device` additions to the existing QEMU invocations for both
+`virt` boards.
+
+## Testing / definition of done
+
+```sh
+qemu-system-arm -M virt -cpu cortex-a7 -kernel <image> -serial stdio -d guest_errors \
+  -device virtio-keyboard-device -device virtio-tablet-device
+
+qemu-system-m68k -M virt -kernel <image> -serial stdio -d guest_errors \
+  -device virtio-keyboard-device -device virtio-tablet-device
+```
+
+Definition of done, verified interactively (unlike `virtio_blk`'s
+self-contained read/write self-test, there is no way to inject input events
+from inside the guest, so this cannot be a boot-time self-test):
+
+- Both devices are discovered and their roles logged via `KDEBUG` at boot.
+- QEMU monitor `sendkey <key>` (or typing into the QEMU display window)
+  produces the expected ASCII on the serial console / in a running editor.
+- Moving the host mouse over the QEMU display window moves the cursor
+  1:1 (no drift after repeated movement, confirming the tablet-scaling math)
+  and clicks register.

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,12 @@ To also attach a virtio-blk disk:
       -global virtio-mmio.force-legacy=false \
       -drive file=disk.img,if=none,format=raw,id=hd0 -device virtio-blk-device,drive=hd0
 
+To also attach virtio-input keyboard and tablet devices:
+
+    qemu-system-arm -M virt -cpu cortex-a7 -m 128 -kernel virt-arm.elf -d guest_errors -serial stdio \
+      -global virtio-mmio.force-legacy=false \
+      -device virtio-keyboard-device -device virtio-tablet-device
+
 To test the m68k `virt` port, run
 
     make virt-m68k_defconfig && make
@@ -52,6 +58,12 @@ To also attach a virtio-blk disk:
     qemu-system-m68k -M virt -m 128 -cpu m68020 -kernel virt-m68k.elf -d guest_errors -serial stdio \
       -global virtio-mmio.force-legacy=false \
       -drive file=disk.img,if=none,format=raw,id=hd0 -device virtio-blk-device,drive=hd0
+
+To also attach virtio-input keyboard and tablet devices:
+
+    qemu-system-m68k -M virt -m 128 -cpu m68020 -kernel virt-m68k.elf -d guest_errors -serial stdio \
+      -global virtio-mmio.force-legacy=false \
+      -device virtio-keyboard-device -device virtio-tablet-device
 
 The `-global virtio-mmio.force-legacy=false` flag is required on QEMU
 versions that default the `virt` machine's virtio-mmio transports to

--- a/readme.md
+++ b/readme.md
@@ -67,8 +67,8 @@ To also attach virtio-input keyboard and tablet devices:
 
 The `-global virtio-mmio.force-legacy=false` flag is required on QEMU
 versions that default the `virt` machine's virtio-mmio transports to
-legacy/version-1; the virtio-blk driver only speaks modern/version-2
-virtio-mmio.
+legacy/version-1; the shared virtio-mmio transport driver only speaks
+modern/version-2 virtio-mmio.
 
 For more information on which Qemu versions to use, see [Circle's Qemu documentation](https://github.com/rsta2/circle/blob/f5999e58f14b90204aafa7859428661cd01b22b1/doc/qemu.txt)
 

--- a/util/virtio.c
+++ b/util/virtio.c
@@ -198,7 +198,7 @@ void virtio_handle_interrupt(VIRTIO_DEV *dev)
     }
 }
 
-BOOL virtio_pop_used(VIRTIO_DEV *dev, UWORD *out_index, ULONG *out_len)
+BOOL virtio_pop_used(VIRTIO_DEV *dev, ULONG *out_index, ULONG *out_len)
 {
     UWORD slot;
 
@@ -206,7 +206,7 @@ BOOL virtio_pop_used(VIRTIO_DEV *dev, UWORD *out_index, ULONG *out_len)
         return FALSE;
 
     slot = dev->pop_idx % VIRTIO_QUEUE_SIZE;
-    *out_index = (UWORD)le2cpu32(dev->used.ring[slot].id);
+    *out_index = le2cpu32(dev->used.ring[slot].id);
     *out_len = le2cpu32(dev->used.ring[slot].len);
     dev->pop_idx++;
 

--- a/util/virtio.c
+++ b/util/virtio.c
@@ -103,6 +103,7 @@ BOOL virtio_probe(ULONG base, UWORD want_device_id, VIRTIO_DEV *dev)
     dev->base = base;
     dev->phys_offset = 0;
     dev->last_used_idx = 0;
+    dev->pop_idx = 0;
     dev->done = FALSE;
     return TRUE;
 }
@@ -195,4 +196,19 @@ void virtio_handle_interrupt(VIRTIO_DEV *dev)
         dev->last_used_idx = le2cpu16(dev->used.idx);
         dev->done = TRUE;
     }
+}
+
+BOOL virtio_pop_used(VIRTIO_DEV *dev, UWORD *out_index, ULONG *out_len)
+{
+    UWORD slot;
+
+    if (dev->pop_idx == le2cpu16(dev->used.idx))
+        return FALSE;
+
+    slot = dev->pop_idx % VIRTIO_QUEUE_SIZE;
+    *out_index = (UWORD)le2cpu32(dev->used.ring[slot].id);
+    *out_len = le2cpu32(dev->used.ring[slot].len);
+    dev->pop_idx++;
+
+    return TRUE;
 }

--- a/util/virtio.h
+++ b/util/virtio.h
@@ -11,6 +11,10 @@
 
 #define VIRTIO_QUEUE_SIZE  8   /* descriptors/ring slots per queue; power of two */
 
+/* Conservative upper bound for this port's ARM D-cache line size (also fine
+ * as a no-op on m68k, which never invalidates anything). */
+#define VIRTIO_CACHE_LINE  64
+
 #define VIRTIO_DESC_F_NEXT   1
 #define VIRTIO_DESC_F_WRITE  2
 
@@ -58,7 +62,17 @@ typedef struct
      * at behind the smaller fields. */
     VIRTIO_DESC  desc[VIRTIO_QUEUE_SIZE];
     VIRTIO_AVAIL avail;
-    VIRTIO_USED  used;
+    /* The used ring is the only part of this struct the device writes, so
+     * it is the only part invalidate_data_cache() is ever pointed at (see
+     * virtio_handle_interrupt()).  That is a pure invalidate on ARM, with
+     * no clean first, so anything sharing a cache line with it loses its
+     * pending CPU writes every time an interrupt arrives.  Give the used
+     * ring its own aligned span, padded out to a whole number of cache
+     * lines, so the driver-owned fields below -- notably pop_idx, which
+     * virtio_pop_used() carries across interrupts -- can never share one
+     * with it. */
+    VIRTIO_USED  used __attribute__((aligned(VIRTIO_CACHE_LINE)));
+    UBYTE used_pad[VIRTIO_CACHE_LINE - (sizeof(VIRTIO_USED) % VIRTIO_CACHE_LINE)];
     ULONG base;             /* mmio base address of this device's transport window */
     ULONG phys_offset;      /* physical_address - virtual(linked)_address, for any
                              * RAM address associated with this device's virtqueue

--- a/util/virtio.h
+++ b/util/virtio.h
@@ -72,6 +72,12 @@ typedef struct
                              * successful virtio_probe(), before calling
                              * virtio_setup_queue(). */
     UWORD last_used_idx;    /* used->idx last consumed by virtio_handle_interrupt() */
+    UWORD pop_idx;          /* used->idx last consumed by virtio_pop_used() -- independent
+                             * of last_used_idx: that one tracks "did anything complete"
+                             * for a single synchronous waiter (virtio_blk's model), this
+                             * one tracks "which entries has the caller actually drained"
+                             * for a queue that keeps several buffers in flight at once
+                             * (virtio-input's eventq). */
     volatile BOOL done;     /* set by virtio_handle_interrupt(), cleared by virtio_submit() */
 } __attribute__((aligned(16))) VIRTIO_DEV;
 
@@ -108,5 +114,15 @@ void virtio_notify(VIRTIO_DEV *dev);
  * as the interrupt source. Acks the device's InterruptStatus and, if the
  * used ring advanced, sets dev->done. */
 void virtio_handle_interrupt(VIRTIO_DEV *dev);
+
+/* Drains one not-yet-consumed used-ring entry: returns TRUE and fills
+ * *out_index (the descriptor index the device completed) and *out_len
+ * (bytes the device wrote/read), advancing past it; returns FALSE once
+ * the caller has caught up with dev->used.idx. Call this after
+ * virtio_handle_interrupt() has run (so dev->used is fresh). Unlike
+ * dev->done, which a single synchronous waiter clears by re-submitting,
+ * this lets a caller that keeps several buffers in flight (like
+ * virtio-input's eventq) drain them all in one interrupt. */
+BOOL virtio_pop_used(VIRTIO_DEV *dev, UWORD *out_index, ULONG *out_len);
 
 #endif /* VIRTIO_H */

--- a/util/virtio.h
+++ b/util/virtio.h
@@ -136,7 +136,15 @@ void virtio_handle_interrupt(VIRTIO_DEV *dev);
  * virtio_handle_interrupt() has run (so dev->used is fresh). Unlike
  * dev->done, which a single synchronous waiter clears by re-submitting,
  * this lets a caller that keeps several buffers in flight (like
- * virtio-input's eventq) drain them all in one interrupt. */
-BOOL virtio_pop_used(VIRTIO_DEV *dev, UWORD *out_index, ULONG *out_len);
+ * virtio-input's eventq) drain them all in one interrupt.
+ *
+ * *out_index is the device-provided id verbatim (ULONG, per the virtio
+ * spec's used-ring layout), not narrowed to the queue's actual index
+ * range: a malformed device could set high bits that a premature
+ * narrowing to UWORD would silently discard, turning an out-of-range id
+ * into a plausible-looking small one and defeating a caller's bounds
+ * check. Callers MUST validate *out_index against their queue size
+ * themselves before using it as an array/descriptor subscript. */
+BOOL virtio_pop_used(VIRTIO_DEV *dev, ULONG *out_index, ULONG *out_len);
 
 #endif /* VIRTIO_H */


### PR DESCRIPTION
Fixes #38

Design doc: docs/superpowers/specs/2026-08-02-virtio-input-driver-design.md

## Summary

Shared virtio-input keyboard/mouse/tablet driver, usable on both QEMU's
`virt-arm` and `virt-m68k` boards via the virtio-mmio transport (device ID
18, shared by keyboard/mouse/tablet — role is determined at probe time by
querying the device's `EV_BIT` config space).

- **Transport**: `util/virtio.c`/`.h` gains a generic `virtio_pop_used()`
  draining primitive, for queues that keep several buffers in flight at
  once (unlike `virtio_blk`'s single-synchronous-waiter model).
- **Discovery**: role detection checks `EV_ABS`/`EV_REL` *before* `EV_KEY`,
  since QEMU's virtio-tablet-device and virtio-mouse-device both also
  report a nonzero `EV_KEY` size for their button codes — checking
  `EV_KEY` first would misclassify them as a second keyboard.
- **Keyboard**: 8 pre-loaded receive buffers per device, drained and
  resubmitted every interrupt; evdev `KEY_*` codes translated to Atari
  scancodes (`bios/virtio_input_keytbl.c`/`.h`) and pushed into `kbd_int()`.
- **Pointer**: `EV_REL` mouse deltas via `call_mousevec()`; `EV_ABS` tablet
  coordinates scaled from the device's reported `ABS_INFO` range to the
  current screen resolution.
- `readme.md` gains QEMU invocation examples for both boards.

## Bugs found and fixed along the way

Two were pre-existing, unrelated to this driver, and already merged
separately to `master`:

- ARM: `desk/gembind.c`'s AES trap was missing a register from its inline
  asm clobber list, corrupting `G.g_xdesk`/window state under load (#45,
  merged via #47).
- m68k: `aes/geminit.c` nested `disable_interrupts()`/`enable_interrupts()`
  incorrectly around `gsx_tick()`, permanently stuck at IPL 7 the first
  time it actually nested (#46, merged via #48).

One is specific to this driver, fixed on this branch (`99ec31e2`): on
`virt-m68k`, this driver's IRQ runs at IPL 5 while the system tick runs at
IPL 6, so the tick can preempt event dispatch mid-flight and re-enter AES
code that assumes it cannot be interrupted. Fixed by masking to IPL 7
around the dispatch loop, m68k-only (ARM needs nothing — it masks IRQs on
exception entry). Independently reviewed and confirmed sound.

## Final review fix

The whole-branch review caught one real bug before merge: the keyboard
keytable's identity-mapped range pulled in evdev `KEY_KPASTERISK` (keypad
`*`) as Atari scancode `0x37` — which `bios/ikbd.c` treats as "mouse button
3", not a key, so pressing keypad `*` fired a phantom middle-click. Fixed
by dropping that one code back to unmapped, since the numeric keypad is
out of scope for this driver (`c62a6b91`). Two cheap, non-blocking
follow-ups landed in the same commit: an ARM cache-invalidate on the
eventq receive buffers before first submission, and a `readme.md` wording
fix.

## Known limitation (not part of this driver)

Task 3's planned human interactive pointer test (moving the mouse over a
real graphical QEMU window and confirming 1:1 cursor tracking) could not
be completed: `virt-arm`/`virt-m68k` currently have no display output
device wired up at all (no `ramfb`/virtio-gpu/VGA — a pre-existing,
structural gap, not something this driver introduces or can fix). Filed
as #68, with an initial investigation and an untested starting point on a
paused branch (#69). A second, unrelated pre-existing bug was found while
attempting this test — a `virt-arm` boot crash from the newly-merged PCI
work (#67, filed and deferred) — and worked around locally (PCI disabled)
to confirm this driver's own dispatch code is otherwise stable.

Everything else was verified extensively via QEMU across every task and
fix round: keyboard/mouse/tablet discovery, eventq draining, keypress and
pointer dispatch end-to-end (scancode → IKBD iorec → AES wake), extended
soak runs with continuous input traffic on both boards, and confirmation
that `virtio_blk` is unaffected when attached alongside the input devices.
