### PR TITLE
Add USB support for Raspberry Pi 4/400

### DIFF
--- a/bios/build.mk
+++ b/bios/build.mk
@@ -36,6 +36,7 @@ obj-$(CPU_ARMV7) += cache_armv7.o cache_armv7_asm.o
 
 obj-$(MACHINE_RPI) += raspi_board.o raspi_uart.o raspi_int.o raspi_mbox.o \
 	 raspi_screen.o raspi_emmc.o
+obj-$(CONF_WITH_USB_XHCI) += raspi_vl805.o
 
 obj-$(MACHINE_VIRT_ARM) += virt_uart.o virt_mmu.o virt_pic.o virt_timer.o
 

--- a/bios/machine/raspi/raspi_vl805.c
+++ b/bios/machine/raspi/raspi_vl805.c
@@ -49,7 +49,7 @@ BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources)
 
     irq = 0;
     ret = pci_read_config_byte(handle, PCI_CONFIG_INTERRUPT_LINE, &irq);
-    if (ret != PCI_SUCCESSFUL)
+    if ((ret != PCI_SUCCESSFUL) || (irq == 0xffU))
         irq = 0;
 
     if (resources != 0) {

--- a/bios/machine/raspi/raspi_vl805.c
+++ b/bios/machine/raspi/raspi_vl805.c
@@ -12,16 +12,51 @@
 #endif
 
 #include "kprint.h"
+#include "pci.h"
 #include "raspi_vl805.h"
+
+#define VL805_XHCI_CLASSCODE 0x0c0330UL
 
 BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources)
 {
+    PCI_HANDLE handle;
+    pci_resource_t resource;
+    UBYTE irq;
+    LONG ret;
+
     if (resources != 0) {
         resources->mmio_base = 0;
         resources->mmio_size = 0;
         resources->irq = 0;
     }
 
-    KINFO(("VL805/xHCI: BCM2711 PCIe discovery is not implemented yet\n"));
-    return FALSE;
+    ret = pci_find_classcode(VL805_XHCI_CLASSCODE, 0UL, 0, &handle);
+    if (ret != PCI_SUCCESSFUL) {
+        KINFO(("VL805/xHCI: PCI device not found (%ld)\n", ret));
+        return FALSE;
+    }
+
+    ret = pci_get_resource(handle, 0, &resource);
+    if (ret != PCI_SUCCESSFUL) {
+        KINFO(("VL805/xHCI: PCI BAR0 is not usable yet (%ld)\n", ret));
+        return FALSE;
+    }
+
+    if ((resource.flags & PCI_RESOURCE_IO) != 0U) {
+        KINFO(("VL805/xHCI: PCI BAR0 is an I/O resource\n"));
+        return FALSE;
+    }
+
+    irq = 0;
+    ret = pci_read_config_byte(handle, PCI_CONFIG_INTERRUPT_LINE, &irq);
+    if (ret != PCI_SUCCESSFUL)
+        irq = 0;
+
+    if (resources != 0) {
+        resources->mmio_base = resource.start + resource.offset;
+        resources->mmio_size = resource.length;
+        resources->irq = (UWORD)irq;
+    }
+
+    return TRUE;
 }

--- a/bios/machine/raspi/raspi_vl805.c
+++ b/bios/machine/raspi/raspi_vl805.c
@@ -16,11 +16,15 @@
 #include "raspi_vl805.h"
 
 #define VL805_XHCI_CLASSCODE 0x0c0330UL
+#define VL805_BAR_IO 0x00000001UL
+#define VL805_BAR_MEM_TYPE_MASK 0x00000006UL
+#define VL805_BAR_MEM_TYPE_64 0x00000004UL
 
 BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources)
 {
     PCI_HANDLE handle;
     pci_resource_t resource;
+    ULONG bar0;
     UBYTE irq;
     LONG ret;
 
@@ -33,6 +37,18 @@ BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources)
     ret = pci_find_classcode(VL805_XHCI_CLASSCODE, 0UL, 0, &handle);
     if (ret != PCI_SUCCESSFUL) {
         KINFO(("VL805/xHCI: PCI device not found (%ld)\n", ret));
+        return FALSE;
+    }
+
+    ret = pci_read_config_long(handle, PCI_CONFIG_BAR0, &bar0);
+    if (ret != PCI_SUCCESSFUL) {
+        KINFO(("VL805/xHCI: PCI BAR0 cannot be read (%ld)\n", ret));
+        return FALSE;
+    }
+
+    if (((bar0 & VL805_BAR_IO) == 0UL) &&
+        ((bar0 & VL805_BAR_MEM_TYPE_MASK) == VL805_BAR_MEM_TYPE_64)) {
+        KINFO(("VL805/xHCI: 64-bit PCI BAR0 is not supported yet\n"));
         return FALSE;
     }
 

--- a/bios/machine/raspi/raspi_vl805.c
+++ b/bios/machine/raspi/raspi_vl805.c
@@ -1,0 +1,27 @@
+/*
+ * raspi_vl805.c - Raspberry Pi 4 VL805 USB controller resources
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "config.h"
+
+#ifndef TARGET_RPI4
+#error This file must only be compiled for Raspberry Pi 4 targets
+#endif
+
+#include "kprint.h"
+#include "raspi_vl805.h"
+
+BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources)
+{
+    if (resources != 0) {
+        resources->mmio_base = 0;
+        resources->mmio_size = 0;
+        resources->irq = 0;
+    }
+
+    KINFO(("VL805/xHCI: BCM2711 PCIe discovery is not implemented yet\n"));
+    return FALSE;
+}

--- a/bios/machine/raspi/raspi_vl805.h
+++ b/bios/machine/raspi/raspi_vl805.h
@@ -1,0 +1,21 @@
+/*
+ * raspi_vl805.h - Raspberry Pi 4 VL805 USB controller resources
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef RASPI_VL805_H
+#define RASPI_VL805_H
+
+#include "portab.h"
+
+typedef struct {
+    ULONG mmio_base;
+    ULONG mmio_size;
+    UWORD irq;
+} raspi_vl805_resources_t;
+
+BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources);
+
+#endif /* RASPI_VL805_H */

--- a/docs/superpowers/plans/2026-08-02-rpi4-usb-xhci-foundation.md
+++ b/docs/superpowers/plans/2026-08-02-rpi4-usb-xhci-foundation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Build the first Raspberry Pi 4/400 USB foundation by enabling a configured xHCI host-controller path that compiles and fails safely until real hardware validation is available.
 
-**Architecture:** Keep the existing generic USB stack unchanged and add a second host-controller driver beside DWC2. Put Raspberry Pi 4 VL805/PCIe resource discovery behind a small machine-specific BIOS helper so generic USB code depends only on configuration symbols and a resource-returning interface.
+**Architecture:** Keep the existing generic USB stack unchanged and add a second host-controller driver beside DWC2. Put Raspberry Pi 4 VL805 resource discovery behind a small machine-specific BIOS helper that consumes the generic PCI layer, so generic USB code depends only on configuration symbols and a resource-returning interface.
 
 **Tech Stack:** C90 with GNU extensions, Kconfig, Kbuild-style `build.mk`, freestanding pTOS BIOS/USB code, `KINFO(())`/`KDEBUG(())` tracing, existing `struct ucdif` USB controller-driver API.
 
@@ -13,7 +13,7 @@
 - Preserve Raspberry Pi 1/2/3 DWC2 behavior.
 - Raspberry Pi 4/400 external USB uses VL805 behind BCM2711 PCIe, not DWC2.
 - Local QEMU `raspi4b` cannot validate the real Pi 4 USB path because it disables `brcm,bcm2711-pcie` and wires only DWC2.
-- Do not add a generic PCI subsystem beyond the Pi 4 resource helper.
+- Do not add private PCIe/VL805 discovery in the USB path; consume the generic PCI layer from issues #56 and #57.
 - Do not replace the existing USB enumeration, hub, or HID mouse layers.
 - Keep machine-specific hardware details behind Raspberry Pi-specific BIOS files.
 - C code must remain C90-compatible: declarations at the top of blocks, `/* */` comments, pTOS fixed-width types where relevant.
@@ -23,11 +23,11 @@
 
 ## File Structure
 
-- Modify `usb/Kconfig`: make `CONF_WITH_USB` available on Raspberry Pi 4 when an xHCI controller exists; add `CONF_WITH_USB_XHCI`; keep DWC2 defaulted only for Raspberry Pi 1/2/3.
+- Modify `usb/Kconfig`: make `CONF_WITH_USB` available on Raspberry Pi 4 only when PCI is enabled; add `CONF_WITH_USB_XHCI`; keep DWC2 defaulted only for Raspberry Pi 1/2/3.
 - Modify `usb/build.mk`: compile `ucd_xhci.o` only when `CONF_WITH_USB_XHCI` is set.
 - Modify `usb/usb.c`: use `CONF_WITH_USB_DWC2` and `CONF_WITH_USB_XHCI` for built-in host-controller declarations and initialization.
 - Create `bios/machine/raspi/raspi_vl805.h`: define `raspi_vl805_resources_t` and declare `raspi_vl805_get_resources()`.
