### PR TITLE
Fix Data Abort crash in cnx_put() on virt-arm with multiple virtio-mmio devices

### DIFF
--- a/desk/gembind.c
+++ b/desk/gembind.c
@@ -77,14 +77,35 @@ static __inline__ WORD gem(const GEMBLK *gb)
     register WORD retval __asm__("r0");
     register WORD opcode __asm__("r0") = 200; /* AES */
     register const GEMBLK *gbreg __asm__("r1") = gb;
+    register WORD gbreg_clobbered __asm__("r1");
 
+    /* "svc 2" runs the whole AES call chain (trapaes, super(), xif(),
+     * crysbind(), and the individual handler for this opcode) as ordinary
+     * C function calls, which are free to clobber r1 like any other
+     * caller-saved register. The compiler must be told r1 no longer
+     * holds gbreg afterwards -- without that, GCC has been seen to keep
+     * using the (by then stale) r1 to address int_out[] for the output
+     * macros (WM_OX and friends) that follow, handing the caller whatever
+     * r1 happened to hold deep inside the call chain instead of the real
+     * reply -- e.g. wind_get(0, WF_WXYWH, ...) silently returning garbage
+     * screen geometry, which corrupts everything downstream that sizes
+     * itself from it (issue #45).
+     *
+     * A plain "r1" clobber can't express this: gbreg is already pinned to
+     * r1 as an input, and GCC rejects clobbering a register that's also a
+     * local-register-variable operand. Declaring a second r1-bound
+     * variable as a (discarded) output, the same way retval/opcode
+     * already share r0, tells the compiler r1's value is gone once the
+     * asm completes, same as a clobber would.
+     */
     __asm__ volatile
     (
         "svc 2"
-        : "=r"(retval)
+        : "=r"(retval), "=r"(gbreg_clobbered)
         : "r"(opcode), "r"(gbreg)
         : "r2", "r3", "r7", "r12", "lr",  "memory", "cc"
     );
+    (void)gbreg_clobbered;
 #else
     register WORD retval __asm__("d0");
     register WORD opcode __asm__("d0") = 200; /* AES */


### PR DESCRIPTION
Fixes #45

## Root cause

`desk/gembind.c`'s `gem()` (the ARM `svc 2` trap used for every AES call
the desktop makes to itself) binds the AESPB pointer to `r1` via a GCC
local-register variable, passed as a plain input operand with `r1`
absent from the clobber list. The trap runs the whole AES dispatch
chain (`trapaes` -> `super()` -> `xif()` -> `crysbind()` -> the opcode's
handler, e.g. `wm_get()`) as ordinary C function calls that are free to
reuse `r1` like any other caller-saved register -- and do. Because GCC
wasn't told `r1` was clobbered, it kept addressing `int_out[]` through
the by-then-stale `r1` for the `WM_OX`/`WM_OY`/`WM_OW`/`WM_OH` (and
other opcodes' analogous) output macros.

For `wind_get(0, WF_WXYWH, &G.g_xdesk, ...)` specifically, that meant
`deskmain()` could get handed whatever garbage `r1` held deep inside
the call chain instead of the real screen geometry. That garbage
propagated into `adjust_menu()`'s menu-bar sizing and other
size-derived heap layout, eventually corrupting the WNODE window list
enough that `cnx_put()` (desk/deskmain.c:1091) would walk off a wild
`pw->w_next` and take a Data Abort (`fsr=00000008`) -- the exact crash
in #45.

Confirmed via GDB register/memory inspection against a live QEMU
virt-arm session (not guessed), and confirmed independent of both
virtio-mmio device count and the virtio-input driver (which doesn't
even exist on `master`) -- those just happened to be two different
ways of perturbing code layout/register allocation enough to expose
this same latent, pre-existing bug. Reproduced and fixed on `master`
directly.

## Fix

Add `r1` to the effective clobber set for the `svc 2` asm. Since
`gbreg` is already pinned to `r1` as a local-register-variable input, a
plain `"r1"` clobber conflicts with that binding, so the fix declares a
second, discarded `r1`-bound output variable instead -- the same
pattern the function already uses for `retval`/`opcode` sharing `r0`.
Scoped to the `#ifdef __arm__` branch only; the m68k branch (`trap #2`,
`d0`/`d1`) is untouched.

## Verification

- QEMU virt-arm, exact repro from the issue
  (`-device virtio-keyboard-device -device virtio-tablet-device`):
  2 runs of 40s each (well past the reported 10-25s window), no crash.
- A debug-instrumented build reproduced the crash 3/3 times before the
  fix, and 0/3 (plus one 35s run) after, with `adjust_menu()`'s trace
  showing consistently correct desktop-menu-bar geometry post-fix vs.
  garbage pre-fix.
- Disassembly before/after: post-fix, GCC now holds the AESPB base
  address in a callee-saved register (`r4`, explicitly saved/restored)
  instead of assuming `r1` survives the trap -- confirming the fix
  addresses the actual mechanism.
- `atari512_defconfig` (m68k, `m68k-atari-mintelf` toolchain) builds
  cleanly, as expected since that branch is untouched.
- Independently reviewed by a second agent, who reproduced the same
  before/after disassembly evidence from scratch; no critical or
  important issues found.