### PR TITLE
Fix SR permanently masked at IPL 7 on virt-m68k, blocking all interrupt-driven input

### DIFF
--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -630,10 +630,19 @@ void run_accs_and_desktop(void)
 
     sh_tographic();                 /* go into graphic mode */
 
-    /* take the tick interrupt */
-    disable_interrupts();
+    /*
+     * take the tick interrupt.
+     *
+     * No disable_interrupts()/enable_interrupts() pair here: gsx_tick()
+     * reaches vdi_vex_timv() (vdi/vdi_misc.c), which already wraps its own
+     * critical section (swapping linea_vars.tim_addr) the same way. Nesting
+     * the two would corrupt the single sr save slot in
+     * bios/arch/m68k/intmask.S -- disable_interrupts()/enable_interrupts()
+     * are documented not to nest -- leaving interrupts permanently masked
+     * after the outer enable_interrupts() "restores" the already-masked sr
+     * that the inner pair clobbered it with (issue #46).
+     */
     gl_ticktime = gsx_tick(tikaddr, &tiksav);
-    enable_interrupts();
 
     /* set initial click rate: must do this after setting gl_ticktime */
     ev_dclick(3, TRUE);
@@ -652,10 +661,9 @@ void run_accs_and_desktop(void)
     sh_init();                      /* init for shell loop */
     sh_main(isgem);                 /* main shell loop */
 
-    /* give back the tick   */
-    disable_interrupts();
+    /* give back the tick (see the comment above the first gsx_tick() call:
+     * no disable_interrupts()/enable_interrupts() pair needed here either) */
     gl_ticktime = gsx_tick(tiksav, &tiksav);
-    enable_interrupts();
 
     /* close workstation    */
     gsx_wsclose();


### PR DESCRIPTION
## Root cause

`bios/arch/m68k/intmask.S`'s `disable_interrupts()`/`enable_interrupts()` use a
single global `savesr` slot to save/restore the CPU's SR around a critical
section. The file's own comment says: "There is a single save slot, so these
do not nest."

`aes/geminit.c`'s `run_accs_and_desktop()` wrapped its `gsx_tick()` call in its
own `disable_interrupts()`/`enable_interrupts()` pair. `gsx_tick()`
(aes/gemgsxif.c) internally reaches `vdi_vex_timv()` (vdi/vdi_misc.c), which
*also* wraps its own critical section (swapping `linea_vars.tim_addr`) in
`disable_interrupts()`/`enable_interrupts()`. That's real nesting: the inner
`disable_interrupts()` overwrites `savesr` with the already-masked SR
(0x2700), so when the outer `enable_interrupts()` runs, it restores SR to
0x2700 (fully masked) instead of the true original value — permanently, since
nothing else in the boot path on virt-m68k ever touches SR again.

Confirmed via QEMU QMP live PC/SR polling (`info registers` sampled at ~ms
granularity while booting): the transition was caught with PC inside `_gsx2`
at the last unmasked sample (SR=0x2000), and the very next sample showed
SR=0x2700 with PC inside `_gem_rsc_fixit` — the function called immediately
after the `gsx_tick()`/`vdi_vex_timv()` chain in `geminit.c`.

Other m68k targets (Atari/Amiga) don't show this symptom because, on targets
with `CONF_WITH_ATARI_VIDEO`, `bios/screen.c`'s `vsync()` unconditionally
forces SR back to 0x2300 on every call, incidentally healing the stuck mask.
virt-m68k has `CONF_WITH_ATARI_VIDEO=0`, so that code is compiled out and the
mask sticks forever — blocking virtio-mmio interrupts (levels 2-5) and the
Goldfish RTC tick (level 6) for the rest of the run, so `hz_200` freezes and
no keyboard/mouse input is ever dispatched.

## Fix

Removed the redundant *outer* `disable_interrupts()`/`enable_interrupts()`
pair around both `gsx_tick()` call sites in `aes/geminit.c` (startup "take
the tick interrupt" and shutdown "give back the tick"). The actual critical
section — the `linea_vars.tim_addr` swap — is already protected by
`vdi_vex_timv()`'s own internal pair, so the outer wrap was pure redundant
nesting.

An earlier attempt fixed this by adding nesting-depth-counter support
directly inside `bios/arch/m68k/intmask.S`. That was abandoned: empirical
testing showed *any* size change to that file — even a single inert `nop` —
reproducibly triggers an unrelated, pre-existing wild-jump crash very early
in boot (before intmask.S's functions are even called), independent of this
issue. The call-site fix avoids that fragile file entirely.

## Verification

- `make virt-m68k_defconfig && make` — clean build.
- `make atari256_defconfig && make` (classic m68000 path, same shared file) —
  clean build.
- `make rpi2_defconfig && make` (ARM) — clean build.
- ColdFire/Firebee not build-tested (no ColdFire toolchain available in this
  environment); the changed code has no `__mcoldfire__`-specific branches.
- Booted the fixed image under QEMU with QMP register polling: `hz_200`
  (200Hz tick counter) advances continuously and SR stays at 0x2000 (IPL 0)
  for a clean 20-second run, vs. freezing permanently at IPL 7 within ~150ms
  before the fix.
- Temporarily pulled in the virtio-input driver (from the sibling
  feature/38 branch, since master predates it) into a scratch copy, enabled
  `ENABLE_KDEBUG`, booted with `-device virtio-keyboard-device`, and used
  QMP `send-key` to send an `a` keypress: confirmed via serial log that the
  scancode (0x1e press / 0x9e release) was correctly computed and passed to
  `kbd_int()`, and the AES event loop (`evnt_multi()`) woke up in response.
  This driver code was not committed here — the committed diff is exactly
  the `aes/geminit.c` change.
- Reviewed by an independent code-review pass, which traced the full call
  chain and confirmed the fix is correct and safe for other targets, and
  separately confirmed `takeerr()` (a similar-looking disable/enable pair a
  few lines above) does not share this bug.

Fixes #46