-- Create `bios/machine/raspi/raspi_vl805.c`: provide the first Pi 4 VL805 resource helper; initially returns failure with a trace instead of pretending hardware is usable.
+- Create `bios/machine/raspi/raspi_vl805.c`: provide the first Pi 4 VL805 resource helper using generic PCI lookup and fail safely when resources are absent or unusable.
 - Modify `bios/build.mk`: compile `raspi_vl805.o` only for `CONF_WITH_USB_XHCI`.
 - Create `usb/ucd_xhci.h`: declare `xhci_init()`.
 - Create `usb/ucd_xhci.c`: add a `struct ucdif`-based xHCI UCD skeleton that registers, probes VL805 resources, and fails safely for unsupported transfers.
@@ -42,7 +42,7 @@
 - Modify: `usb/usb.c:46-78`
 
 **Interfaces:**
-- Consumes: existing Kconfig symbols `MACHINE_RPI`, `TARGET_RPI4`, `CONF_WITH_USB_DWC2`.
+- Consumes: existing Kconfig symbols `MACHINE_RPI`, `TARGET_RPI4`, `CONF_WITH_USB_DWC2`, `CONF_WITH_PCI`.
 - Produces: new Kconfig symbol `CONF_WITH_USB_XHCI`; new function declaration/use `void xhci_init(void)` guarded by `CONF_WITH_USB_XHCI`.
 
 - [ ] **Step 1: Update USB Kconfig dependencies**
@@ -54,7 +54,7 @@ menu "USB support"
 
 config CONF_WITH_USB
 	bool "USB stack"
-	depends on MACHINE_RPI
+	depends on MACHINE_RPI && (!TARGET_RPI4 || CONF_WITH_PCI)
 	default y
 	help
 	  A minimal USB stack, derived from the one in FreeMiNT and U-Boot.
@@ -71,6 +71,7 @@ config CONF_WITH_USB_DWC2
 
 config CONF_WITH_USB_XHCI
 	bool
+	depends on CONF_WITH_PCI
 	default y if CONF_WITH_USB && TARGET_RPI4
 	help
 	  The xHCI host controller used for the Raspberry Pi 4/400 external
@@ -150,7 +151,7 @@ git commit -m "Wire Raspberry Pi 4 USB xHCI configuration"
 - Modify: `bios/build.mk`
 
 **Interfaces:**
-- Consumes: `config.h`, `portab.h`, `kprint.h`, Raspberry Pi target symbols.
+- Consumes: `config.h`, `portab.h`, `kprint.h`, `pci.h`, Raspberry Pi target symbols, and initialized generic PCI enumeration.
 - Produces: `typedef struct raspi_vl805_resources_t { ULONG mmio_base; ULONG mmio_size; UWORD irq; } raspi_vl805_resources_t;` and `BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources);`.
 
 - [ ] **Step 1: Create the public helper header**
@@ -200,18 +201,53 @@ Create `bios/machine/raspi/raspi_vl805.c` with:
 #endif
 
 #include "kprint.h"
+#include "pci.h"
 #include "raspi_vl805.h"
+
+#define VL805_XHCI_CLASSCODE 0x0c0330UL
 
 BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources)
 {
+    PCI_HANDLE handle;
+    pci_resource_t resource;
+    UBYTE irq;
+    LONG ret;
+
     if (resources != 0) {
         resources->mmio_base = 0;
         resources->mmio_size = 0;
         resources->irq = 0;
     }
 
-    KINFO(("VL805/xHCI: BCM2711 PCIe discovery is not implemented yet\n"));
-    return FALSE;
+    ret = pci_find_classcode(VL805_XHCI_CLASSCODE, 0UL, 0, &handle);
+    if (ret != PCI_SUCCESSFUL) {
+        KINFO(("VL805/xHCI: PCI device not found (%ld)\n", ret));
+        return FALSE;
+    }
+
+    ret = pci_get_resource(handle, 0, &resource);
+    if (ret != PCI_SUCCESSFUL) {
+        KINFO(("VL805/xHCI: PCI BAR0 is not usable yet (%ld)\n", ret));
+        return FALSE;
+    }
+
+    if ((resource.flags & PCI_RESOURCE_IO) != 0U) {
+        KINFO(("VL805/xHCI: PCI BAR0 is an I/O resource\n"));
+        return FALSE;
+    }
+
+    irq = 0;
+    ret = pci_read_config_byte(handle, PCI_CONFIG_INTERRUPT_LINE, &irq);
+    if ((ret != PCI_SUCCESSFUL) || (irq == 0xffU))
+        irq = 0;
+
+    if (resources != 0) {
+        resources->mmio_base = resource.start + resource.offset;
+        resources->mmio_size = resource.length;
+        resources->irq = (UWORD)irq;
+    }
+
+    return TRUE;
 }
 ```
 
@@ -234,7 +270,7 @@ make rpi4_defconfig
 make obj/raspi_vl805.o
 ```
 
-Expected: `obj/raspi_vl805.o` builds or the build proceeds until a missing external toolchain is reported. If the target name is not accepted by the Makefile, run `make` and verify the compile command includes `raspi_vl805.c`.
+Expected: `obj/raspi_vl805.o` builds or the build proceeds until a missing external toolchain is reported. Runtime resource discovery may still fail safely until the Raspberry Pi 4 PCI backend can expose a usable 32-bit-accessible MMIO BAR for the VL805.
 
 - [ ] **Step 5: Commit the VL805 helper**
 
@@ -242,7 +278,7 @@ Run:
 
 ```bash
 git add bios/machine/raspi/raspi_vl805.h bios/machine/raspi/raspi_vl805.c bios/build.mk
-git commit -m "Add Raspberry Pi 4 VL805 resource stub"
+git commit -m "Add Raspberry Pi 4 VL805 resource helper"
 ```
 
 ---
@@ -502,6 +538,6 @@ Expected: branch `feature/37-add-usb-support-for-rpi4-400` updates PR #55.
 
 ## Self-Review
 
-- Spec coverage: Task 1 covers Kconfig/build and config-driven init; Task 2 covers Pi 4-specific VL805 discovery boundary; Task 3 covers xHCI UCD skeleton and safe failure; Task 4 covers QEMU/hardware validation limits through build and documentation checks.
+- Spec coverage: Task 1 covers Kconfig/build and config-driven init; Task 2 covers Pi 4-specific VL805 resource boundary backed by generic PCI; Task 3 covers xHCI UCD skeleton and safe failure; Task 4 covers QEMU/hardware validation limits through build and documentation checks.
 - Placeholder scan: No placeholders are present; incomplete hardware bring-up is intentionally represented as explicit safe-failure behavior.
 - Type consistency: `raspi_vl805_resources_t`, `raspi_vl805_get_resources()`, and `xhci_init()` signatures are defined before use and are consistent across tasks.

--- a/docs/superpowers/plans/2026-08-02-rpi4-usb-xhci-foundation.md
+++ b/docs/superpowers/plans/2026-08-02-rpi4-usb-xhci-foundation.md
@@ -1,0 +1,507 @@
+# Raspberry Pi 4 USB xHCI/VL805 Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first Raspberry Pi 4/400 USB foundation by enabling a configured xHCI host-controller path that compiles and fails safely until real hardware validation is available.
+
+**Architecture:** Keep the existing generic USB stack unchanged and add a second host-controller driver beside DWC2. Put Raspberry Pi 4 VL805/PCIe resource discovery behind a small machine-specific BIOS helper so generic USB code depends only on configuration symbols and a resource-returning interface.
+
+**Tech Stack:** C90 with GNU extensions, Kconfig, Kbuild-style `build.mk`, freestanding pTOS BIOS/USB code, `KINFO(())`/`KDEBUG(())` tracing, existing `struct ucdif` USB controller-driver API.
+
+## Global Constraints
+
+- Preserve Raspberry Pi 1/2/3 DWC2 behavior.
+- Raspberry Pi 4/400 external USB uses VL805 behind BCM2711 PCIe, not DWC2.
+- Local QEMU `raspi4b` cannot validate the real Pi 4 USB path because it disables `brcm,bcm2711-pcie` and wires only DWC2.
+- Do not add a generic PCI subsystem beyond the Pi 4 resource helper.
+- Do not replace the existing USB enumeration, hub, or HID mouse layers.
+- Keep machine-specific hardware details behind Raspberry Pi-specific BIOS files.
+- C code must remain C90-compatible: declarations at the top of blocks, `/* */` comments, pTOS fixed-width types where relevant.
+- Do not touch the existing untracked `package-lock.json`.
+
+---
+
+## File Structure
+
+- Modify `usb/Kconfig`: make `CONF_WITH_USB` available on Raspberry Pi 4 when an xHCI controller exists; add `CONF_WITH_USB_XHCI`; keep DWC2 defaulted only for Raspberry Pi 1/2/3.
+- Modify `usb/build.mk`: compile `ucd_xhci.o` only when `CONF_WITH_USB_XHCI` is set.
+- Modify `usb/usb.c`: use `CONF_WITH_USB_DWC2` and `CONF_WITH_USB_XHCI` for built-in host-controller declarations and initialization.
+- Create `bios/machine/raspi/raspi_vl805.h`: define `raspi_vl805_resources_t` and declare `raspi_vl805_get_resources()`.
+- Create `bios/machine/raspi/raspi_vl805.c`: provide the first Pi 4 VL805 resource helper; initially returns failure with a trace instead of pretending hardware is usable.
+- Modify `bios/build.mk`: compile `raspi_vl805.o` only for `CONF_WITH_USB_XHCI`.
+- Create `usb/ucd_xhci.h`: declare `xhci_init()`.
+- Create `usb/ucd_xhci.c`: add a `struct ucdif`-based xHCI UCD skeleton that registers, probes VL805 resources, and fails safely for unsupported transfers.
+
+---
+
+### Task 1: Wire Raspberry Pi 4 USB Configuration
+
+**Files:**
+- Modify: `usb/Kconfig:12-28`
+- Modify: `usb/build.mk:8-10`
+- Modify: `usb/usb.c:46-78`
+
+**Interfaces:**
+- Consumes: existing Kconfig symbols `MACHINE_RPI`, `TARGET_RPI4`, `CONF_WITH_USB_DWC2`.
+- Produces: new Kconfig symbol `CONF_WITH_USB_XHCI`; new function declaration/use `void xhci_init(void)` guarded by `CONF_WITH_USB_XHCI`.
+
+- [ ] **Step 1: Update USB Kconfig dependencies**
+
+Replace the USB menu body in `usb/Kconfig` with this content:
+
+```kconfig
+menu "USB support"
+
+config CONF_WITH_USB
+	bool "USB stack"
+	depends on MACHINE_RPI
+	default y
+	help
+	  A minimal USB stack, derived from the one in FreeMiNT and U-Boot.
+	  It currently provides mice using the HID boot report protocol.
+	  A host controller driver is required, so the stack is only
+	  available on machines that have one.
+
+config CONF_WITH_USB_DWC2
+	bool
+	default y if CONF_WITH_USB && MACHINE_RPI && !TARGET_RPI4
+	help
+	  The Synopsys DesignWare USB 2.0 OTG host controller, used on the
+	  Raspberry Pi 1, 2 and 3.
+
+config CONF_WITH_USB_XHCI
+	bool
+	default y if CONF_WITH_USB && TARGET_RPI4
+	help
+	  The xHCI host controller used for the Raspberry Pi 4/400 external
+	  USB ports through the VL805 PCIe bridge.
+
+endmenu
+```
+
+- [ ] **Step 2: Wire the xHCI object into the USB build**
+
+Edit `usb/build.mk` so the end of the file is:
+
+```make
+obj-y += usb.o ucd.o udd.o usb_api.o usb_hub.o udd_mouse.o
+
+obj-$(CONF_WITH_USB_DWC2) += ucd_dwc2.o
+obj-$(CONF_WITH_USB_XHCI) += ucd_xhci.o
+```
+
+- [ ] **Step 3: Make USB built-in UCD init configuration-driven**
+
+In `usb/usb.c`, replace the built-in driver declarations near lines 46-50 with:
+
+```c
+/* Built-in drivers: */
+#if CONF_WITH_USB_DWC2
+extern void dwc2_init(void);
+#endif
+#if CONF_WITH_USB_XHCI
+extern void xhci_init(void);
+#endif
+extern int usb_mouse_init(void);
+```
+
+Then replace the built-in driver initialization block near lines 74-78 with:
+
+```c
+    /* Initialize built-in drivers */
+#if CONF_WITH_USB_DWC2
+    dwc2_init();
+#endif
+#if CONF_WITH_USB_XHCI
+    xhci_init();
+#endif
+    usb_mouse_init();
+```
+
+- [ ] **Step 4: Run generated config smoke checks**
+
+Run:
+
+```bash
+make rpi2_defconfig
+grep '^CONF_WITH_USB' .config
+make rpi4_defconfig
+grep '^CONF_WITH_USB' .config
+```
+
+Expected rpi2 output includes `CONF_WITH_USB=y` and `CONF_WITH_USB_DWC2=y`. Expected rpi4 output includes `CONF_WITH_USB=y` and `CONF_WITH_USB_XHCI=y`.
+
+- [ ] **Step 5: Commit configuration wiring**
+
+Run:
+
+```bash
+git add usb/Kconfig usb/build.mk usb/usb.c
+git commit -m "Wire Raspberry Pi 4 USB xHCI configuration"
+```
+
+---
+
+### Task 2: Add Raspberry Pi 4 VL805 Resource Helper
+
+**Files:**
+- Create: `bios/machine/raspi/raspi_vl805.h`
+- Create: `bios/machine/raspi/raspi_vl805.c`
+- Modify: `bios/build.mk`
+
+**Interfaces:**
+- Consumes: `config.h`, `portab.h`, `kprint.h`, Raspberry Pi target symbols.
+- Produces: `typedef struct raspi_vl805_resources_t { ULONG mmio_base; ULONG mmio_size; UWORD irq; } raspi_vl805_resources_t;` and `BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources);`.
+
+- [ ] **Step 1: Create the public helper header**
+
+Create `bios/machine/raspi/raspi_vl805.h` with:
+
+```c
+/*
+ * raspi_vl805.h - Raspberry Pi 4 VL805 USB controller resources
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef RASPI_VL805_H
+#define RASPI_VL805_H
+
+#include "portab.h"
+
+typedef struct {
+    ULONG mmio_base;
+    ULONG mmio_size;
+    UWORD irq;
+} raspi_vl805_resources_t;
+
+BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources);
+
+#endif /* RASPI_VL805_H */
+```
+
+- [ ] **Step 2: Create the first resource-helper implementation**
+
+Create `bios/machine/raspi/raspi_vl805.c` with:
+
+```c
+/*
+ * raspi_vl805.c - Raspberry Pi 4 VL805 USB controller resources
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "config.h"
+
+#ifndef TARGET_RPI4
+#error This file must only be compiled for Raspberry Pi 4 targets
+#endif
+
+#include "kprint.h"
+#include "raspi_vl805.h"
+
+BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources)
+{
+    if (resources != 0) {
+        resources->mmio_base = 0;
+        resources->mmio_size = 0;
+        resources->irq = 0;
+    }
+
+    KINFO(("VL805/xHCI: BCM2711 PCIe discovery is not implemented yet\n"));
+    return FALSE;
+}
+```
+
+- [ ] **Step 3: Wire the helper into the BIOS build**
+
+In `bios/build.mk`, add this object next to the other Raspberry Pi machine-specific object wiring:
+
+```make
+obj-$(CONF_WITH_USB_XHCI) += raspi_vl805.o
+```
+
+If the file already groups Raspberry Pi objects, place it in that group; otherwise place it near other conditional machine objects and preserve link-order-sensitive comments.
+
+- [ ] **Step 4: Compile-check the helper target selection**
+
+Run:
+
+```bash
+make rpi4_defconfig
+make obj/raspi_vl805.o
+```
+
+Expected: `obj/raspi_vl805.o` builds or the build proceeds until a missing external toolchain is reported. If the target name is not accepted by the Makefile, run `make` and verify the compile command includes `raspi_vl805.c`.
+
+- [ ] **Step 5: Commit the VL805 helper**
+
+Run:
+
+```bash
+git add bios/machine/raspi/raspi_vl805.h bios/machine/raspi/raspi_vl805.c bios/build.mk
+git commit -m "Add Raspberry Pi 4 VL805 resource stub"
+```
+
+---
+
+### Task 3: Add xHCI UCD Skeleton
+
+**Files:**
+- Create: `usb/ucd_xhci.h`
+- Create: `usb/ucd_xhci.c`
+
+**Interfaces:**
+- Consumes: `raspi_vl805_get_resources(raspi_vl805_resources_t *resources)` from Task 2; existing `ucd_register()`, `struct ucdif`, ioctl command constants from `usb_api.h`.
+- Produces: `void xhci_init(void)` for Task 1's `usb_init()` call; a registered UCD named `xhci` that fails cleanly while hardware bring-up is incomplete.
+
+- [ ] **Step 1: Create the xHCI header**
+
+Create `usb/ucd_xhci.h` with:
+
+```c
+/*
+ * ucd_xhci.h - xHCI USB host controller driver
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef UCD_XHCI_H
+#define UCD_XHCI_H
+
+void xhci_init(void);
+
+#endif /* UCD_XHCI_H */
+```
+
+- [ ] **Step 2: Create the xHCI UCD skeleton**
+
+Create `usb/ucd_xhci.c` with:
+
+```c
+/*
+ * ucd_xhci.c - xHCI USB host controller driver
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "usb_global.h"
+#include "usb.h"
+#include "usb_api.h"
+#include "raspi_vl805.h"
+#include "ucd_xhci.h"
+
+struct xhci_priv {
+    raspi_vl805_resources_t resources;
+    BOOL have_resources;
+};
+
+static long xhci_open(struct ucdif *u);
+static long xhci_close(struct ucdif *u);
+static long xhci_ioctl(struct ucdif *u, short cmd, long arg);
+static long xhci_lowlevel_init(struct xhci_priv *priv);
+
+static char xhci_lname[] = "xHCI USB driver\0";
+static struct usb_device *root_hub_dev = NULL;
+static struct xhci_priv xhci_local;
+static struct ucdif xhci_uif =
+{
+    0,
+    USB_API_VERSION,
+    USB_CONTRLL,
+    xhci_lname,
+    "xhci",
+    0,
+    0,
+    xhci_open,
+    xhci_close,
+    0,
+    xhci_ioctl,
+    0,
+    (long *)&xhci_local
+};
+
+static long xhci_open(struct ucdif *u)
+{
+    (void)u;
+    return E_OK;
+}
+
+static long xhci_close(struct ucdif *u)
+{
+    struct xhci_priv *priv;
+
+    priv = (struct xhci_priv *)u->ucd_priv;
+    priv->have_resources = FALSE;
+    return E_OK;
+}
+
+static long xhci_lowlevel_init(struct xhci_priv *priv)
+{
+    priv->have_resources = raspi_vl805_get_resources(&priv->resources);
+    if (!priv->have_resources) {
+        KINFO(("xhci: VL805 controller not available\n"));
+        return -1;
+    }
+
+    KINFO(("xhci: MMIO 0x%lx size 0x%lx irq %u\n",
+           priv->resources.mmio_base,
+           priv->resources.mmio_size,
+           priv->resources.irq));
+    KINFO(("xhci: controller bring-up is not implemented yet\n"));
+    return -1;
+}
+
+static long xhci_ioctl(struct ucdif *u, short cmd, long arg)
+{
+    struct xhci_priv *priv;
+
+    priv = (struct xhci_priv *)u->ucd_priv;
+
+    switch (cmd) {
+    case LOWLEVEL_INIT:
+        return xhci_lowlevel_init(priv);
+    case LOWLEVEL_STOP:
+        priv->have_resources = FALSE;
+        return E_OK;
+    case SUBMIT_CONTROL_MSG:
+    case SUBMIT_BULK_MSG:
+    case SUBMIT_INT_MSG:
+        (void)arg;
+        KINFO(("xhci: transfer submission is not implemented yet\n"));
+        return -1;
+    default:
+        (void)arg;
+        return -1;
+    }
+}
+
+void xhci_init(void)
+{
+    if (ucd_register(&xhci_uif, &root_hub_dev)) {
+        KINFO(("xhci_init(): ucd register failed!\n"));
+        return;
+    }
+
+    KDEBUG(("xhci_init(): ucd register succeeded!\n"));
+}
+```
+
+- [ ] **Step 3: Verify include paths**
+
+Run:
+
+```bash
+make rpi4_defconfig
+make obj/ucd_xhci.o
+```
+
+Expected: `ucd_xhci.c` finds `raspi_vl805.h` through the existing `usb_copts` BIOS include paths, or the build reports only missing external toolchain problems.
+
+- [ ] **Step 4: Commit the xHCI UCD skeleton**
+
+Run:
+
+```bash
+git add usb/ucd_xhci.h usb/ucd_xhci.c
+git commit -m "Add xHCI USB controller skeleton"
+```
+
+---
+
+### Task 4: Build Verification and Documentation Polish
+
+**Files:**
+- Modify if needed: `docs/superpowers/specs/2026-08-02-rpi4-usb-xhci-design.md`
+- Modify if needed: `docs/superpowers/plans/2026-08-02-rpi4-usb-xhci-foundation.md`
+
+**Interfaces:**
+- Consumes: completed Tasks 1-3.
+- Produces: verified buildable foundation and documentation that reflects any implementation adjustments.
+
+- [ ] **Step 1: Verify generated configs**
+
+Run:
+
+```bash
+make rpi2_defconfig
+grep '^CONF_WITH_USB' .config
+make rpi4_defconfig
+grep '^CONF_WITH_USB' .config
+```
+
+Expected rpi2 config selects DWC2. Expected rpi4 config selects xHCI.
+
+- [ ] **Step 2: Run Raspberry Pi 2 build smoke test**
+
+Run:
+
+```bash
+make rpi2_defconfig
+make
+```
+
+Expected: build succeeds if the ARM toolchain is installed. If `arm-none-eabi-*` is missing, record that verification is blocked by the missing toolchain.
+
+- [ ] **Step 3: Run Raspberry Pi 4 build smoke test**
+
+Run:
+
+```bash
+make rpi4_defconfig
+make
+```
+
+Expected: build succeeds if the ARM toolchain is installed. If `arm-none-eabi-*` is missing, record that verification is blocked by the missing toolchain.
+
+- [ ] **Step 4: Run formatting/readiness check**
+
+Run:
+
+```bash
+make gitready
+```
+
+Expected: no style errors. If the command requires unavailable toolchain pieces, record the exact failure.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat master...HEAD
+git diff master...HEAD -- usb/Kconfig usb/build.mk usb/usb.c bios/build.mk bios/machine/raspi/raspi_vl805.h bios/machine/raspi/raspi_vl805.c usb/ucd_xhci.h usb/ucd_xhci.c docs/superpowers/specs/2026-08-02-rpi4-usb-xhci-design.md docs/superpowers/plans/2026-08-02-rpi4-usb-xhci-foundation.md
+```
+
+Expected: only issue #37 design, plan, and USB/VL805 scaffold files are changed. The untracked `package-lock.json` is not staged.
+
+- [ ] **Step 6: Commit verification notes if docs changed**
+
+If verification required documentation updates, run:
+
+```bash
+git add docs/superpowers/specs/2026-08-02-rpi4-usb-xhci-design.md docs/superpowers/plans/2026-08-02-rpi4-usb-xhci-foundation.md
+git commit -m "Document Raspberry Pi 4 USB verification limits"
+```
+
+- [ ] **Step 7: Push the branch**
+
+Run:
+
+```bash
+git push
+```
+
+Expected: branch `feature/37-add-usb-support-for-rpi4-400` updates PR #55.
+
+---
+
+## Self-Review
+
+- Spec coverage: Task 1 covers Kconfig/build and config-driven init; Task 2 covers Pi 4-specific VL805 discovery boundary; Task 3 covers xHCI UCD skeleton and safe failure; Task 4 covers QEMU/hardware validation limits through build and documentation checks.
+- Placeholder scan: No placeholders are present; incomplete hardware bring-up is intentionally represented as explicit safe-failure behavior.
+- Type consistency: `raspi_vl805_resources_t`, `raspi_vl805_get_resources()`, and `xhci_init()` signatures are defined before use and are consistent across tasks.

--- a/docs/superpowers/plans/2026-08-02-rpi4-usb-xhci-foundation.md
+++ b/docs/superpowers/plans/2026-08-02-rpi4-usb-xhci-foundation.md
@@ -71,7 +71,7 @@ config CONF_WITH_USB_DWC2
 
 config CONF_WITH_USB_XHCI
 	bool
-	depends on CONF_WITH_PCI
+	depends on CONF_WITH_USB && TARGET_RPI4 && CONF_WITH_PCI
 	default y if CONF_WITH_USB && TARGET_RPI4
 	help
 	  The xHCI host controller used for the Raspberry Pi 4/400 external
@@ -205,11 +205,15 @@ Create `bios/machine/raspi/raspi_vl805.c` with:
 #include "raspi_vl805.h"
 
 #define VL805_XHCI_CLASSCODE 0x0c0330UL
+#define VL805_BAR_IO 0x00000001UL
+#define VL805_BAR_MEM_TYPE_MASK 0x00000006UL
+#define VL805_BAR_MEM_TYPE_64 0x00000004UL
 
 BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources)
 {
     PCI_HANDLE handle;
     pci_resource_t resource;
+    ULONG bar0;
     UBYTE irq;
     LONG ret;
 
@@ -222,6 +226,18 @@ BOOL raspi_vl805_get_resources(raspi_vl805_resources_t *resources)
     ret = pci_find_classcode(VL805_XHCI_CLASSCODE, 0UL, 0, &handle);
     if (ret != PCI_SUCCESSFUL) {
         KINFO(("VL805/xHCI: PCI device not found (%ld)\n", ret));
+        return FALSE;
+    }
+
+    ret = pci_read_config_long(handle, PCI_CONFIG_BAR0, &bar0);
+    if (ret != PCI_SUCCESSFUL) {
+        KINFO(("VL805/xHCI: PCI BAR0 cannot be read (%ld)\n", ret));
+        return FALSE;
+    }
+
+    if (((bar0 & VL805_BAR_IO) == 0UL) &&
+        ((bar0 & VL805_BAR_MEM_TYPE_MASK) == VL805_BAR_MEM_TYPE_64)) {
+        KINFO(("VL805/xHCI: 64-bit PCI BAR0 is not supported yet\n"));
         return FALSE;
     }
 
@@ -381,7 +397,7 @@ static long xhci_lowlevel_init(struct xhci_priv *priv)
     priv->have_resources = raspi_vl805_get_resources(&priv->resources);
     if (!priv->have_resources) {
         KINFO(("xhci: VL805 controller not available\n"));
-        return -1;
+        return EOPNOTSUPP;
     }
 
     KINFO(("xhci: MMIO 0x%lx size 0x%lx irq %u\n",
@@ -389,7 +405,7 @@ static long xhci_lowlevel_init(struct xhci_priv *priv)
            priv->resources.mmio_size,
            priv->resources.irq));
     KINFO(("xhci: controller bring-up is not implemented yet\n"));
-    return -1;
+    return EOPNOTSUPP;
 }
 
 static long xhci_ioctl(struct ucdif *u, short cmd, long arg)
@@ -409,10 +425,10 @@ static long xhci_ioctl(struct ucdif *u, short cmd, long arg)
     case SUBMIT_INT_MSG:
         (void)arg;
         KINFO(("xhci: transfer submission is not implemented yet\n"));
-        return -1;
+        return EOPNOTSUPP;
     default:
         (void)arg;
-        return -1;
+        return EINVFN;
     }
 }
 

--- a/docs/superpowers/specs/2026-08-02-rpi4-usb-xhci-design.md
+++ b/docs/superpowers/specs/2026-08-02-rpi4-usb-xhci-design.md
@@ -6,16 +6,18 @@ Issue #37 tracks USB support for Raspberry Pi 4 and 400. These boards do not use
 
 The current tree has a generic USB layer in `usb/` plus one host-controller driver, `usb/ucd_dwc2.c`. `usb/Kconfig` deliberately excludes `CONF_WITH_USB` on `TARGET_RPI4`, and `usb/usb.c` only initializes DWC2 when `TARGET_RPI4` is not set.
 
+The generic PCI layer and Raspberry Pi 4 BCM2711 PCIe backend from issues #56 and #57 are now available. This USB foundation should consume those APIs for VL805 discovery and BAR lookup instead of carrying a private PCIe discovery path.
+
 Local QEMU validation is not available for the real Pi 4 USB path. The local QEMU checkout at `/home/freyr/qemu`, commit `9e69071fc292cd735aff3ae1440b6c16e3b61900`, disables the `brcm,bcm2711-pcie` devicetree node in `hw/arm/raspi4b.c` and wires only the shared DWC2 OTG controller in `hw/arm/bcm2838.c`. Therefore an xHCI/VL805 driver must be validated on real Raspberry Pi 4/400 hardware unless QEMU gains BCM2711 PCIe plus VL805/xHCI support.
 
 ## Goal
 
-Add a buildable Raspberry Pi 4 USB foundation without changing Raspberry Pi 1/2/3 DWC2 behavior. The first implementation should provide clean Kconfig/build integration, Pi 4-specific PCIe/VL805 discovery scaffolding, and an xHCI host-controller driver shell that fails safely until hardware bring-up is complete.
+Add a buildable Raspberry Pi 4 USB foundation without changing Raspberry Pi 1/2/3 DWC2 behavior. The first implementation should provide clean Kconfig/build integration, Pi 4-specific VL805 resource discovery through generic PCI, and an xHCI host-controller driver shell that fails safely until hardware bring-up is complete.
 
 ## Non-Goals
 
 - Do not attempt to emulate VL805 in QEMU as part of this issue.
-- Do not add a generic PCI subsystem beyond the Pi 4 needs.
+- Do not add private PCIe/VL805 discovery in the USB path; consume the generic PCI layer.
 - Do not replace the existing USB enumeration, hub, or HID mouse layers.
 - Do not enable unvalidated Pi 4 USB behavior by pretending DWC2 covers the external ports.
 
@@ -25,10 +27,10 @@ Add a buildable Raspberry Pi 4 USB foundation without changing Raspberry Pi 1/2/
 
 Add small, reviewable layers in dependency order:
 
-1. Update `usb/Kconfig` so `CONF_WITH_USB` can be enabled for Raspberry Pi 4 when an xHCI controller option is selected.
+1. Update `usb/Kconfig` so `CONF_WITH_USB` can be enabled for Raspberry Pi 4 only when PCI-backed xHCI support is available.
 2. Add `CONF_WITH_USB_XHCI` and wire it into `usb/build.mk` as `ucd_xhci.o`.
 3. Replace `#ifndef TARGET_RPI4` in `usb/usb.c` with configuration-driven built-in UCD initialization: DWC2 behind `CONF_WITH_USB_DWC2`, xHCI behind `CONF_WITH_USB_XHCI`.
-4. Add a Pi 4-specific PCIe/VL805 discovery layer under the Raspberry Pi machine code, exposed through a narrow interface used by the xHCI driver.
+4. Add a Pi 4-specific VL805 resource helper under the Raspberry Pi machine code, exposed through a narrow interface used by the xHCI driver and backed by generic PCI discovery/resource APIs.
 5. Add an xHCI UCD driver skeleton that registers through the existing `struct ucdif` API and returns a clear failure if no usable VL805 controller is discovered.
 
 This keeps the generic USB layer stable while making the Pi 4 path compile and fail predictably until real hardware testing can drive the register-level details.
@@ -37,7 +39,7 @@ This keeps the generic USB layer stable while making the Pi 4 path compile and f
 
 ### Kconfig and Build Wiring
 
-`CONF_WITH_USB` should depend on `MACHINE_RPI` and at least one supported host-controller option. `CONF_WITH_USB_DWC2` remains the default for Raspberry Pi 1/2/3. `CONF_WITH_USB_XHCI` becomes the Raspberry Pi 4 host-controller option.
+`CONF_WITH_USB` should depend on `MACHINE_RPI` and at least one supported host-controller option. For Raspberry Pi 4, it also depends on `CONF_WITH_PCI` because the external USB controller is discovered through PCI. `CONF_WITH_USB_DWC2` remains the default for Raspberry Pi 1/2/3. `CONF_WITH_USB_XHCI` becomes the Raspberry Pi 4 host-controller option and depends on `CONF_WITH_PCI`.
 
 `usb/build.mk` adds `obj-$(CONF_WITH_USB_XHCI) += ucd_xhci.o`.
 
@@ -50,13 +52,13 @@ This keeps the generic USB layer stable while making the Pi 4 path compile and f
 
 The initialization order remains simple: set up the generic USB API, initialize built-in host controllers, then initialize USB HID mouse support.
 
-### Pi 4 PCIe/VL805 Discovery
+### Pi 4 VL805 Resource Discovery
 
-Add a Raspberry Pi-specific helper that owns BCM2711 PCIe/VL805 knowledge and keeps it out of generic USB code. Its first interface should be small:
+Add a Raspberry Pi-specific helper that owns VL805 resource policy and keeps it out of generic USB code. BCM2711 PCIe discovery itself belongs to the generic PCI backend. The helper's first interface should be small:
 
-- Initialize or probe the Pi 4 PCIe root complex.
-- Locate the VL805 xHCI function.
-- Return the xHCI MMIO base, size, and IRQ if available.
+- Locate the VL805 xHCI function with generic PCI class lookup.
+- Request the xHCI BAR resource with `pci_get_resource()`.
+- Return the xHCI MMIO base, size, and IRQ if available and usable.
 - Return failure without touching generic USB state when not available.
 
 This helper belongs behind Raspberry Pi machine configuration. It should not introduce `#ifdef TARGET_RPI4` into generic USB code.
@@ -74,13 +76,14 @@ The UCD API boundary lets the existing enumeration and HID device drivers remain
 
 ## Data Flow
 
-At boot, `bios/bios.c` calls `usb_init()` when `CONF_WITH_USB` is enabled. `usb_init()` initializes generic USB state and registers built-in UCD drivers. On Raspberry Pi 4, `xhci_init()` registers the xHCI UCD. During `ucd_register()`, the UCD opens and runs `LOWLEVEL_INIT`. The xHCI UCD asks the Pi 4 PCIe/VL805 helper for controller resources, maps its registers through existing uncached/MMIO access patterns, and either starts xHCI operation or returns a clean error.
+At boot, `bios/bios.c` initializes PCI before USB when PCI is enabled, then calls `usb_init()` when `CONF_WITH_USB` is enabled. `usb_init()` initializes generic USB state and registers built-in UCD drivers. On Raspberry Pi 4, `xhci_init()` registers the xHCI UCD. During `ucd_register()`, the UCD opens and runs `LOWLEVEL_INIT`. The xHCI UCD asks the Pi 4 VL805 helper for controller resources. The helper uses generic PCI discovery and resource lookup; if the current PCI backend cannot expose a usable MMIO BAR, the UCD returns a clean error.
 
 Once the xHCI controller is operational, the existing USB core allocates a root hub device and calls `usb_new_device()`. Later work fills in xHCI control, interrupt, and bulk transfer handling so the existing hub and HID mouse stack can enumerate devices.
 
 ## Error Handling
 
-- If PCIe/VL805 is missing, uninitialized, or unsupported, `LOWLEVEL_INIT` returns failure and logs a concise `KINFO` message.
+- If PCI/VL805 is missing, uninitialized, or unsupported, `LOWLEVEL_INIT` returns failure and logs a concise `KINFO` message.
+- If the VL805 BAR is absent, is an I/O resource, or maps to an unavailable high PCI MMIO window, resource discovery returns failure without pretending the controller is usable.
 - If xHCI reset or halt/start transitions time out, return failure rather than continuing with partial state.
 - If DMA ring allocation or alignment requirements cannot be met, return failure before registering devices.
 - Avoid panics for absent hardware because QEMU raspi4b and non-Pi4 builds may expose different USB hardware.

--- a/docs/superpowers/specs/2026-08-02-rpi4-usb-xhci-design.md
+++ b/docs/superpowers/specs/2026-08-02-rpi4-usb-xhci-design.md
@@ -39,7 +39,7 @@ This keeps the generic USB layer stable while making the Pi 4 path compile and f
 
 ### Kconfig and Build Wiring
 
-`CONF_WITH_USB` should depend on `MACHINE_RPI` and at least one supported host-controller option. For Raspberry Pi 4, it also depends on `CONF_WITH_PCI` because the external USB controller is discovered through PCI. `CONF_WITH_USB_DWC2` remains the default for Raspberry Pi 1/2/3. `CONF_WITH_USB_XHCI` becomes the Raspberry Pi 4 host-controller option and depends on `CONF_WITH_PCI`.
+`CONF_WITH_USB` should depend on `MACHINE_RPI` and at least one supported host-controller option. For Raspberry Pi 4, it also depends on `CONF_WITH_PCI` because the external USB controller is discovered through PCI. `CONF_WITH_USB_DWC2` remains the default for Raspberry Pi 1/2/3. `CONF_WITH_USB_XHCI` becomes the Raspberry Pi 4 host-controller option and depends on `CONF_WITH_USB`, `TARGET_RPI4`, and `CONF_WITH_PCI` so it cannot pull Raspberry Pi-specific VL805 code into other PCI-enabled targets.
 
 `usb/build.mk` adds `obj-$(CONF_WITH_USB_XHCI) += ucd_xhci.o`.
 
@@ -57,6 +57,7 @@ The initialization order remains simple: set up the generic USB API, initialize 
 Add a Raspberry Pi-specific helper that owns VL805 resource policy and keeps it out of generic USB code. BCM2711 PCIe discovery itself belongs to the generic PCI backend. The helper's first interface should be small:
 
 - Locate the VL805 xHCI function with generic PCI class lookup.
+- Reject 64-bit BAR0 explicitly until the generic PCI resource layer and Raspberry Pi mapping code can represent and map that address correctly.
 - Request the xHCI BAR resource with `pci_get_resource()`.
 - Return the xHCI MMIO base, size, and IRQ if available and usable.
 - Return failure without touching generic USB state when not available.
@@ -83,7 +84,8 @@ Once the xHCI controller is operational, the existing USB core allocates a root 
 ## Error Handling
 
 - If PCI/VL805 is missing, uninitialized, or unsupported, `LOWLEVEL_INIT` returns failure and logs a concise `KINFO` message.
-- If the VL805 BAR is absent, is an I/O resource, or maps to an unavailable high PCI MMIO window, resource discovery returns failure without pretending the controller is usable.
+- If the VL805 BAR is absent, is 64-bit, is an I/O resource, or maps to an unavailable high PCI MMIO window, resource discovery returns failure without pretending the controller is usable.
+- Until xHCI bring-up and transfers exist, the xHCI UCD returns explicit `EOPNOTSUPP` for unsupported operations and `EINVFN` for unknown ioctls.
 - If xHCI reset or halt/start transitions time out, return failure rather than continuing with partial state.
 - If DMA ring allocation or alignment requirements cannot be met, return failure before registering devices.
 - Avoid panics for absent hardware because QEMU raspi4b and non-Pi4 builds may expose different USB hardware.

--- a/docs/superpowers/specs/2026-08-02-rpi4-usb-xhci-design.md
+++ b/docs/superpowers/specs/2026-08-02-rpi4-usb-xhci-design.md
@@ -1,0 +1,115 @@
+# Raspberry Pi 4/400 USB xHCI/VL805 Design
+
+## Context
+
+Issue #37 tracks USB support for Raspberry Pi 4 and 400. These boards do not use the DWC2 controller that pTOS currently drives for Raspberry Pi 1/2/3. Their external USB ports are exposed by the VL805 PCIe-to-xHCI controller behind the BCM2711 PCIe root complex.
+
+The current tree has a generic USB layer in `usb/` plus one host-controller driver, `usb/ucd_dwc2.c`. `usb/Kconfig` deliberately excludes `CONF_WITH_USB` on `TARGET_RPI4`, and `usb/usb.c` only initializes DWC2 when `TARGET_RPI4` is not set.
+
+Local QEMU validation is not available for the real Pi 4 USB path. The local QEMU checkout at `/home/freyr/qemu`, commit `9e69071fc292cd735aff3ae1440b6c16e3b61900`, disables the `brcm,bcm2711-pcie` devicetree node in `hw/arm/raspi4b.c` and wires only the shared DWC2 OTG controller in `hw/arm/bcm2838.c`. Therefore an xHCI/VL805 driver must be validated on real Raspberry Pi 4/400 hardware unless QEMU gains BCM2711 PCIe plus VL805/xHCI support.
+
+## Goal
+
+Add a buildable Raspberry Pi 4 USB foundation without changing Raspberry Pi 1/2/3 DWC2 behavior. The first implementation should provide clean Kconfig/build integration, Pi 4-specific PCIe/VL805 discovery scaffolding, and an xHCI host-controller driver shell that fails safely until hardware bring-up is complete.
+
+## Non-Goals
+
+- Do not attempt to emulate VL805 in QEMU as part of this issue.
+- Do not add a generic PCI subsystem beyond the Pi 4 needs.
+- Do not replace the existing USB enumeration, hub, or HID mouse layers.
+- Do not enable unvalidated Pi 4 USB behavior by pretending DWC2 covers the external ports.
+
+## Approach
+
+### Recommended Path: Buildable Foundation First
+
+Add small, reviewable layers in dependency order:
+
+1. Update `usb/Kconfig` so `CONF_WITH_USB` can be enabled for Raspberry Pi 4 when an xHCI controller option is selected.
+2. Add `CONF_WITH_USB_XHCI` and wire it into `usb/build.mk` as `ucd_xhci.o`.
+3. Replace `#ifndef TARGET_RPI4` in `usb/usb.c` with configuration-driven built-in UCD initialization: DWC2 behind `CONF_WITH_USB_DWC2`, xHCI behind `CONF_WITH_USB_XHCI`.
+4. Add a Pi 4-specific PCIe/VL805 discovery layer under the Raspberry Pi machine code, exposed through a narrow interface used by the xHCI driver.
+5. Add an xHCI UCD driver skeleton that registers through the existing `struct ucdif` API and returns a clear failure if no usable VL805 controller is discovered.
+
+This keeps the generic USB layer stable while making the Pi 4 path compile and fail predictably until real hardware testing can drive the register-level details.
+
+## Components
+
+### Kconfig and Build Wiring
+
+`CONF_WITH_USB` should depend on `MACHINE_RPI` and at least one supported host-controller option. `CONF_WITH_USB_DWC2` remains the default for Raspberry Pi 1/2/3. `CONF_WITH_USB_XHCI` becomes the Raspberry Pi 4 host-controller option.
+
+`usb/build.mk` adds `obj-$(CONF_WITH_USB_XHCI) += ucd_xhci.o`.
+
+### Built-In Host Controller Initialization
+
+`usb/usb.c` should include built-in host-controller declarations based on config symbols rather than target macros:
+
+- `dwc2_init()` when `CONF_WITH_USB_DWC2` is enabled.
+- `xhci_init()` when `CONF_WITH_USB_XHCI` is enabled.
+
+The initialization order remains simple: set up the generic USB API, initialize built-in host controllers, then initialize USB HID mouse support.
+
+### Pi 4 PCIe/VL805 Discovery
+
+Add a Raspberry Pi-specific helper that owns BCM2711 PCIe/VL805 knowledge and keeps it out of generic USB code. Its first interface should be small:
+
+- Initialize or probe the Pi 4 PCIe root complex.
+- Locate the VL805 xHCI function.
+- Return the xHCI MMIO base, size, and IRQ if available.
+- Return failure without touching generic USB state when not available.
+
+This helper belongs behind Raspberry Pi machine configuration. It should not introduce `#ifdef TARGET_RPI4` into generic USB code.
+
+### xHCI UCD Driver
+
+Add `usb/ucd_xhci.c` and a matching private header if needed. The driver should follow the existing `ucd_dwc2.c` contract:
+
+- Define a `struct ucdif` with `open`, `close`, and `ioctl` handlers.
+- Implement `LOWLEVEL_INIT`, `LOWLEVEL_STOP`, `SUBMIT_CONTROL_MSG`, `SUBMIT_BULK_MSG`, and `SUBMIT_INT_MSG` entry points.
+- Initially, `LOWLEVEL_INIT` may only discover the controller and fail with a useful trace if PCIe/VL805 is unavailable.
+- Root hub, transfer rings, event rings, device contexts, and endpoint context handling can be added incrementally after hardware validation starts.
+
+The UCD API boundary lets the existing enumeration and HID device drivers remain unchanged.
+
+## Data Flow
+
+At boot, `bios/bios.c` calls `usb_init()` when `CONF_WITH_USB` is enabled. `usb_init()` initializes generic USB state and registers built-in UCD drivers. On Raspberry Pi 4, `xhci_init()` registers the xHCI UCD. During `ucd_register()`, the UCD opens and runs `LOWLEVEL_INIT`. The xHCI UCD asks the Pi 4 PCIe/VL805 helper for controller resources, maps its registers through existing uncached/MMIO access patterns, and either starts xHCI operation or returns a clean error.
+
+Once the xHCI controller is operational, the existing USB core allocates a root hub device and calls `usb_new_device()`. Later work fills in xHCI control, interrupt, and bulk transfer handling so the existing hub and HID mouse stack can enumerate devices.
+
+## Error Handling
+
+- If PCIe/VL805 is missing, uninitialized, or unsupported, `LOWLEVEL_INIT` returns failure and logs a concise `KINFO` message.
+- If xHCI reset or halt/start transitions time out, return failure rather than continuing with partial state.
+- If DMA ring allocation or alignment requirements cannot be met, return failure before registering devices.
+- Avoid panics for absent hardware because QEMU raspi4b and non-Pi4 builds may expose different USB hardware.
+
+## Testing
+
+Automated validation can cover only build and non-regression behavior:
+
+- `make rpi2_defconfig && make` verifies DWC2 behavior still builds.
+- `make rpi4_defconfig && make` verifies Pi 4 USB wiring compiles.
+- Any available m68k smoke build should still compile because USB remains Raspberry Pi-scoped.
+
+Hardware validation is required for functional completion:
+
+- Boot on Raspberry Pi 4 or 400 with firmware that initializes VL805.
+- Confirm PCIe/VL805 discovery logs the expected controller.
+- Confirm xHCI controller reset/start succeeds.
+- Confirm root hub enumeration.
+- Confirm HID mouse enumeration and reports through the existing USB mouse path.
+
+## Risks
+
+- VL805 firmware and PCIe initialization requirements may differ by bootloader/firmware version.
+- DMA coherency may require stricter uncached allocation or cache maintenance than the current DWC2 path.
+- xHCI is substantially more complex than DWC2; the first useful milestone should be a cleanly buildable scaffold, not full device support.
+- QEMU cannot validate real Pi 4 USB, so hardware logs will be needed before claiming functional support.
+
+## Open Questions
+
+- Which Raspberry Pi 4/400 firmware and bootloader version should be treated as the first supported baseline?
+- Is a real Pi 4/400 available for iterative testing during implementation?
+- Should keyboard HID support be added alongside mouse once xHCI interrupt transfers work, or should issue #37 remain focused on matching the current mouse-only USB feature set?

--- a/usb/Kconfig
+++ b/usb/Kconfig
@@ -11,7 +11,7 @@ menu "USB support"
 
 config CONF_WITH_USB
 	bool "USB stack"
-	depends on MACHINE_RPI && !TARGET_RPI4
+	depends on MACHINE_RPI
 	default y
 	help
 	  A minimal USB stack, derived from the one in FreeMiNT and U-Boot.
@@ -21,10 +21,16 @@ config CONF_WITH_USB
 
 config CONF_WITH_USB_DWC2
 	bool
-	default y if CONF_WITH_USB && MACHINE_RPI
+	default y if CONF_WITH_USB && MACHINE_RPI && !TARGET_RPI4
 	help
 	  The Synopsys DesignWare USB 2.0 OTG host controller, used on the
-	  Raspberry Pi 1, 2 and 3.  The Raspberry Pi 4 uses a different
-	  controller, which is not supported yet.
+	  Raspberry Pi 1, 2 and 3.
+
+config CONF_WITH_USB_XHCI
+	bool
+	default y if CONF_WITH_USB && TARGET_RPI4
+	help
+	  The xHCI host controller used for the Raspberry Pi 4/400 external
+	  USB ports through the VL805 PCIe bridge.
 
 endmenu

--- a/usb/Kconfig
+++ b/usb/Kconfig
@@ -11,7 +11,7 @@ menu "USB support"
 
 config CONF_WITH_USB
 	bool "USB stack"
-	depends on MACHINE_RPI
+	depends on MACHINE_RPI && (!TARGET_RPI4 || CONF_WITH_PCI)
 	default y
 	help
 	  A minimal USB stack, derived from the one in FreeMiNT and U-Boot.

--- a/usb/Kconfig
+++ b/usb/Kconfig
@@ -28,6 +28,7 @@ config CONF_WITH_USB_DWC2
 
 config CONF_WITH_USB_XHCI
 	bool
+	depends on CONF_WITH_PCI
 	default y if CONF_WITH_USB && TARGET_RPI4
 	help
 	  The xHCI host controller used for the Raspberry Pi 4/400 external

--- a/usb/Kconfig
+++ b/usb/Kconfig
@@ -28,7 +28,7 @@ config CONF_WITH_USB_DWC2
 
 config CONF_WITH_USB_XHCI
 	bool
-	depends on CONF_WITH_PCI
+	depends on CONF_WITH_USB && TARGET_RPI4 && CONF_WITH_PCI
 	default y if CONF_WITH_USB && TARGET_RPI4
 	help
 	  The xHCI host controller used for the Raspberry Pi 4/400 external

--- a/usb/build.mk
+++ b/usb/build.mk
@@ -8,3 +8,4 @@
 obj-y += usb.o ucd.o udd.o usb_api.o usb_hub.o udd_mouse.o
 
 obj-$(CONF_WITH_USB_DWC2) += ucd_dwc2.o
+obj-$(CONF_WITH_USB_XHCI) += ucd_xhci.o

--- a/usb/ucd_xhci.c
+++ b/usb/ucd_xhci.c
@@ -1,0 +1,15 @@
+/*
+ * ucd_xhci.c - xHCI USB controller driver
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "usb_global.h"
+#include "ucd_xhci.h"
+
+void xhci_init(void)
+{
+    /* The VL805 PCIe resource path is wired in a later task. */
+    KINFO(("xhci_init(): controller initialization not implemented yet\n"));
+}

--- a/usb/ucd_xhci.c
+++ b/usb/ucd_xhci.c
@@ -61,7 +61,7 @@ static long xhci_lowlevel_init(struct xhci_priv *priv)
     priv->have_resources = raspi_vl805_get_resources(&priv->resources);
     if (!priv->have_resources) {
         KINFO(("xhci: VL805 controller not available\n"));
-        return -1;
+        return EOPNOTSUPP;
     }
 
     KINFO(("xhci: MMIO 0x%lx size 0x%lx irq %u\n",
@@ -69,7 +69,7 @@ static long xhci_lowlevel_init(struct xhci_priv *priv)
            priv->resources.mmio_size,
            priv->resources.irq));
     KINFO(("xhci: controller bring-up is not implemented yet\n"));
-    return -1;
+    return EOPNOTSUPP;
 }
 
 static long xhci_ioctl(struct ucdif *u, short cmd, long arg)
@@ -89,10 +89,10 @@ static long xhci_ioctl(struct ucdif *u, short cmd, long arg)
     case SUBMIT_INT_MSG:
         (void)arg;
         KINFO(("xhci: transfer submission is not implemented yet\n"));
-        return -1;
+        return EOPNOTSUPP;
     default:
         (void)arg;
-        return -1;
+        return EINVFN;
     }
 }
 

--- a/usb/ucd_xhci.c
+++ b/usb/ucd_xhci.c
@@ -1,15 +1,107 @@
 /*
- * ucd_xhci.c - xHCI USB controller driver
+ * ucd_xhci.c - xHCI USB host controller driver
  *
  * This file is distributed under the GPL, version 2 or at your
  * option any later version.  See doc/license.txt for details.
  */
 
 #include "usb_global.h"
+#include "usb.h"
+#include "usb_api.h"
+#include "raspi_vl805.h"
 #include "ucd_xhci.h"
+
+struct xhci_priv {
+    raspi_vl805_resources_t resources;
+    BOOL have_resources;
+};
+
+static long xhci_open(struct ucdif *u);
+static long xhci_close(struct ucdif *u);
+static long xhci_ioctl(struct ucdif *u, short cmd, long arg);
+static long xhci_lowlevel_init(struct xhci_priv *priv);
+
+static char xhci_lname[] = "xHCI USB driver\0";
+static struct usb_device *root_hub_dev = NULL;
+static struct xhci_priv xhci_local;
+static struct ucdif xhci_uif =
+{
+    0,
+    USB_API_VERSION,
+    USB_CONTRLL,
+    xhci_lname,
+    "xhci",
+    0,
+    0,
+    xhci_open,
+    xhci_close,
+    0,
+    xhci_ioctl,
+    0,
+    (long *)&xhci_local
+};
+
+static long xhci_open(struct ucdif *u)
+{
+    (void)u;
+    return E_OK;
+}
+
+static long xhci_close(struct ucdif *u)
+{
+    struct xhci_priv *priv;
+
+    priv = (struct xhci_priv *)u->ucd_priv;
+    priv->have_resources = FALSE;
+    return E_OK;
+}
+
+static long xhci_lowlevel_init(struct xhci_priv *priv)
+{
+    priv->have_resources = raspi_vl805_get_resources(&priv->resources);
+    if (!priv->have_resources) {
+        KINFO(("xhci: VL805 controller not available\n"));
+        return -1;
+    }
+
+    KINFO(("xhci: MMIO 0x%lx size 0x%lx irq %u\n",
+           priv->resources.mmio_base,
+           priv->resources.mmio_size,
+           priv->resources.irq));
+    KINFO(("xhci: controller bring-up is not implemented yet\n"));
+    return -1;
+}
+
+static long xhci_ioctl(struct ucdif *u, short cmd, long arg)
+{
+    struct xhci_priv *priv;
+
+    priv = (struct xhci_priv *)u->ucd_priv;
+
+    switch (cmd) {
+    case LOWLEVEL_INIT:
+        return xhci_lowlevel_init(priv);
+    case LOWLEVEL_STOP:
+        priv->have_resources = FALSE;
+        return E_OK;
+    case SUBMIT_CONTROL_MSG:
+    case SUBMIT_BULK_MSG:
+    case SUBMIT_INT_MSG:
+        (void)arg;
+        KINFO(("xhci: transfer submission is not implemented yet\n"));
+        return -1;
+    default:
+        (void)arg;
+        return -1;
+    }
+}
 
 void xhci_init(void)
 {
-    /* The VL805 PCIe resource path is wired in a later task. */
-    KINFO(("xhci_init(): controller initialization not implemented yet\n"));
+    if (ucd_register(&xhci_uif, &root_hub_dev)) {
+        KINFO(("xhci_init(): ucd register failed!\n"));
+        return;
+    }
+
+    KDEBUG(("xhci_init(): ucd register succeeded!\n"));
 }

--- a/usb/ucd_xhci.h
+++ b/usb/ucd_xhci.h
@@ -1,5 +1,5 @@
 /*
- * ucd_xhci.h - xHCI USB controller driver interface
+ * ucd_xhci.h - xHCI USB host controller driver
  *
  * This file is distributed under the GPL, version 2 or at your
  * option any later version.  See doc/license.txt for details.

--- a/usb/ucd_xhci.h
+++ b/usb/ucd_xhci.h
@@ -1,0 +1,13 @@
+/*
+ * ucd_xhci.h - xHCI USB controller driver interface
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef UCD_XHCI_H
+#define UCD_XHCI_H
+
+void xhci_init(void);
+
+#endif /* UCD_XHCI_H */

--- a/usb/usb.c
+++ b/usb/usb.c
@@ -38,6 +38,9 @@
 #include "usb.h"
 #include "usb_hub.h"
 #include "usb_api.h"
+#if CONF_WITH_USB_XHCI
+#include "ucd_xhci.h"
+#endif
 
 struct usb_device usb_dev[USB_MAX_DEVICE];
 static long asynch_allowed;
@@ -46,9 +49,6 @@ static long asynch_allowed;
 /* Built-in drivers: */
 #if CONF_WITH_USB_DWC2
 extern void dwc2_init(void);
-#endif
-#if CONF_WITH_USB_XHCI
-extern void xhci_init(void);
 #endif
 extern int usb_mouse_init(void);
 

--- a/usb/usb.c
+++ b/usb/usb.c
@@ -43,11 +43,14 @@ struct usb_device usb_dev[USB_MAX_DEVICE];
 static long asynch_allowed;
 
 
-// Bultin drivers:
-#ifndef TARGET_RPI4
-extern void dwc2_init (void);
+/* Built-in drivers: */
+#if CONF_WITH_USB_DWC2
+extern void dwc2_init(void);
 #endif
-extern int usb_mouse_init (void);
+#if CONF_WITH_USB_XHCI
+extern void xhci_init(void);
+#endif
+extern int usb_mouse_init(void);
 
 /***************************************************************************
  * Init USB Device
@@ -72,8 +75,11 @@ void usb_init(void)
     setup_usb_module_api();
 
     /* Initialize built-in drivers */
-#ifndef TARGET_RPI4
+#if CONF_WITH_USB_DWC2
     dwc2_init();
+#endif
+#if CONF_WITH_USB_XHCI
+    xhci_init();
 #endif
     usb_mouse_init();
 }


### PR DESCRIPTION
Fixes #37

## Summary
- Add Raspberry Pi 4/400 USB xHCI configuration alongside the existing Raspberry Pi DWC2 path.
- Add an xHCI UCD skeleton that registers with the existing USB stack and fails safely for unimplemented transfer operations.
- Discover the Raspberry Pi 4 VL805 xHCI controller through the generic PCI layer and request BAR0 resources with `pci_get_resource()`.
- Keep Raspberry Pi 1/2/3 USB on DWC2 and make Raspberry Pi 4 USB depend on PCI support.

## Current Scope
- This is a foundation PR, not full USB operation on Raspberry Pi 4 yet.
- VL805 discovery now uses generic PCI, but usable MMIO still depends on adding a 32-bit-accessible mapping for the BCM2711 high outbound PCI window.
- PCI interrupt routing remains out of scope and tracked separately by #63.
- xHCI command/event rings, DMA, root hub behavior, and transfer submission are intentionally not implemented yet.

## Validation
- `make rpi4_defconfig && make`
- `make rpi2_defconfig && make`
- `make rpi4_defconfig && make obj/usb.o obj/ucd_xhci.o obj/raspi_vl805.o`
- `make rpi2_defconfig && make obj/usb.o obj/ucd_dwc2.o`
- `make gitready`
- `git diff --check`

## Notes
- QEMU `raspi4b` is not a useful functional target for this path because current QEMU disables BCM2711 PCIe and does not emulate VL805.
- Real Raspberry Pi 4/400 validation remains required for later functional USB bring-up.