### PR TITLE
Add generic PCI bus support

### DIFF
--- a/.superpowers/sdd/2026-08-02-generic-pci-bios-layer/final-fix-report.md
+++ b/.superpowers/sdd/2026-08-02-generic-pci-bios-layer/final-fix-report.md
@@ -1,0 +1,31 @@
+# Final Review Fix Report
+
+## Files Changed
+
+- `bios/pci_core.c`
+- `docs/superpowers/plans/2026-08-02-generic-pci-bios-layer.md`
+- `docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md`
+
+## Commits
+
+- `52eaa06c Fix PCI final review findings`
+
+## Fixes
+
+- `pci_virt_to_bus()` and `pci_bus_to_virt()` now preserve backend PCI-window translation but fall back to identity translation when the backend reports `PCI_BAD_RESOURCE` for addresses outside its PCI windows. This lets normal RAM addresses such as `0x40000000` translate successfully on QEMU ARM `virt`.
+- BAR probing now uses the cached header type: type 0 devices probe six BARs, type 1 bridges probe two BARs, and other header types skip BAR decoding. The 64-bit BAR skip logic is bounded by that header-specific BAR count.
+- PCI init now runs a lightweight boot-time self-check when devices are present. It reports only failures through existing kernel logging and exercises exact lookup, wildcard lookup, class-code mask lookup, invalid handle/register errors, interrupt hook supported-or-unsupported status, and RAM identity DMA translation.
+- The plan and spec now document the final BAR limits, address-translation fallback semantics, and runtime/API validation path.
+
+## Commands And Results
+
+- `make virt-arm_defconfig && make`: passed; produced `virt-arm.elf`. Build emitted existing non-PCI warnings in VDI/AES code and the existing DATA segment warning.
+- `git diff --check`: passed with no output.
+- `timeout 8 qemu-system-arm -M virt,highmem=off -cpu cortex-a7 -m 128 -kernel virt-arm.elf -d guest_errors -display none -serial stdio -device virtio-net-pci`: reached boot output with `pci: 3 device(s) found`, no PCI self-check failure messages, and reached `AES: EMUDESK: evnt_multi()` before timeout terminated QEMU with SIGTERM.
+
+## Self-Review
+
+- The translation fallback is narrow: backend errors other than `PCI_BAD_RESOURCE` still fail, while non-window addresses keep identity behavior.
+- Bridge BAR probing no longer writes bus-number or bridge-window registers as BARs.
+- The validation path avoids a permanent CLI/user-facing surface and stays within existing kernel logging patterns.
+- `package-lock.json` remains untracked and was not staged or modified.

--- a/bios/Kconfig
+++ b/bios/Kconfig
@@ -198,6 +198,27 @@ config HD_DETECT_RETRIES
 
 endmenu
 
+menu "PCI bus support"
+
+config CONF_WITH_PCI
+	bool "PCI bus support"
+	depends on MACHINE_VIRT_ARM
+	default y if MACHINE_VIRT_ARM
+	help
+	  Native pTOS PCI layer modeled on useful Atari PCI BIOS service
+	  semantics. This provides discovery, configuration-space access,
+	  resource reporting and card ownership through pTOS C APIs, not the
+	  Atari _PCI cookie or function-table ABI.
+
+config CONF_WITH_PCI_VIRT_ECAM
+	bool
+	depends on CONF_WITH_PCI && MACHINE_VIRT_ARM
+	default y
+	help
+	  QEMU ARM virt generic ECAM PCIe backend.
+
+endmenu
+
 menu "Serial ports and console"
 
 config CONF_WITH_MFP

--- a/bios/bios.c
+++ b/bios/bios.c
@@ -371,11 +371,6 @@ static void bios_init(void)
     KDEBUG(("fill_cookie_jar()\n"));
     fill_cookie_jar();  /* detect hardware features and fill the cookie jar */
 
-#if CONF_WITH_PCI
-    KDEBUG(("pci_init()\n"));
-    pci_init();
-#endif
-
     /* Set up the BIOS console output */
     KDEBUG(("linea_init()\n"));
     linea_init();       /* initialize screen related line-a variables */
@@ -431,6 +426,11 @@ static void bios_init(void)
 #if CONF_WITH_SCC
     if (has_scc)
         boot_status |= SCC_AVAILABLE;   /* track progress */
+#endif
+
+#if CONF_WITH_PCI
+    KDEBUG(("pci_init()\n"));
+    pci_init();
 #endif
 
     /* The sound init must be done before allowing MFC interrupts,

--- a/bios/bios.c
+++ b/bios/bios.c
@@ -58,6 +58,9 @@
 #include "delay.h"
 #include "biosbind.h"
 #include "memory.h"
+#if CONF_WITH_PCI
+#include "pci.h"
+#endif
 #include "nova.h"
 #ifdef MACHINE_AMIGA
 #include "amiga.h"
@@ -367,6 +370,11 @@ static void bios_init(void)
     cookie_init();      /* sets a cookie jar */
     KDEBUG(("fill_cookie_jar()\n"));
     fill_cookie_jar();  /* detect hardware features and fill the cookie jar */
+
+#if CONF_WITH_PCI
+    KDEBUG(("pci_init()\n"));
+    pci_init();
+#endif
 
     /* Set up the BIOS console output */
     KDEBUG(("linea_init()\n"));

--- a/bios/build.mk
+++ b/bios/build.mk
@@ -41,6 +41,9 @@ obj-$(MACHINE_VIRT_ARM) += virt_uart.o virt_mmu.o virt_pic.o virt_timer.o
 
 obj-$(MACHINE_VIRT_M68K) += goldfish_tty.o goldfish_pic.o goldfish_rtc.o goldfish_rtc_isr.o goldfish_pic_isr.o
 
+obj-$(CONF_WITH_PCI) += pci_core.o
+obj-$(CONF_WITH_PCI_VIRT_ECAM) += virt_pci.o
+
 obj-$(CONF_WITH_VIRTIO_BLK) += virtio_blk.o
 
 # Fonts.  A multi-language image needs the fonts of every charset, a

--- a/bios/machine/virt-arm/virt_memmap.h
+++ b/bios/machine/virt-arm/virt_memmap.h
@@ -19,6 +19,12 @@
 #define VIRT_GIC_DIST_BASE  0x08000000UL
 #define VIRT_GIC_CPU_BASE   0x08010000UL
 #define VIRT_UART0_BASE     0x09000000UL
+#define VIRT_PCIE_MMIO_BASE     0x10000000UL
+#define VIRT_PCIE_MMIO_SIZE     0x2eff0000UL
+#define VIRT_PCIE_PIO_BASE      0x3eff0000UL
+#define VIRT_PCIE_PIO_SIZE      0x00010000UL
+#define VIRT_PCIE_ECAM_BASE     0x3f000000UL
+#define VIRT_PCIE_ECAM_SIZE     0x01000000UL
 
 /* virtio-mmio: 32 transports, 0x200 bytes apart, starting at GIC SPI 16
  * (see hw/arm/virt.c: base_memmap[VIRT_MMIO], irqmap[VIRT_MMIO],

--- a/bios/machine/virt-arm/virt_pci.c
+++ b/bios/machine/virt-arm/virt_pci.c
@@ -1,0 +1,12 @@
+/*
+ * virt_pci.c - QEMU ARM virt PCI backend
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "config.h"
+
+#ifndef MACHINE_VIRT_ARM
+#error This file must only be compiled for the QEMU ARM virt target
+#endif

--- a/bios/machine/virt-arm/virt_pci.c
+++ b/bios/machine/virt-arm/virt_pci.c
@@ -10,3 +10,167 @@
 #ifndef MACHINE_VIRT_ARM
 #error This file must only be compiled for the QEMU ARM virt target
 #endif
+
+#include "portab.h"
+#include "endian.h"
+#include "pci.h"
+#include "pci_backend.h"
+#include "virt_memmap.h"
+#include "virt_pci.h"
+
+static LONG virt_pci_init(void)
+{
+    return PCI_SUCCESSFUL;
+}
+
+static LONG virt_pci_get_windows(pci_backend_windows_t *windows)
+{
+    if (windows == 0)
+        return PCI_GENERAL_ERROR;
+
+    windows->ecam_base = VIRT_PCIE_ECAM_BASE;
+    windows->ecam_size = VIRT_PCIE_ECAM_SIZE;
+    windows->mmio_base = VIRT_PCIE_MMIO_BASE;
+    windows->mmio_size = VIRT_PCIE_MMIO_SIZE;
+    windows->pio_base = VIRT_PCIE_PIO_BASE;
+    windows->pio_size = VIRT_PCIE_PIO_SIZE;
+
+    return PCI_SUCCESSFUL;
+}
+
+static volatile UBYTE *virt_pci_ecam_ptr(UBYTE bus, UBYTE dev, UBYTE func, UWORD reg)
+{
+    return (volatile UBYTE *)(VIRT_PCIE_ECAM_BASE + ((ULONG)bus << 20) +
+                              ((ULONG)dev << 15) + ((ULONG)func << 12) + reg);
+}
+
+static LONG virt_pci_read_config(UBYTE bus, UBYTE dev, UBYTE func, UWORD reg, UWORD size, ULONG *value)
+{
+    volatile UBYTE *ptr;
+    volatile UWORD *word_ptr;
+    volatile ULONG *long_ptr;
+
+    if (value == 0)
+        return PCI_GENERAL_ERROR;
+
+    ptr = virt_pci_ecam_ptr(bus, dev, func, reg);
+
+    if (size == 1U) {
+        *value = (ULONG)*ptr;
+        return PCI_SUCCESSFUL;
+    }
+
+    if (size == 2U) {
+        word_ptr = (volatile UWORD *)ptr;
+        *value = (ULONG)le2cpu16(*word_ptr);
+        return PCI_SUCCESSFUL;
+    }
+
+    if (size == 4U) {
+        long_ptr = (volatile ULONG *)ptr;
+        *value = le2cpu32(*long_ptr);
+        return PCI_SUCCESSFUL;
+    }
+
+    return PCI_BAD_REGISTER_NUMBER;
+}
+
+static LONG virt_pci_write_config(UBYTE bus, UBYTE dev, UBYTE func, UWORD reg, UWORD size, ULONG value)
+{
+    volatile UBYTE *ptr;
+    volatile UWORD *word_ptr;
+    volatile ULONG *long_ptr;
+
+    ptr = virt_pci_ecam_ptr(bus, dev, func, reg);
+
+    if (size == 1U) {
+        *ptr = (UBYTE)value;
+        return PCI_SUCCESSFUL;
+    }
+
+    if (size == 2U) {
+        word_ptr = (volatile UWORD *)ptr;
+        *word_ptr = cpu2le16((UWORD)value);
+        return PCI_SUCCESSFUL;
+    }
+
+    if (size == 4U) {
+        long_ptr = (volatile ULONG *)ptr;
+        *long_ptr = cpu2le32(value);
+        return PCI_SUCCESSFUL;
+    }
+
+    return PCI_BAD_REGISTER_NUMBER;
+}
+
+static LONG virt_pci_bus_to_phys(ULONG bus_address, BOOL io, ULONG *phys_address)
+{
+    if (phys_address == 0)
+        return PCI_GENERAL_ERROR;
+
+    if (io) {
+        if (bus_address >= VIRT_PCIE_PIO_SIZE)
+            return PCI_BAD_RESOURCE;
+        *phys_address = VIRT_PCIE_PIO_BASE + bus_address;
+        return PCI_SUCCESSFUL;
+    }
+
+    if ((bus_address < VIRT_PCIE_MMIO_BASE) ||
+        (bus_address >= VIRT_PCIE_MMIO_BASE + VIRT_PCIE_MMIO_SIZE))
+        return PCI_BAD_RESOURCE;
+
+    *phys_address = bus_address;
+    return PCI_SUCCESSFUL;
+}
+
+static LONG virt_pci_phys_to_bus(ULONG phys_address, BOOL io, ULONG *bus_address)
+{
+    if (bus_address == 0)
+        return PCI_GENERAL_ERROR;
+
+    if (io) {
+        if ((phys_address < VIRT_PCIE_PIO_BASE) ||
+            (phys_address >= VIRT_PCIE_PIO_BASE + VIRT_PCIE_PIO_SIZE))
+            return PCI_BAD_RESOURCE;
+        *bus_address = phys_address - VIRT_PCIE_PIO_BASE;
+        return PCI_SUCCESSFUL;
+    }
+
+    if ((phys_address < VIRT_PCIE_MMIO_BASE) ||
+        (phys_address >= VIRT_PCIE_MMIO_BASE + VIRT_PCIE_MMIO_SIZE))
+        return PCI_BAD_RESOURCE;
+
+    *bus_address = phys_address;
+    return PCI_SUCCESSFUL;
+}
+
+static LONG virt_pci_hook_interrupt(PCI_HANDLE handle, UBYTE line, pci_interrupt_handler_t handler, void *param)
+{
+    return PCI_FUNC_NOT_SUPPORTED;
+}
+
+static LONG virt_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
+{
+    return PCI_FUNC_NOT_SUPPORTED;
+}
+
+static pci_backend_t virt_pci_backend_ops = {
+    virt_pci_init,
+    virt_pci_get_windows,
+    virt_pci_read_config,
+    virt_pci_write_config,
+    virt_pci_bus_to_phys,
+    virt_pci_phys_to_bus,
+    virt_pci_hook_interrupt,
+    virt_pci_unhook_interrupt
+};
+
+const pci_backend_t *virt_pci_backend(void)
+{
+    return &virt_pci_backend_ops;
+}
+
+const pci_backend_t *pci_backend_get(void)
+{
+    return virt_pci_backend();
+}

--- a/bios/machine/virt-arm/virt_pci.c
+++ b/bios/machine/virt-arm/virt_pci.c
@@ -146,11 +146,17 @@ static LONG virt_pci_phys_to_bus(ULONG phys_address, BOOL io, ULONG *bus_address
 
 static LONG virt_pci_hook_interrupt(PCI_HANDLE handle, UBYTE line, pci_interrupt_handler_t handler, void *param)
 {
+    (void)handle;
+    (void)line;
+    (void)handler;
+    (void)param;
     return PCI_FUNC_NOT_SUPPORTED;
 }
 
 static LONG virt_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
 {
+    (void)handle;
+    (void)line;
     return PCI_FUNC_NOT_SUPPORTED;
 }
 

--- a/bios/machine/virt-arm/virt_pci.h
+++ b/bios/machine/virt-arm/virt_pci.h
@@ -1,0 +1,19 @@
+/*
+ * virt_pci.h - QEMU ARM virt PCI backend
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef VIRT_PCI_H
+#define VIRT_PCI_H
+
+#ifdef MACHINE_VIRT_ARM
+
+#include "pci_backend.h"
+
+const pci_backend_t *virt_pci_backend(void);
+
+#endif /* MACHINE_VIRT_ARM */
+
+#endif /* VIRT_PCI_H */

--- a/bios/pci_backend.h
+++ b/bios/pci_backend.h
@@ -1,0 +1,36 @@
+/*
+ * pci_backend.h - internal PCI host bridge backend interface
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef PCI_BACKEND_H
+#define PCI_BACKEND_H
+
+#include "portab.h"
+#include "pci.h"
+
+typedef struct {
+    ULONG ecam_base;
+    ULONG ecam_size;
+    ULONG mmio_base;
+    ULONG mmio_size;
+    ULONG pio_base;
+    ULONG pio_size;
+} pci_backend_windows_t;
+
+typedef struct {
+    LONG (*init)(void);
+    LONG (*get_windows)(pci_backend_windows_t *windows);
+    LONG (*read_config)(UBYTE bus, UBYTE dev, UBYTE func, UWORD reg, UWORD size, ULONG *value);
+    LONG (*write_config)(UBYTE bus, UBYTE dev, UBYTE func, UWORD reg, UWORD size, ULONG value);
+    LONG (*bus_to_phys)(ULONG bus_address, BOOL io, ULONG *phys_address);
+    LONG (*phys_to_bus)(ULONG phys_address, BOOL io, ULONG *bus_address);
+    LONG (*hook_interrupt)(PCI_HANDLE handle, UBYTE line, pci_interrupt_handler_t handler, void *param);
+    LONG (*unhook_interrupt)(PCI_HANDLE handle, UBYTE line);
+} pci_backend_t;
+
+const pci_backend_t *pci_backend_get(void);
+
+#endif /* PCI_BACKEND_H */

--- a/bios/pci_core.c
+++ b/bios/pci_core.c
@@ -1,0 +1,19 @@
+/*
+ * pci_core.c - native pTOS PCI access layer
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "config.h"
+
+#if CONF_WITH_PCI
+
+#include "pci.h"
+
+LONG pci_init(void)
+{
+    return PCI_SUCCESSFUL;
+}
+
+#endif /* CONF_WITH_PCI */

--- a/bios/pci_core.c
+++ b/bios/pci_core.c
@@ -11,6 +11,7 @@
 
 #include "pci.h"
 #include "pci_backend.h"
+#include "endian.h"
 #include "kprint.h"
 #include "string.h"
 
@@ -18,6 +19,12 @@
 #define PCI_DEVICES_PER_BUS 32
 #define PCI_FUNCTIONS_PER_DEVICE 8
 #define PCI_HEADER_MULTIFUNCTION 0x80U
+#define PCI_BAR_IO              0x00000001UL
+#define PCI_BAR_MEM_TYPE_MASK   0x00000006UL
+#define PCI_BAR_MEM_TYPE_64     0x00000004UL
+#define PCI_BAR_MEM_PREFETCH    0x00000008UL
+#define PCI_BAR_IO_MASK         0xfffffffcUL
+#define PCI_BAR_MEM_MASK        0xfffffff0UL
 
 typedef struct {
     PCI_HANDLE handle;
@@ -47,8 +54,11 @@ static LONG pci_write_config_raw(pci_device_t *device, UWORD reg, UWORD size, UL
 static void pci_scan_bus(UBYTE bus);
 static void pci_scan_device(UBYTE bus, UBYTE dev);
 static void pci_add_function(UBYTE bus, UBYTE dev, UBYTE func);
+static void pci_decode_bars(pci_device_t *device);
+static void pci_decode_bar(pci_device_t *device, UWORD bar);
+static ULONG pci_bar_size(ULONG mask, BOOL io);
 static BOOL pci_class_matches(ULONG device_class, ULONG requested_class);
-static LONG pci_check_resource_access(pci_device_t *device, ULONG address, ULONG size, BOOL io);
+static LONG pci_find_resource_for_address(pci_device_t *device, BOOL io, ULONG address, UWORD size, pci_resource_t **resource);
 static LONG pci_read_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE *value);
 static LONG pci_read_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD *value);
 static LONG pci_read_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG *value);
@@ -217,9 +227,100 @@ static void pci_add_function(UBYTE bus, UBYTE dev, UBYTE func)
         value = 0UL;
     device->interrupt_pin = (UBYTE)value;
 
+    pci_decode_bars(device);
+
     device->callback = 0;
     device->used = 0;
     pci_device_count++;
+}
+
+static void pci_decode_bars(pci_device_t *device)
+{
+    UWORD bar;
+    UWORD last;
+    ULONG original;
+
+    memset(device->resources, 0, sizeof(device->resources));
+
+    for (bar = 0; bar < PCI_MAX_BARS; bar++) {
+        pci_decode_bar(device, bar);
+        if ((device->resources[bar].length != 0UL) &&
+            ((device->resources[bar].flags & PCI_RESOURCE_IO) == 0U)) {
+            if (pci_read_config_raw(device, PCI_CONFIG_BAR0 + (bar * 4U), 4, &original) == PCI_SUCCESSFUL) {
+                if ((original & PCI_BAR_MEM_TYPE_MASK) == PCI_BAR_MEM_TYPE_64)
+                    bar++;
+            }
+        }
+    }
+
+    last = PCI_MAX_BARS;
+    for (bar = 0; bar < PCI_MAX_BARS; bar++) {
+        if (device->resources[bar].length != 0UL)
+            last = bar;
+    }
+
+    if (last < PCI_MAX_BARS)
+        device->resources[last].flags |= PCI_RESOURCE_LAST;
+}
+
+static void pci_decode_bar(pci_device_t *device, UWORD bar)
+{
+    UWORD reg;
+    ULONG original;
+    ULONG mask;
+    ULONG masked_address;
+    ULONG phys_address;
+    BOOL io;
+    pci_resource_t *resource;
+
+    reg = PCI_CONFIG_BAR0 + (bar * 4U);
+
+    if (pci_read_config_raw(device, reg, 4, &original) != PCI_SUCCESSFUL)
+        return;
+    if (original == 0UL)
+        return;
+
+    if (pci_write_config_raw(device, reg, 4, 0xffffffffUL) != PCI_SUCCESSFUL)
+        return;
+    if (pci_read_config_raw(device, reg, 4, &mask) != PCI_SUCCESSFUL) {
+        pci_write_config_raw(device, reg, 4, original);
+        return;
+    }
+    pci_write_config_raw(device, reg, 4, original);
+
+    if (mask == 0UL)
+        return;
+
+    io = (original & PCI_BAR_IO) != 0UL;
+    masked_address = original & (io ? PCI_BAR_IO_MASK : PCI_BAR_MEM_MASK);
+    mask &= io ? PCI_BAR_IO_MASK : PCI_BAR_MEM_MASK;
+    if (mask == 0UL)
+        return;
+
+    if ((pci_backend != 0) && (pci_backend->bus_to_phys != 0)) {
+        if (pci_backend->bus_to_phys(masked_address, io, &phys_address) != PCI_SUCCESSFUL)
+            return;
+    } else {
+        phys_address = masked_address;
+    }
+
+    resource = &device->resources[bar];
+    resource->flags = PCI_RESOURCE_8BIT | PCI_RESOURCE_16BIT |
+                      PCI_RESOURCE_32BIT | PCI_RESOURCE_ORDER_INTEL;
+    if (io)
+        resource->flags |= PCI_RESOURCE_IO;
+    resource->start = masked_address;
+    resource->length = pci_bar_size(mask, io);
+    resource->offset = phys_address - masked_address;
+    resource->dmaoffset = 0UL;
+}
+
+static ULONG pci_bar_size(ULONG mask, BOOL io)
+{
+    ULONG masked_size;
+
+    masked_size = mask & (io ? PCI_BAR_IO_MASK : PCI_BAR_MEM_MASK);
+    return (~masked_size) + 1UL;
 }
 
 LONG pci_init(void)
@@ -396,14 +497,11 @@ LONG pci_get_resource(PCI_HANDLE handle, UWORD bar, pci_resource_t *resource)
 {
     pci_device_t *device;
 
-    if (resource == 0)
-        return PCI_GENERAL_ERROR;
-
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
 
-    if (bar >= PCI_MAX_BARS)
+    if ((bar >= PCI_MAX_BARS) || (resource == 0))
         return PCI_BAD_RESOURCE;
 
     if (device->resources[bar].length == 0UL)
@@ -413,28 +511,30 @@ LONG pci_get_resource(PCI_HANDLE handle, UWORD bar, pci_resource_t *resource)
     return PCI_SUCCESSFUL;
 }
 
-static LONG pci_check_resource_access(pci_device_t *device, ULONG address, ULONG size, BOOL io)
+static LONG pci_find_resource_for_address(pci_device_t *device, BOOL io, ULONG address, UWORD size, pci_resource_t **resource)
 {
     UWORD bar;
     ULONG end;
     ULONG resource_end;
-    pci_resource_t *resource;
+    pci_resource_t *candidate;
 
-    if (size == 0UL)
+    if ((device == 0) || (resource == 0) || (size == 0U))
         return PCI_BAD_RESOURCE;
 
-    end = address + size - 1UL;
+    end = address + (ULONG)size;
     if (end < address)
         return PCI_BAD_RESOURCE;
 
     for (bar = 0; bar < PCI_MAX_BARS; bar++) {
-        resource = &device->resources[bar];
-        if (resource->length != 0UL) {
-            if (((resource->flags & PCI_RESOURCE_IO) != 0U) == io) {
-                resource_end = resource->start + resource->length - 1UL;
-                if (resource_end >= resource->start) {
-                    if ((address >= resource->start) && (end <= resource_end))
+        candidate = &device->resources[bar];
+        if (candidate->length != 0UL) {
+            if (((candidate->flags & PCI_RESOURCE_IO) != 0U) == io) {
+                resource_end = candidate->start + candidate->length;
+                if (resource_end >= candidate->start) {
+                    if ((address >= candidate->start) && (end <= resource_end)) {
+                        *resource = candidate;
                         return PCI_SUCCESSFUL;
+                    }
                 }
             }
         }
@@ -446,79 +546,103 @@ static LONG pci_check_resource_access(pci_device_t *device, ULONG address, ULONG
 static LONG pci_read_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE *value)
 {
     pci_device_t *device;
+    pci_resource_t *resource;
+    volatile UBYTE *ptr;
 
     if (value == 0)
         return PCI_GENERAL_ERROR;
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_check_resource_access(device, address, 1UL, io) != PCI_SUCCESSFUL)
+    if (pci_find_resource_for_address(device, io, address, 1U, &resource) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    return PCI_FUNC_NOT_SUPPORTED;
+    ptr = (volatile UBYTE *)(address + resource->offset);
+    *value = *ptr;
+    return PCI_SUCCESSFUL;
 }
 
 static LONG pci_read_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD *value)
 {
     pci_device_t *device;
+    pci_resource_t *resource;
+    volatile UWORD *ptr;
 
     if (value == 0)
         return PCI_GENERAL_ERROR;
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_check_resource_access(device, address, 2UL, io) != PCI_SUCCESSFUL)
+    if (pci_find_resource_for_address(device, io, address, 2U, &resource) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    return PCI_FUNC_NOT_SUPPORTED;
+    ptr = (volatile UWORD *)(address + resource->offset);
+    *value = le2cpu16(*ptr);
+    return PCI_SUCCESSFUL;
 }
 
 static LONG pci_read_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG *value)
 {
     pci_device_t *device;
+    pci_resource_t *resource;
+    volatile ULONG *ptr;
 
     if (value == 0)
         return PCI_GENERAL_ERROR;
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_check_resource_access(device, address, 4UL, io) != PCI_SUCCESSFUL)
+    if (pci_find_resource_for_address(device, io, address, 4U, &resource) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    return PCI_FUNC_NOT_SUPPORTED;
+    ptr = (volatile ULONG *)(address + resource->offset);
+    *value = le2cpu32(*ptr);
+    return PCI_SUCCESSFUL;
 }
 
 static LONG pci_write_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE value)
 {
     pci_device_t *device;
+    pci_resource_t *resource;
+    volatile UBYTE *ptr;
 
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_check_resource_access(device, address, 1UL, io) != PCI_SUCCESSFUL)
+    if (pci_find_resource_for_address(device, io, address, 1U, &resource) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    return PCI_FUNC_NOT_SUPPORTED;
+    ptr = (volatile UBYTE *)(address + resource->offset);
+    *ptr = value;
+    return PCI_SUCCESSFUL;
 }
 
 static LONG pci_write_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD value)
 {
     pci_device_t *device;
+    pci_resource_t *resource;
+    volatile UWORD *ptr;
 
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_check_resource_access(device, address, 2UL, io) != PCI_SUCCESSFUL)
+    if (pci_find_resource_for_address(device, io, address, 2U, &resource) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    return PCI_FUNC_NOT_SUPPORTED;
+    ptr = (volatile UWORD *)(address + resource->offset);
+    *ptr = cpu2le16(value);
+    return PCI_SUCCESSFUL;
 }
 
 static LONG pci_write_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG value)
 {
     pci_device_t *device;
+    pci_resource_t *resource;
+    volatile ULONG *ptr;
 
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_check_resource_access(device, address, 4UL, io) != PCI_SUCCESSFUL)
+    if (pci_find_resource_for_address(device, io, address, 4U, &resource) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    return PCI_FUNC_NOT_SUPPORTED;
+    ptr = (volatile ULONG *)(address + resource->offset);
+    *ptr = cpu2le32(value);
+    return PCI_SUCCESSFUL;
 }
 
 LONG pci_read_mem_byte(PCI_HANDLE handle, ULONG address, UBYTE *value)
@@ -611,12 +735,11 @@ LONG pci_get_card_used(PCI_HANDLE handle, pci_card_callback_t *callback)
 {
     pci_device_t *device;
 
-    if (callback == 0)
-        return PCI_GENERAL_ERROR;
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    *callback = device->callback;
+    if (callback != 0)
+        *callback = device->callback;
     return device->used;
 }
 
@@ -628,7 +751,7 @@ LONG pci_set_card_used(PCI_HANDLE handle, pci_card_callback_t callback, LONG sta
     if (device == 0)
         return PCI_BAD_HANDLE;
     if ((state < 0) || (state > 3))
-        return PCI_SET_FAILED;
+        return PCI_GENERAL_ERROR;
     if (state == 2)
         device->callback = callback;
     else
@@ -661,7 +784,7 @@ LONG pci_virt_to_bus(PCI_HANDLE handle, ULONG address, pci_mem_t *mem)
             return PCI_GENERAL_ERROR;
     }
     mem->address = bus_address;
-    mem->length = 0xffffffffUL;
+    mem->length = 0xffffffffUL - address;
     return PCI_SUCCESSFUL;
 }
 
@@ -681,7 +804,7 @@ LONG pci_bus_to_virt(PCI_HANDLE handle, ULONG address, pci_mem_t *mem)
             return PCI_GENERAL_ERROR;
     }
     mem->address = phys_address;
-    mem->length = 0xffffffffUL;
+    mem->length = 0xffffffffUL - address;
     return PCI_SUCCESSFUL;
 }
 
@@ -690,7 +813,7 @@ LONG pci_virt_to_phys(ULONG address, pci_mem_t *mem)
     if (mem == 0)
         return PCI_GENERAL_ERROR;
     mem->address = address;
-    mem->length = 0xffffffffUL;
+    mem->length = 0xffffffffUL - address;
     return PCI_SUCCESSFUL;
 }
 
@@ -699,7 +822,7 @@ LONG pci_phys_to_virt(ULONG address, pci_mem_t *mem)
     if (mem == 0)
         return PCI_GENERAL_ERROR;
     mem->address = address;
-    mem->length = 0xffffffffUL;
+    mem->length = 0xffffffffUL - address;
     return PCI_SUCCESSFUL;
 }
 

--- a/bios/pci_core.c
+++ b/bios/pci_core.c
@@ -10,9 +10,682 @@
 #if CONF_WITH_PCI
 
 #include "pci.h"
+#include "pci_backend.h"
+#include "kprint.h"
+#include "string.h"
+
+#define PCI_MAX_DEVICES 64
+#define PCI_DEVICES_PER_BUS 32
+#define PCI_FUNCTIONS_PER_DEVICE 8
+#define PCI_HEADER_MULTIFUNCTION 0x80U
+
+typedef struct {
+    PCI_HANDLE handle;
+    UBYTE bus;
+    UBYTE dev;
+    UBYTE func;
+    UWORD vendor;
+    UWORD device;
+    ULONG classcode;
+    UBYTE header_type;
+    UBYTE interrupt_line;
+    UBYTE interrupt_pin;
+    pci_resource_t resources[PCI_MAX_BARS];
+    pci_card_callback_t callback;
+    LONG used;
+} pci_device_t;
+
+static const pci_backend_t *pci_backend;
+static pci_device_t pci_devices[PCI_MAX_DEVICES];
+static UWORD pci_device_count;
+static BOOL pci_table_full_reported;
+
+static pci_device_t *pci_device_from_handle(PCI_HANDLE handle);
+static LONG pci_check_reg(UWORD reg, UWORD size);
+static LONG pci_read_config_raw(pci_device_t *device, UWORD reg, UWORD size, ULONG *value);
+static LONG pci_write_config_raw(pci_device_t *device, UWORD reg, UWORD size, ULONG value);
+static void pci_scan_bus(UBYTE bus);
+static void pci_scan_device(UBYTE bus, UBYTE dev);
+static void pci_add_function(UBYTE bus, UBYTE dev, UBYTE func);
+static BOOL pci_class_matches(ULONG device_class, ULONG requested_class);
+static pci_resource_t *pci_find_resource(pci_device_t *device, ULONG address, BOOL io);
+static LONG pci_read_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE *value);
+static LONG pci_read_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD *value);
+static LONG pci_read_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG *value);
+static LONG pci_write_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE value);
+static LONG pci_write_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD value);
+static LONG pci_write_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG value);
+
+static pci_device_t *pci_device_from_handle(PCI_HANDLE handle)
+{
+    ULONG index;
+
+    if (handle == PCI_HANDLE_NONE)
+        return 0;
+
+    index = handle - 1UL;
+    if (index >= (ULONG)pci_device_count)
+        return 0;
+
+    if (pci_devices[index].handle != handle)
+        return 0;
+
+    return &pci_devices[index];
+}
+
+static LONG pci_check_reg(UWORD reg, UWORD size)
+{
+    if (reg >= 256U)
+        return PCI_BAD_REGISTER_NUMBER;
+
+    if ((ULONG)reg + (ULONG)size > 256UL)
+        return PCI_BAD_REGISTER_NUMBER;
+
+    if ((size == 2U) && ((reg & 1U) != 0U))
+        return PCI_BAD_REGISTER_NUMBER;
+
+    if ((size == 4U) && ((reg & 3U) != 0U))
+        return PCI_BAD_REGISTER_NUMBER;
+
+    if ((size != 1U) && (size != 2U) && (size != 4U))
+        return PCI_BAD_REGISTER_NUMBER;
+
+    return PCI_SUCCESSFUL;
+}
+
+static LONG pci_read_config_raw(pci_device_t *device, UWORD reg, UWORD size, ULONG *value)
+{
+    LONG ret;
+
+    if ((device == 0) || (value == 0))
+        return PCI_GENERAL_ERROR;
+
+    ret = pci_check_reg(reg, size);
+    if (ret != PCI_SUCCESSFUL)
+        return ret;
+
+    if ((pci_backend == 0) || (pci_backend->read_config == 0))
+        return PCI_FUNC_NOT_SUPPORTED;
+
+    return pci_backend->read_config(device->bus, device->dev, device->func, reg, size, value);
+}
+
+static LONG pci_write_config_raw(pci_device_t *device, UWORD reg, UWORD size, ULONG value)
+{
+    LONG ret;
+
+    if (device == 0)
+        return PCI_GENERAL_ERROR;
+
+    ret = pci_check_reg(reg, size);
+    if (ret != PCI_SUCCESSFUL)
+        return ret;
+
+    if ((pci_backend == 0) || (pci_backend->write_config == 0))
+        return PCI_FUNC_NOT_SUPPORTED;
+
+    return pci_backend->write_config(device->bus, device->dev, device->func, reg, size, value);
+}
+
+static void pci_scan_bus(UBYTE bus)
+{
+    UBYTE dev;
+
+    for (dev = 0; dev < PCI_DEVICES_PER_BUS; dev++)
+        pci_scan_device(bus, dev);
+}
+
+static void pci_scan_device(UBYTE bus, UBYTE dev)
+{
+    ULONG value;
+    UBYTE header_type;
+    UBYTE func;
+
+    if ((pci_backend == 0) || (pci_backend->read_config == 0))
+        return;
+
+    if (pci_backend->read_config(bus, dev, 0, PCI_CONFIG_VENDOR_ID, 2, &value) != PCI_SUCCESSFUL)
+        return;
+
+    if ((UWORD)value == PCI_ANY_VENDOR)
+        return;
+
+    pci_add_function(bus, dev, 0);
+
+    if (pci_backend->read_config(bus, dev, 0, PCI_CONFIG_HEADER_TYPE, 1, &value) != PCI_SUCCESSFUL)
+        return;
+
+    header_type = (UBYTE)value;
+    if ((header_type & PCI_HEADER_MULTIFUNCTION) == 0U)
+        return;
+
+    for (func = 1; func < PCI_FUNCTIONS_PER_DEVICE; func++) {
+        if (pci_backend->read_config(bus, dev, func, PCI_CONFIG_VENDOR_ID, 2, &value) == PCI_SUCCESSFUL) {
+            if ((UWORD)value != PCI_ANY_VENDOR)
+                pci_add_function(bus, dev, func);
+        }
+    }
+}
+
+static void pci_add_function(UBYTE bus, UBYTE dev, UBYTE func)
+{
+    ULONG value;
+    ULONG base;
+    ULONG subclass;
+    ULONG progif;
+    pci_device_t *device;
+
+    if (pci_device_count >= PCI_MAX_DEVICES) {
+        if (!pci_table_full_reported) {
+            KINFO(("pci: device table full\n"));
+            pci_table_full_reported = TRUE;
+        }
+        return;
+    }
+
+    device = &pci_devices[pci_device_count];
+    device->handle = (PCI_HANDLE)pci_device_count + 1UL;
+    device->bus = bus;
+    device->dev = dev;
+    device->func = func;
+
+    if (pci_backend->read_config(bus, dev, func, PCI_CONFIG_VENDOR_ID, 2, &value) != PCI_SUCCESSFUL)
+        return;
+    device->vendor = (UWORD)value;
+
+    if (pci_backend->read_config(bus, dev, func, PCI_CONFIG_DEVICE_ID, 2, &value) != PCI_SUCCESSFUL)
+        return;
+    device->device = (UWORD)value;
+
+    if (pci_backend->read_config(bus, dev, func, PCI_CONFIG_BASE_CLASS, 1, &base) != PCI_SUCCESSFUL)
+        return;
+    if (pci_backend->read_config(bus, dev, func, PCI_CONFIG_SUBCLASS, 1, &subclass) != PCI_SUCCESSFUL)
+        return;
+    if (pci_backend->read_config(bus, dev, func, PCI_CONFIG_PROGIF, 1, &progif) != PCI_SUCCESSFUL)
+        return;
+    device->classcode = ((base & 0xffUL) << 16) | ((subclass & 0xffUL) << 8) | (progif & 0xffUL);
+
+    if (pci_backend->read_config(bus, dev, func, PCI_CONFIG_HEADER_TYPE, 1, &value) != PCI_SUCCESSFUL)
+        return;
+    device->header_type = (UBYTE)value;
+
+    if (pci_backend->read_config(bus, dev, func, PCI_CONFIG_INTERRUPT_LINE, 1, &value) != PCI_SUCCESSFUL)
+        value = 0UL;
+    device->interrupt_line = (UBYTE)value;
+
+    if (pci_backend->read_config(bus, dev, func, PCI_CONFIG_INTERRUPT_PIN, 1, &value) != PCI_SUCCESSFUL)
+        value = 0UL;
+    device->interrupt_pin = (UBYTE)value;
+
+    device->callback = 0;
+    device->used = 0;
+    pci_device_count++;
+}
 
 LONG pci_init(void)
 {
+    LONG ret;
+
+    pci_device_count = 0;
+    pci_table_full_reported = FALSE;
+    memset(pci_devices, 0, sizeof(pci_devices));
+    pci_backend = pci_backend_get();
+
+    if ((pci_backend == 0) || (pci_backend->init == 0))
+        return PCI_FUNC_NOT_SUPPORTED;
+
+    ret = pci_backend->init();
+    if (ret != PCI_SUCCESSFUL)
+        return ret;
+
+    pci_scan_bus(0);
+    KINFO(("pci: %u device(s) found\n", pci_device_count));
+
+    return PCI_SUCCESSFUL;
+}
+
+LONG pci_find_device(UWORD vendor, UWORD device, UWORD index, PCI_HANDLE *handle)
+{
+    UWORD i;
+    UWORD found;
+
+    if (handle == 0)
+        return PCI_GENERAL_ERROR;
+
+    *handle = PCI_HANDLE_NONE;
+
+    if (vendor == PCI_ANY_VENDOR)
+        device = 0;
+
+    found = 0;
+    for (i = 0; i < pci_device_count; i++) {
+        if ((vendor == PCI_ANY_VENDOR) ||
+            ((pci_devices[i].vendor == vendor) && (pci_devices[i].device == device))) {
+            if (found == index) {
+                *handle = pci_devices[i].handle;
+                return PCI_SUCCESSFUL;
+            }
+            found++;
+        }
+    }
+
+    return PCI_DEVICE_NOT_FOUND;
+}
+
+static BOOL pci_class_matches(ULONG device_class, ULONG requested_class)
+{
+    ULONG mask;
+
+    mask = PCI_CLASS_CODE_MASK;
+    if ((requested_class & PCI_CLASS_MASK_BASE) != 0UL)
+        mask &= 0x0000ffffUL;
+    if ((requested_class & PCI_CLASS_MASK_SUBCLASS) != 0UL)
+        mask &= 0x00ff00ffUL;
+    if ((requested_class & PCI_CLASS_MASK_PROGIF) != 0UL)
+        mask &= 0x00ffff00UL;
+
+    return (device_class & mask) == (requested_class & mask & PCI_CLASS_CODE_MASK);
+}
+
+LONG pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle)
+{
+    UWORD i;
+    UWORD found;
+
+    if (handle == 0)
+        return PCI_GENERAL_ERROR;
+
+    *handle = PCI_HANDLE_NONE;
+
+    found = 0;
+    for (i = 0; i < pci_device_count; i++) {
+        if (pci_class_matches(pci_devices[i].classcode, classcode)) {
+            if (found == index) {
+                *handle = pci_devices[i].handle;
+                return PCI_SUCCESSFUL;
+            }
+            found++;
+        }
+    }
+
+    return PCI_DEVICE_NOT_FOUND;
+}
+
+LONG pci_read_config_byte(PCI_HANDLE handle, UWORD reg, UBYTE *value)
+{
+    ULONG raw;
+    LONG ret;
+    pci_device_t *device;
+
+    if (value == 0)
+        return PCI_GENERAL_ERROR;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+
+    ret = pci_read_config_raw(device, reg, 1, &raw);
+    if (ret == PCI_SUCCESSFUL)
+        *value = (UBYTE)raw;
+    return ret;
+}
+
+LONG pci_read_config_word(PCI_HANDLE handle, UWORD reg, UWORD *value)
+{
+    ULONG raw;
+    LONG ret;
+    pci_device_t *device;
+
+    if (value == 0)
+        return PCI_GENERAL_ERROR;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+
+    ret = pci_read_config_raw(device, reg, 2, &raw);
+    if (ret == PCI_SUCCESSFUL)
+        *value = (UWORD)raw;
+    return ret;
+}
+
+LONG pci_read_config_long(PCI_HANDLE handle, UWORD reg, ULONG *value)
+{
+    pci_device_t *device;
+
+    if (value == 0)
+        return PCI_GENERAL_ERROR;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    return pci_read_config_raw(device, reg, 4, value);
+}
+
+LONG pci_write_config_byte(PCI_HANDLE handle, UWORD reg, UBYTE value)
+{
+    pci_device_t *device;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    return pci_write_config_raw(device, reg, 1, (ULONG)value);
+}
+
+LONG pci_write_config_word(PCI_HANDLE handle, UWORD reg, UWORD value)
+{
+    pci_device_t *device;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    return pci_write_config_raw(device, reg, 2, (ULONG)value);
+}
+
+LONG pci_write_config_long(PCI_HANDLE handle, UWORD reg, ULONG value)
+{
+    pci_device_t *device;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    return pci_write_config_raw(device, reg, 4, value);
+}
+
+LONG pci_get_resource(PCI_HANDLE handle, UWORD bar, pci_resource_t *resource)
+{
+    pci_device_t *device;
+
+    if (resource == 0)
+        return PCI_GENERAL_ERROR;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+
+    if (bar >= PCI_MAX_BARS)
+        return PCI_BAD_RESOURCE;
+
+    *resource = device->resources[bar];
+    return PCI_SUCCESSFUL;
+}
+
+static pci_resource_t *pci_find_resource(pci_device_t *device, ULONG address, BOOL io)
+{
+    UWORD bar;
+    pci_resource_t *resource;
+
+    for (bar = 0; bar < PCI_MAX_BARS; bar++) {
+        resource = &device->resources[bar];
+        if (resource->length != 0UL) {
+            if (((resource->flags & PCI_RESOURCE_IO) != 0U) == io) {
+                if ((address >= resource->start) && (address < resource->start + resource->length))
+                    return resource;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static LONG pci_read_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE *value)
+{
+    pci_device_t *device;
+
+    if (value == 0)
+        return PCI_GENERAL_ERROR;
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    if (pci_find_resource(device, address, io) == 0)
+        return PCI_BAD_RESOURCE;
+    *value = *((volatile UBYTE *)address);
+    return PCI_SUCCESSFUL;
+}
+
+static LONG pci_read_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD *value)
+{
+    pci_device_t *device;
+
+    if (value == 0)
+        return PCI_GENERAL_ERROR;
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    if (pci_find_resource(device, address, io) == 0)
+        return PCI_BAD_RESOURCE;
+    *value = *((volatile UWORD *)address);
+    return PCI_SUCCESSFUL;
+}
+
+static LONG pci_read_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG *value)
+{
+    pci_device_t *device;
+
+    if (value == 0)
+        return PCI_GENERAL_ERROR;
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    if (pci_find_resource(device, address, io) == 0)
+        return PCI_BAD_RESOURCE;
+    *value = *((volatile ULONG *)address);
+    return PCI_SUCCESSFUL;
+}
+
+static LONG pci_write_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE value)
+{
+    pci_device_t *device;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    if (pci_find_resource(device, address, io) == 0)
+        return PCI_BAD_RESOURCE;
+    *((volatile UBYTE *)address) = value;
+    return PCI_SUCCESSFUL;
+}
+
+static LONG pci_write_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD value)
+{
+    pci_device_t *device;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    if (pci_find_resource(device, address, io) == 0)
+        return PCI_BAD_RESOURCE;
+    *((volatile UWORD *)address) = value;
+    return PCI_SUCCESSFUL;
+}
+
+static LONG pci_write_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG value)
+{
+    pci_device_t *device;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    if (pci_find_resource(device, address, io) == 0)
+        return PCI_BAD_RESOURCE;
+    *((volatile ULONG *)address) = value;
+    return PCI_SUCCESSFUL;
+}
+
+LONG pci_read_mem_byte(PCI_HANDLE handle, ULONG address, UBYTE *value)
+{
+    return pci_read_bus_byte(handle, address, FALSE, value);
+}
+
+LONG pci_read_mem_word(PCI_HANDLE handle, ULONG address, UWORD *value)
+{
+    return pci_read_bus_word(handle, address, FALSE, value);
+}
+
+LONG pci_read_mem_long(PCI_HANDLE handle, ULONG address, ULONG *value)
+{
+    return pci_read_bus_long(handle, address, FALSE, value);
+}
+
+LONG pci_write_mem_byte(PCI_HANDLE handle, ULONG address, UBYTE value)
+{
+    return pci_write_bus_byte(handle, address, FALSE, value);
+}
+
+LONG pci_write_mem_word(PCI_HANDLE handle, ULONG address, UWORD value)
+{
+    return pci_write_bus_word(handle, address, FALSE, value);
+}
+
+LONG pci_write_mem_long(PCI_HANDLE handle, ULONG address, ULONG value)
+{
+    return pci_write_bus_long(handle, address, FALSE, value);
+}
+
+LONG pci_read_io_byte(PCI_HANDLE handle, ULONG address, UBYTE *value)
+{
+    return pci_read_bus_byte(handle, address, TRUE, value);
+}
+
+LONG pci_read_io_word(PCI_HANDLE handle, ULONG address, UWORD *value)
+{
+    return pci_read_bus_word(handle, address, TRUE, value);
+}
+
+LONG pci_read_io_long(PCI_HANDLE handle, ULONG address, ULONG *value)
+{
+    return pci_read_bus_long(handle, address, TRUE, value);
+}
+
+LONG pci_write_io_byte(PCI_HANDLE handle, ULONG address, UBYTE value)
+{
+    return pci_write_bus_byte(handle, address, TRUE, value);
+}
+
+LONG pci_write_io_word(PCI_HANDLE handle, ULONG address, UWORD value)
+{
+    return pci_write_bus_word(handle, address, TRUE, value);
+}
+
+LONG pci_write_io_long(PCI_HANDLE handle, ULONG address, ULONG value)
+{
+    return pci_write_bus_long(handle, address, TRUE, value);
+}
+
+LONG pci_hook_interrupt(PCI_HANDLE handle, pci_interrupt_handler_t handler, void *param)
+{
+    pci_device_t *device;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    if (handler == 0)
+        return PCI_GENERAL_ERROR;
+    if ((pci_backend == 0) || (pci_backend->hook_interrupt == 0))
+        return PCI_FUNC_NOT_SUPPORTED;
+    return pci_backend->hook_interrupt(handle, device->interrupt_line, handler, param);
+}
+
+LONG pci_unhook_interrupt(PCI_HANDLE handle)
+{
+    pci_device_t *device;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    if ((pci_backend == 0) || (pci_backend->unhook_interrupt == 0))
+        return PCI_FUNC_NOT_SUPPORTED;
+    return pci_backend->unhook_interrupt(handle, device->interrupt_line);
+}
+
+LONG pci_get_card_used(PCI_HANDLE handle, pci_card_callback_t *callback)
+{
+    pci_device_t *device;
+
+    if (callback == 0)
+        return PCI_GENERAL_ERROR;
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    *callback = device->callback;
+    return device->used;
+}
+
+LONG pci_set_card_used(PCI_HANDLE handle, pci_card_callback_t callback, LONG state)
+{
+    pci_device_t *device;
+
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    device->callback = callback;
+    device->used = state;
+    return PCI_SUCCESSFUL;
+}
+
+LONG pci_get_pagesize(ULONG *pagesize)
+{
+    if (pagesize == 0)
+        return PCI_GENERAL_ERROR;
+    *pagesize = 4096UL;
+    return PCI_SUCCESSFUL;
+}
+
+LONG pci_virt_to_bus(PCI_HANDLE handle, ULONG address, pci_mem_t *mem)
+{
+    ULONG bus_address;
+    pci_device_t *device;
+
+    if (mem == 0)
+        return PCI_GENERAL_ERROR;
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    bus_address = address;
+    if ((pci_backend != 0) && (pci_backend->phys_to_bus != 0)) {
+        if (pci_backend->phys_to_bus(address, FALSE, &bus_address) != PCI_SUCCESSFUL)
+            return PCI_GENERAL_ERROR;
+    }
+    mem->address = bus_address;
+    mem->length = 0xffffffffUL;
+    return PCI_SUCCESSFUL;
+}
+
+LONG pci_bus_to_virt(PCI_HANDLE handle, ULONG address, pci_mem_t *mem)
+{
+    ULONG phys_address;
+    pci_device_t *device;
+
+    if (mem == 0)
+        return PCI_GENERAL_ERROR;
+    device = pci_device_from_handle(handle);
+    if (device == 0)
+        return PCI_BAD_HANDLE;
+    phys_address = address;
+    if ((pci_backend != 0) && (pci_backend->bus_to_phys != 0)) {
+        if (pci_backend->bus_to_phys(address, FALSE, &phys_address) != PCI_SUCCESSFUL)
+            return PCI_GENERAL_ERROR;
+    }
+    mem->address = phys_address;
+    mem->length = 0xffffffffUL;
+    return PCI_SUCCESSFUL;
+}
+
+LONG pci_virt_to_phys(ULONG address, pci_mem_t *mem)
+{
+    if (mem == 0)
+        return PCI_GENERAL_ERROR;
+    mem->address = address;
+    mem->length = 0xffffffffUL;
+    return PCI_SUCCESSFUL;
+}
+
+LONG pci_phys_to_virt(ULONG address, pci_mem_t *mem)
+{
+    if (mem == 0)
+        return PCI_GENERAL_ERROR;
+    mem->address = address;
+    mem->length = 0xffffffffUL;
     return PCI_SUCCESSFUL;
 }
 

--- a/bios/pci_core.c
+++ b/bios/pci_core.c
@@ -48,7 +48,7 @@ static void pci_scan_bus(UBYTE bus);
 static void pci_scan_device(UBYTE bus, UBYTE dev);
 static void pci_add_function(UBYTE bus, UBYTE dev, UBYTE func);
 static BOOL pci_class_matches(ULONG device_class, ULONG requested_class);
-static pci_resource_t *pci_find_resource(pci_device_t *device, ULONG address, BOOL io);
+static LONG pci_check_resource_access(pci_device_t *device, ULONG address, ULONG size, BOOL io);
 static LONG pci_read_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE *value);
 static LONG pci_read_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD *value);
 static LONG pci_read_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG *value);
@@ -406,26 +406,41 @@ LONG pci_get_resource(PCI_HANDLE handle, UWORD bar, pci_resource_t *resource)
     if (bar >= PCI_MAX_BARS)
         return PCI_BAD_RESOURCE;
 
+    if (device->resources[bar].length == 0UL)
+        return PCI_BAD_RESOURCE;
+
     *resource = device->resources[bar];
     return PCI_SUCCESSFUL;
 }
 
-static pci_resource_t *pci_find_resource(pci_device_t *device, ULONG address, BOOL io)
+static LONG pci_check_resource_access(pci_device_t *device, ULONG address, ULONG size, BOOL io)
 {
     UWORD bar;
+    ULONG end;
+    ULONG resource_end;
     pci_resource_t *resource;
+
+    if (size == 0UL)
+        return PCI_BAD_RESOURCE;
+
+    end = address + size - 1UL;
+    if (end < address)
+        return PCI_BAD_RESOURCE;
 
     for (bar = 0; bar < PCI_MAX_BARS; bar++) {
         resource = &device->resources[bar];
         if (resource->length != 0UL) {
             if (((resource->flags & PCI_RESOURCE_IO) != 0U) == io) {
-                if ((address >= resource->start) && (address < resource->start + resource->length))
-                    return resource;
+                resource_end = resource->start + resource->length - 1UL;
+                if (resource_end >= resource->start) {
+                    if ((address >= resource->start) && (end <= resource_end))
+                        return PCI_SUCCESSFUL;
+                }
             }
         }
     }
 
-    return 0;
+    return PCI_BAD_RESOURCE;
 }
 
 static LONG pci_read_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE *value)
@@ -437,10 +452,9 @@ static LONG pci_read_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE *
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_find_resource(device, address, io) == 0)
+    if (pci_check_resource_access(device, address, 1UL, io) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    *value = *((volatile UBYTE *)address);
-    return PCI_SUCCESSFUL;
+    return PCI_FUNC_NOT_SUPPORTED;
 }
 
 static LONG pci_read_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD *value)
@@ -452,10 +466,9 @@ static LONG pci_read_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD *
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_find_resource(device, address, io) == 0)
+    if (pci_check_resource_access(device, address, 2UL, io) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    *value = *((volatile UWORD *)address);
-    return PCI_SUCCESSFUL;
+    return PCI_FUNC_NOT_SUPPORTED;
 }
 
 static LONG pci_read_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG *value)
@@ -467,10 +480,9 @@ static LONG pci_read_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG *
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_find_resource(device, address, io) == 0)
+    if (pci_check_resource_access(device, address, 4UL, io) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    *value = *((volatile ULONG *)address);
-    return PCI_SUCCESSFUL;
+    return PCI_FUNC_NOT_SUPPORTED;
 }
 
 static LONG pci_write_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE value)
@@ -480,10 +492,9 @@ static LONG pci_write_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE 
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_find_resource(device, address, io) == 0)
+    if (pci_check_resource_access(device, address, 1UL, io) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    *((volatile UBYTE *)address) = value;
-    return PCI_SUCCESSFUL;
+    return PCI_FUNC_NOT_SUPPORTED;
 }
 
 static LONG pci_write_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD value)
@@ -493,10 +504,9 @@ static LONG pci_write_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD 
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_find_resource(device, address, io) == 0)
+    if (pci_check_resource_access(device, address, 2UL, io) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    *((volatile UWORD *)address) = value;
-    return PCI_SUCCESSFUL;
+    return PCI_FUNC_NOT_SUPPORTED;
 }
 
 static LONG pci_write_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG value)
@@ -506,10 +516,9 @@ static LONG pci_write_bus_long(PCI_HANDLE handle, ULONG address, BOOL io, ULONG 
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    if (pci_find_resource(device, address, io) == 0)
+    if (pci_check_resource_access(device, address, 4UL, io) != PCI_SUCCESSFUL)
         return PCI_BAD_RESOURCE;
-    *((volatile ULONG *)address) = value;
-    return PCI_SUCCESSFUL;
+    return PCI_FUNC_NOT_SUPPORTED;
 }
 
 LONG pci_read_mem_byte(PCI_HANDLE handle, ULONG address, UBYTE *value)
@@ -618,7 +627,12 @@ LONG pci_set_card_used(PCI_HANDLE handle, pci_card_callback_t callback, LONG sta
     device = pci_device_from_handle(handle);
     if (device == 0)
         return PCI_BAD_HANDLE;
-    device->callback = callback;
+    if ((state < 0) || (state > 3))
+        return PCI_SET_FAILED;
+    if (state == 2)
+        device->callback = callback;
+    else
+        device->callback = 0;
     device->used = state;
     return PCI_SUCCESSFUL;
 }
@@ -627,7 +641,7 @@ LONG pci_get_pagesize(ULONG *pagesize)
 {
     if (pagesize == 0)
         return PCI_GENERAL_ERROR;
-    *pagesize = 4096UL;
+    *pagesize = 0UL;
     return PCI_SUCCESSFUL;
 }
 

--- a/bios/pci_core.c
+++ b/bios/pci_core.c
@@ -62,7 +62,7 @@ static void pci_decode_bars(pci_device_t *device);
 static void pci_decode_bar(pci_device_t *device, UWORD bar);
 static UWORD pci_bar_limit(const pci_device_t *device);
 static ULONG pci_bar_size(ULONG mask, BOOL io);
-static BOOL pci_class_matches(ULONG device_class, ULONG requested_class);
+static BOOL pci_class_matches(ULONG device_class, ULONG requested_class, ULONG requested_mask);
 static void pci_self_check(void);
 static void pci_dummy_interrupt(void *param);
 static LONG pci_find_resource_for_address(pci_device_t *device, BOOL io, ULONG address, UWORD size, pci_resource_t **resource);
@@ -398,16 +398,16 @@ LONG pci_find_device(UWORD vendor, UWORD device, UWORD index, PCI_HANDLE *handle
     return PCI_DEVICE_NOT_FOUND;
 }
 
-static BOOL pci_class_matches(ULONG device_class, ULONG requested_class)
+static BOOL pci_class_matches(ULONG device_class, ULONG requested_class, ULONG requested_mask)
 {
     ULONG mask;
 
     mask = PCI_CLASS_CODE_MASK;
-    if ((requested_class & PCI_CLASS_MASK_BASE) != 0UL)
+    if ((requested_mask & PCI_CLASS_MASK_BASE) != 0UL)
         mask &= 0x0000ffffUL;
-    if ((requested_class & PCI_CLASS_MASK_SUBCLASS) != 0UL)
+    if ((requested_mask & PCI_CLASS_MASK_SUBCLASS) != 0UL)
         mask &= 0x00ff00ffUL;
-    if ((requested_class & PCI_CLASS_MASK_PROGIF) != 0UL)
+    if ((requested_mask & PCI_CLASS_MASK_PROGIF) != 0UL)
         mask &= 0x00ffff00UL;
 
     return (device_class & mask) == (requested_class & mask & PCI_CLASS_CODE_MASK);
@@ -442,7 +442,7 @@ static void pci_self_check(void)
     if ((ret != PCI_SUCCESSFUL) || (all_handle != pci_devices[0].handle))
         KINFO(("pci: self-check wildcard lookup failed (%ld)\n", ret));
 
-    ret = pci_find_classcode(pci_devices[0].classcode | PCI_CLASS_MASK_PROGIF, 0, &handle);
+    ret = pci_find_classcode(pci_devices[0].classcode, PCI_CLASS_MASK_PROGIF, 0, &handle);
     if (ret != PCI_SUCCESSFUL)
         KINFO(("pci: self-check class lookup failed (%ld)\n", ret));
 
@@ -465,7 +465,7 @@ static void pci_self_check(void)
         KINFO(("pci: self-check RAM virt-to-bus failed (%ld, %08lx)\n", ret, mem.address));
 }
 
-LONG pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle)
+LONG pci_find_classcode(ULONG classcode, ULONG mask, UWORD index, PCI_HANDLE *handle)
 {
     UWORD i;
     UWORD found;
@@ -477,7 +477,7 @@ LONG pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle)
 
     found = 0;
     for (i = 0; i < pci_device_count; i++) {
-        if (pci_class_matches(pci_devices[i].classcode, classcode)) {
+        if (pci_class_matches(pci_devices[i].classcode, classcode, mask)) {
             if (found == index) {
                 *handle = pci_devices[i].handle;
                 return PCI_SUCCESSFUL;

--- a/bios/pci_core.c
+++ b/bios/pci_core.c
@@ -239,18 +239,20 @@ static void pci_decode_bars(pci_device_t *device)
     UWORD bar;
     UWORD last;
     ULONG original;
+    BOOL skip_next;
 
     memset(device->resources, 0, sizeof(device->resources));
 
     for (bar = 0; bar < PCI_MAX_BARS; bar++) {
-        pci_decode_bar(device, bar);
-        if ((device->resources[bar].length != 0UL) &&
-            ((device->resources[bar].flags & PCI_RESOURCE_IO) == 0U)) {
-            if (pci_read_config_raw(device, PCI_CONFIG_BAR0 + (bar * 4U), 4, &original) == PCI_SUCCESSFUL) {
-                if ((original & PCI_BAR_MEM_TYPE_MASK) == PCI_BAR_MEM_TYPE_64)
-                    bar++;
-            }
+        skip_next = FALSE;
+        if (pci_read_config_raw(device, PCI_CONFIG_BAR0 + (bar * 4U), 4, &original) == PCI_SUCCESSFUL) {
+            if (((original & PCI_BAR_IO) == 0UL) &&
+                ((original & PCI_BAR_MEM_TYPE_MASK) == PCI_BAR_MEM_TYPE_64))
+                skip_next = TRUE;
         }
+        pci_decode_bar(device, bar);
+        if (skip_next)
+            bar++;
     }
 
     last = PCI_MAX_BARS;

--- a/bios/pci_core.c
+++ b/bios/pci_core.c
@@ -598,6 +598,10 @@ static LONG pci_find_resource_for_address(pci_device_t *device, BOOL io, ULONG a
     if ((device == 0) || (resource == 0) || (size == 0U))
         return PCI_BAD_RESOURCE;
 
+    if (((size == 2U) && ((address & 1UL) != 0UL)) ||
+        ((size == 4U) && ((address & 3UL) != 0UL)))
+        return PCI_BAD_RESOURCE;
+
     end = address + (ULONG)size;
     if (end < address)
         return PCI_BAD_RESOURCE;

--- a/bios/pci_core.c
+++ b/bios/pci_core.c
@@ -19,6 +19,10 @@
 #define PCI_DEVICES_PER_BUS 32
 #define PCI_FUNCTIONS_PER_DEVICE 8
 #define PCI_HEADER_MULTIFUNCTION 0x80U
+#define PCI_HEADER_TYPE_MASK     0x7fU
+#define PCI_HEADER_TYPE_DEVICE   0x00U
+#define PCI_HEADER_TYPE_BRIDGE   0x01U
+#define PCI_BRIDGE_BARS          2
 #define PCI_BAR_IO              0x00000001UL
 #define PCI_BAR_MEM_TYPE_MASK   0x00000006UL
 #define PCI_BAR_MEM_TYPE_64     0x00000004UL
@@ -56,8 +60,11 @@ static void pci_scan_device(UBYTE bus, UBYTE dev);
 static void pci_add_function(UBYTE bus, UBYTE dev, UBYTE func);
 static void pci_decode_bars(pci_device_t *device);
 static void pci_decode_bar(pci_device_t *device, UWORD bar);
+static UWORD pci_bar_limit(const pci_device_t *device);
 static ULONG pci_bar_size(ULONG mask, BOOL io);
 static BOOL pci_class_matches(ULONG device_class, ULONG requested_class);
+static void pci_self_check(void);
+static void pci_dummy_interrupt(void *param);
 static LONG pci_find_resource_for_address(pci_device_t *device, BOOL io, ULONG address, UWORD size, pci_resource_t **resource);
 static LONG pci_read_bus_byte(PCI_HANDLE handle, ULONG address, BOOL io, UBYTE *value);
 static LONG pci_read_bus_word(PCI_HANDLE handle, ULONG address, BOOL io, UWORD *value);
@@ -238,16 +245,19 @@ static void pci_decode_bars(pci_device_t *device)
 {
     UWORD bar;
     UWORD last;
+    UWORD limit;
     ULONG original;
     BOOL skip_next;
 
     memset(device->resources, 0, sizeof(device->resources));
 
-    for (bar = 0; bar < PCI_MAX_BARS; bar++) {
+    limit = pci_bar_limit(device);
+    for (bar = 0; bar < limit; bar++) {
         skip_next = FALSE;
         if (pci_read_config_raw(device, PCI_CONFIG_BAR0 + (bar * 4U), 4, &original) == PCI_SUCCESSFUL) {
             if (((original & PCI_BAR_IO) == 0UL) &&
-                ((original & PCI_BAR_MEM_TYPE_MASK) == PCI_BAR_MEM_TYPE_64))
+                ((original & PCI_BAR_MEM_TYPE_MASK) == PCI_BAR_MEM_TYPE_64) &&
+                (bar + 1U < limit))
                 skip_next = TRUE;
         }
         pci_decode_bar(device, bar);
@@ -263,6 +273,18 @@ static void pci_decode_bars(pci_device_t *device)
 
     if (last < PCI_MAX_BARS)
         device->resources[last].flags |= PCI_RESOURCE_LAST;
+}
+
+static UWORD pci_bar_limit(const pci_device_t *device)
+{
+    UBYTE type;
+
+    type = device->header_type & PCI_HEADER_TYPE_MASK;
+    if (type == PCI_HEADER_TYPE_DEVICE)
+        return PCI_MAX_BARS;
+    if (type == PCI_HEADER_TYPE_BRIDGE)
+        return PCI_BRIDGE_BARS;
+    return 0;
 }
 
 static void pci_decode_bar(pci_device_t *device, UWORD bar)
@@ -343,6 +365,7 @@ LONG pci_init(void)
 
     pci_scan_bus(0);
     KINFO(("pci: %u device(s) found\n", pci_device_count));
+    pci_self_check();
 
     return PCI_SUCCESSFUL;
 }
@@ -388,6 +411,58 @@ static BOOL pci_class_matches(ULONG device_class, ULONG requested_class)
         mask &= 0x00ffff00UL;
 
     return (device_class & mask) == (requested_class & mask & PCI_CLASS_CODE_MASK);
+}
+
+static void pci_dummy_interrupt(void *param)
+{
+    (void)param;
+}
+
+static void pci_self_check(void)
+{
+    PCI_HANDLE handle;
+    PCI_HANDLE all_handle;
+    pci_mem_t mem;
+    ULONG value;
+    UWORD word;
+    LONG ret;
+
+    if (pci_device_count == 0)
+        return;
+
+    mem.address = 0UL;
+    mem.length = 0UL;
+    handle = pci_devices[0].handle;
+
+    ret = pci_find_device(pci_devices[0].vendor, pci_devices[0].device, 0, &handle);
+    if ((ret != PCI_SUCCESSFUL) || (handle != pci_devices[0].handle))
+        KINFO(("pci: self-check exact lookup failed (%ld)\n", ret));
+
+    ret = pci_find_device(PCI_ANY_VENDOR, 0, 0, &all_handle);
+    if ((ret != PCI_SUCCESSFUL) || (all_handle != pci_devices[0].handle))
+        KINFO(("pci: self-check wildcard lookup failed (%ld)\n", ret));
+
+    ret = pci_find_classcode(pci_devices[0].classcode | PCI_CLASS_MASK_PROGIF, 0, &handle);
+    if (ret != PCI_SUCCESSFUL)
+        KINFO(("pci: self-check class lookup failed (%ld)\n", ret));
+
+    ret = pci_read_config_long(PCI_HANDLE_NONE, PCI_CONFIG_VENDOR_ID, &value);
+    if (ret != PCI_BAD_HANDLE)
+        KINFO(("pci: self-check invalid handle returned %ld\n", ret));
+
+    ret = pci_read_config_word(pci_devices[0].handle, 0xffU, &word);
+    if (ret != PCI_BAD_REGISTER_NUMBER)
+        KINFO(("pci: self-check invalid register returned %ld\n", ret));
+
+    ret = pci_hook_interrupt(pci_devices[0].handle, pci_dummy_interrupt, 0);
+    if ((ret != PCI_SUCCESSFUL) && (ret != PCI_FUNC_NOT_SUPPORTED))
+        KINFO(("pci: self-check interrupt hook returned %ld\n", ret));
+    if (ret == PCI_SUCCESSFUL)
+        pci_unhook_interrupt(pci_devices[0].handle);
+
+    ret = pci_virt_to_bus(pci_devices[0].handle, 0x40000000UL, &mem);
+    if ((ret != PCI_SUCCESSFUL) || (mem.address != 0x40000000UL))
+        KINFO(("pci: self-check RAM virt-to-bus failed (%ld, %08lx)\n", ret, mem.address));
 }
 
 LONG pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle)
@@ -773,6 +848,7 @@ LONG pci_get_pagesize(ULONG *pagesize)
 LONG pci_virt_to_bus(PCI_HANDLE handle, ULONG address, pci_mem_t *mem)
 {
     ULONG bus_address;
+    LONG ret;
     pci_device_t *device;
 
     if (mem == 0)
@@ -782,7 +858,8 @@ LONG pci_virt_to_bus(PCI_HANDLE handle, ULONG address, pci_mem_t *mem)
         return PCI_BAD_HANDLE;
     bus_address = address;
     if ((pci_backend != 0) && (pci_backend->phys_to_bus != 0)) {
-        if (pci_backend->phys_to_bus(address, FALSE, &bus_address) != PCI_SUCCESSFUL)
+        ret = pci_backend->phys_to_bus(address, FALSE, &bus_address);
+        if ((ret != PCI_SUCCESSFUL) && (ret != PCI_BAD_RESOURCE))
             return PCI_GENERAL_ERROR;
     }
     mem->address = bus_address;
@@ -793,6 +870,7 @@ LONG pci_virt_to_bus(PCI_HANDLE handle, ULONG address, pci_mem_t *mem)
 LONG pci_bus_to_virt(PCI_HANDLE handle, ULONG address, pci_mem_t *mem)
 {
     ULONG phys_address;
+    LONG ret;
     pci_device_t *device;
 
     if (mem == 0)
@@ -802,7 +880,8 @@ LONG pci_bus_to_virt(PCI_HANDLE handle, ULONG address, pci_mem_t *mem)
         return PCI_BAD_HANDLE;
     phys_address = address;
     if ((pci_backend != 0) && (pci_backend->bus_to_phys != 0)) {
-        if (pci_backend->bus_to_phys(address, FALSE, &phys_address) != PCI_SUCCESSFUL)
+        ret = pci_backend->bus_to_phys(address, FALSE, &phys_address);
+        if ((ret != PCI_SUCCESSFUL) && (ret != PCI_BAD_RESOURCE))
             return PCI_GENERAL_ERROR;
     }
     mem->address = phys_address;

--- a/docs/superpowers/plans/2026-08-02-generic-pci-bios-layer.md
+++ b/docs/superpowers/plans/2026-08-02-generic-pci-bios-layer.md
@@ -142,7 +142,7 @@ typedef LONG (*pci_card_callback_t)(LONG function);
 
 LONG pci_init(void);
 LONG pci_find_device(UWORD vendor, UWORD device, UWORD index, PCI_HANDLE *handle);
-LONG pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle);
+LONG pci_find_classcode(ULONG classcode, ULONG mask, UWORD index, PCI_HANDLE *handle);
 LONG pci_read_config_byte(PCI_HANDLE handle, UWORD reg, UBYTE *value);
 LONG pci_read_config_word(PCI_HANDLE handle, UWORD reg, UWORD *value);
 LONG pci_read_config_long(PCI_HANDLE handle, UWORD reg, ULONG *value);
@@ -441,7 +441,7 @@ Implement these public functions in `bios/pci_core.c`:
 ```c
 LONG pci_init(void);
 LONG pci_find_device(UWORD vendor, UWORD device, UWORD index, PCI_HANDLE *handle);
-LONG pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle);
+LONG pci_find_classcode(ULONG classcode, ULONG mask, UWORD index, PCI_HANDLE *handle);
 ```
 
 Requirements:
@@ -449,7 +449,7 @@ Requirements:
 - `pci_init()` clears the device table, calls `pci_backend_get()`, calls `backend->init()`, scans bus 0, logs `KINFO(("pci: %u device(s) found\n", pci_device_count));`, and returns `PCI_SUCCESSFUL` when backend init succeeds even if no devices are found.
 - `pci_find_device()` must not return `PCI_BAD_VENDOR_ID` for `vendor == PCI_ANY_VENDOR`; ignore `device` in that case to match the Atari special case.
 - `pci_find_device()` returns `PCI_DEVICE_NOT_FOUND` and sets `*handle = PCI_HANDLE_NONE` when no match exists.
-- `pci_find_classcode()` applies mask bits from the high byte of `classcode`: bit 26 ignores base class, bit 25 ignores subclass, bit 24 ignores programming interface.
+- `pci_find_classcode()` applies mask bits from the separate `mask` parameter: bit 26 ignores base class, bit 25 ignores subclass, bit 24 ignores programming interface. This intentionally differs from the Atari PCI BIOS packed `D0` argument while preserving the same comparison semantics for native pTOS C callers.
 - Both lookup functions treat a null output pointer as `PCI_GENERAL_ERROR`.
 
 - [ ] **Step 6: Implement public config read/write functions**

--- a/docs/superpowers/plans/2026-08-02-generic-pci-bios-layer.md
+++ b/docs/superpowers/plans/2026-08-02-generic-pci-bios-layer.md
@@ -606,6 +606,7 @@ static ULONG pci_bar_size(ULONG mask, BOOL io);
 Requirements:
 
 - During `pci_add_function()`, call `pci_decode_bars()` after interrupt fields are read.
+- Limit BAR probing by PCI header type: type 0 devices have six BARs, type 1 bridges have two BARs, and other header types are not BAR-decoded by this first implementation.
 - For each BAR, save the original value, write `0xffffffffUL`, read the mask, restore the original value, and skip BARs where original or mask is zero.
 - I/O BAR bus address is `original & PCI_BAR_IO_MASK` and size uses `mask & PCI_BAR_IO_MASK`.
 - Memory BAR bus address is `original & PCI_BAR_MEM_MASK` and size uses `mask & PCI_BAR_MEM_MASK`.
@@ -693,7 +694,7 @@ Requirements:
 
 - `pci_get_pagesize()` writes `0` and returns `PCI_SUCCESSFUL`.
 - Handle-based functions validate the handle before using backend translation.
-- For the first backend, translation is identity unless backend `phys_to_bus()` or `bus_to_phys()` maps the address through a PCI window.
+- For the first backend, translation is identity when backend `phys_to_bus()` or `bus_to_phys()` reports that the address is outside its PCI windows; PCI window translations still use the backend result.
 - Fill `pci_mem_t.address` with the translated address and `pci_mem_t.length` with `0xffffffffUL - address` when translation succeeds.
 
 - [ ] **Step 7: Compile-check resource implementation**
@@ -767,11 +768,11 @@ Run the QEMU command appropriate for the produced `virt-arm` image. If the build
 qemu-system-arm -M virt,highmem=off -cpu cortex-a7 -m 128 -kernel virt-arm.elf -d guest_errors -display none -serial stdio -device virtio-net-pci
 ```
 
-Expected: boot reaches BIOS startup far enough to print PCI initialization, and the log includes `pci: N device(s) found` with `N` greater than zero. If the command line needs this tree's documented virt-arm boot flags, adjust only the machine/image arguments and record the exact command in the report.
+Expected: boot reaches BIOS startup far enough to print PCI initialization, and the log includes `pci: N device(s) found` with `N` greater than zero. PCI self-check failures must not appear in the log. If the command line needs this tree's documented virt-arm boot flags, adjust only the machine/image arguments and record the exact command in the report.
 
 - [ ] **Step 4: Verify debug discoverability without adding permanent diagnostics**
 
-Inspect boot output from Step 3. If `pci: N device(s) found` is the only PCI log, keep it. Do not add a permanent CLI command in issue #56 because `virt-arm_defconfig` disables CLI and this feature is a BIOS service, not a user command.
+Inspect boot output from Step 3. The PCI core may run a boot-time self-check that logs only failures through existing kernel logging; it should cover exact lookup, wildcard lookup, class-code masks, invalid handle/register errors, interrupt hook supported-or-unsupported status, and identity RAM DMA translation. Do not add a permanent CLI command in issue #56 because `virt-arm_defconfig` disables CLI and this feature is a BIOS service, not a user command.
 
 - [ ] **Step 5: Run readiness checks**
 

--- a/docs/superpowers/plans/2026-08-02-generic-pci-bios-layer.md
+++ b/docs/superpowers/plans/2026-08-02-generic-pci-bios-layer.md
@@ -1,0 +1,819 @@
+# Generic PCI BIOS Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a native pTOS PCI layer modeled on Atari PCI BIOS service semantics, with QEMU ARM `virt` ECAM as the first buildable and testable backend.
+
+**Architecture:** Split PCI into a driver-facing API in `include/pci.h`, a shared BIOS core that owns handles/enumeration/resources, and machine backends that provide config-space and address-translation callbacks. The first backend is QEMU ARM `virt`; Raspberry Pi 4 PCIe support remains a follow-up backend in issue #57.
+
+**Tech Stack:** C90 with GNU extensions, Kconfig, Kbuild-style `build.mk`, freestanding BIOS code, `portab.h` fixed-width types, `KINFO(())`/`KDEBUG(())` tracing, QEMU ARM `virt` generic ECAM PCIe host bridge.
+
+## Global Constraints
+
+- Add a configurable generic PCI subsystem that is disabled for targets without PCI support.
+- Provide a native pTOS PCI API modeled on useful Atari PCI BIOS service semantics.
+- Represent PCI devices with opaque positive 32-bit handles.
+- Support lookup by vendor/device ID, including vendor ID `0xffff` for iterating all devices.
+- Support lookup by class code with Atari PCI BIOS-style mask bits.
+- Provide byte, word, and long configuration-space read/write helpers.
+- Provide BAR-backed memory and I/O resource descriptors.
+- Provide memory and I/O read/write helpers through resource descriptors.
+- Provide interrupt hook/unhook entry points that return a documented unsupported error when routing is not implemented.
+- Provide card-used state helpers.
+- Provide PMMU/address-translation helpers with identity behavior on non-MMU or already identity-mapped targets.
+- Add QEMU ARM `virt` as the first real backend using its generic ECAM PCIe host bridge.
+- Do not implement the Atari PCI BIOS 680x0 register calling convention.
+- Do not install or expose the Atari `_PCI` cookie.
+- Do not implement the Atari PCI BIOS function-table ABI.
+- Do not add the Raspberry Pi 4 backend in issue #56; that belongs to issue #57.
+- Do not refactor inherited PCI consumers in issue #56 except where needed to avoid duplicate new abstractions; the full audit belongs to issue #59.
+- C code must remain C90-compatible: declarations at the top of blocks, `/* */` comments, pTOS fixed-width types where relevant.
+- Do not touch the existing untracked `package-lock.json`.
+
+---
+
+## File Structure
+
+- Create `include/pci.h`: public native pTOS PCI API, error codes, handles, resource descriptors, and PCI register constants needed by drivers.
+- Create `bios/pci_backend.h`: internal backend interface used by the shared PCI core; not included by drivers.
+- Create `bios/pci_core.c`: shared PCI implementation for init, enumeration, lookup, config access, BAR decoding, resources, memory/I/O access helpers, card-used state, interrupts, and address translation.
+- Create `bios/machine/virt-arm/virt_pci.c`: QEMU ARM `virt` ECAM backend with fixed ECAM/MMIO/PIO windows.
+- Create `bios/machine/virt-arm/virt_pci.h`: QEMU ARM `virt` backend declaration for the shared core.
+- Modify `bios/machine/virt-arm/virt_memmap.h`: add PCI ECAM/MMIO/PIO constants from QEMU `hw/arm/virt.c`.
+- Modify `bios/Kconfig`: add `CONF_WITH_PCI` and `CONF_WITH_PCI_VIRT_ECAM`.
+- Modify `bios/build.mk`: build shared PCI and virt backend objects only when selected.
+- Modify `bios/bios.c`: call `pci_init()` during BIOS initialization when `CONF_WITH_PCI` is enabled.
+- Modify `configs/virt-arm_defconfig` only if config generation does not preserve the intended default.
+- Modify `docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md` only if implementation reveals a correction to the approved design.
+
+---
+
+### Task 1: Public API, Configuration, And Init Hook
+
+**Files:**
+- Create: `include/pci.h`
+- Create: `bios/pci_core.c` temporary build stub
+- Create: `bios/machine/virt-arm/virt_pci.c` temporary build stub
+- Modify: `bios/Kconfig`
+- Modify: `bios/build.mk`
+- Modify: `bios/bios.c`
+
+**Interfaces:**
+- Consumes: `portab.h`, `config.h`, existing BIOS initialization flow in `bios/bios.c`.
+- Produces: public `PCI_HANDLE`, `pci_resource_t`, `pci_mem_t`, PCI status codes, API function prototypes, and a `CONF_WITH_PCI`-guarded `pci_init()` call.
+
+- [ ] **Step 1: Create the public PCI header**
+
+Create `include/pci.h` with this exact public interface:
+
+```c
+/*
+ * pci.h - native pTOS PCI access layer
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef PCI_H
+#define PCI_H
+
+#include "portab.h"
+
+typedef ULONG PCI_HANDLE;
+
+#define PCI_HANDLE_NONE              0UL
+
+#define PCI_SUCCESSFUL               0L
+#define PCI_FUNC_NOT_SUPPORTED      -2L
+#define PCI_BAD_VENDOR_ID           -3L
+#define PCI_DEVICE_NOT_FOUND        -4L
+#define PCI_BAD_REGISTER_NUMBER     -5L
+#define PCI_SET_FAILED              -6L
+#define PCI_BUFFER_TOO_SMALL        -7L
+#define PCI_GENERAL_ERROR           -8L
+#define PCI_BAD_HANDLE              -9L
+#define PCI_BAD_RESOURCE           -10L
+
+#define PCI_ANY_VENDOR          0xffffU
+
+#define PCI_CLASS_MASK_PROGIF   0x01000000UL
+#define PCI_CLASS_MASK_SUBCLASS 0x02000000UL
+#define PCI_CLASS_MASK_BASE     0x04000000UL
+#define PCI_CLASS_CODE_MASK     0x00ffffffUL
+
+#define PCI_RESOURCE_IO         0x4000U
+#define PCI_RESOURCE_LAST       0x8000U
+#define PCI_RESOURCE_8BIT       0x0100U
+#define PCI_RESOURCE_16BIT      0x0200U
+#define PCI_RESOURCE_32BIT      0x0400U
+#define PCI_RESOURCE_ORDER_MOTOROLA 0x0000U
+#define PCI_RESOURCE_ORDER_INTEL    0x000fU
+
+#define PCI_CONFIG_VENDOR_ID    0x00U
+#define PCI_CONFIG_DEVICE_ID    0x02U
+#define PCI_CONFIG_COMMAND      0x04U
+#define PCI_CONFIG_STATUS       0x06U
+#define PCI_CONFIG_PROGIF       0x09U
+#define PCI_CONFIG_SUBCLASS     0x0aU
+#define PCI_CONFIG_BASE_CLASS   0x0bU
+#define PCI_CONFIG_HEADER_TYPE  0x0eU
+#define PCI_CONFIG_BAR0         0x10U
+#define PCI_CONFIG_INTERRUPT_LINE 0x3cU
+#define PCI_CONFIG_INTERRUPT_PIN  0x3dU
+
+#define PCI_MAX_BARS            6
+
+typedef struct {
+    UWORD next;
+    UWORD flags;
+    ULONG start;
+    ULONG length;
+    ULONG offset;
+    ULONG dmaoffset;
+} pci_resource_t;
+
+typedef struct {
+    ULONG address;
+    ULONG length;
+} pci_mem_t;
+
+typedef void (*pci_interrupt_handler_t)(void *param);
+typedef LONG (*pci_card_callback_t)(LONG function);
+
+LONG pci_init(void);
+LONG pci_find_device(UWORD vendor, UWORD device, UWORD index, PCI_HANDLE *handle);
+LONG pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle);
+LONG pci_read_config_byte(PCI_HANDLE handle, UWORD reg, UBYTE *value);
+LONG pci_read_config_word(PCI_HANDLE handle, UWORD reg, UWORD *value);
+LONG pci_read_config_long(PCI_HANDLE handle, UWORD reg, ULONG *value);
+LONG pci_write_config_byte(PCI_HANDLE handle, UWORD reg, UBYTE value);
+LONG pci_write_config_word(PCI_HANDLE handle, UWORD reg, UWORD value);
+LONG pci_write_config_long(PCI_HANDLE handle, UWORD reg, ULONG value);
+LONG pci_get_resource(PCI_HANDLE handle, UWORD bar, pci_resource_t *resource);
+LONG pci_read_mem_byte(PCI_HANDLE handle, ULONG address, UBYTE *value);
+LONG pci_read_mem_word(PCI_HANDLE handle, ULONG address, UWORD *value);
+LONG pci_read_mem_long(PCI_HANDLE handle, ULONG address, ULONG *value);
+LONG pci_write_mem_byte(PCI_HANDLE handle, ULONG address, UBYTE value);
+LONG pci_write_mem_word(PCI_HANDLE handle, ULONG address, UWORD value);
+LONG pci_write_mem_long(PCI_HANDLE handle, ULONG address, ULONG value);
+LONG pci_read_io_byte(PCI_HANDLE handle, ULONG address, UBYTE *value);
+LONG pci_read_io_word(PCI_HANDLE handle, ULONG address, UWORD *value);
+LONG pci_read_io_long(PCI_HANDLE handle, ULONG address, ULONG *value);
+LONG pci_write_io_byte(PCI_HANDLE handle, ULONG address, UBYTE value);
+LONG pci_write_io_word(PCI_HANDLE handle, ULONG address, UWORD value);
+LONG pci_write_io_long(PCI_HANDLE handle, ULONG address, ULONG value);
+LONG pci_hook_interrupt(PCI_HANDLE handle, pci_interrupt_handler_t handler, void *param);
+LONG pci_unhook_interrupt(PCI_HANDLE handle);
+LONG pci_get_card_used(PCI_HANDLE handle, pci_card_callback_t *callback);
+LONG pci_set_card_used(PCI_HANDLE handle, pci_card_callback_t callback, LONG state);
+LONG pci_get_pagesize(ULONG *pagesize);
+LONG pci_virt_to_bus(PCI_HANDLE handle, ULONG address, pci_mem_t *mem);
+LONG pci_bus_to_virt(PCI_HANDLE handle, ULONG address, pci_mem_t *mem);
+LONG pci_virt_to_phys(ULONG address, pci_mem_t *mem);
+LONG pci_phys_to_virt(ULONG address, pci_mem_t *mem);
+
+#endif /* PCI_H */
+```
+
+- [ ] **Step 2: Add PCI Kconfig options**
+
+In `bios/Kconfig`, add this menu after the storage devices menu and before `menu "Serial ports and console"`:
+
+```kconfig
+menu "PCI bus support"
+
+config CONF_WITH_PCI
+	bool "PCI bus support"
+	depends on MACHINE_VIRT_ARM
+	default y if MACHINE_VIRT_ARM
+	help
+	  Native pTOS PCI layer modeled on useful Atari PCI BIOS service
+	  semantics. This provides discovery, configuration-space access,
+	  resource reporting and card ownership through pTOS C APIs, not the
+	  Atari _PCI cookie or function-table ABI.
+
+config CONF_WITH_PCI_VIRT_ECAM
+	bool
+	depends on CONF_WITH_PCI && MACHINE_VIRT_ARM
+	default y
+	help
+	  QEMU ARM virt generic ECAM PCIe backend.
+
+endmenu
+```
+
+- [ ] **Step 3: Wire initial PCI objects into the BIOS build**
+
+In `bios/build.mk`, add these lines after the `MACHINE_VIRT_M68K` object line and before `CONF_WITH_VIRTIO_BLK`:
+
+```make
+obj-$(CONF_WITH_PCI) += pci_core.o
+obj-$(CONF_WITH_PCI_VIRT_ECAM) += virt_pci.o
+```
+
+- [ ] **Step 4: Add the BIOS init hook**
+
+In `bios/bios.c`, add the header include after the existing `#include "memory.h"` line:
+
+```c
+#if CONF_WITH_PCI
+#include "pci.h"
+#endif
+```
+
+Then add this initialization block after `fill_cookie_jar();` and before the console/Line-A initialization block:
+
+```c
+#if CONF_WITH_PCI
+    KDEBUG(("pci_init()\n"));
+    pci_init();
+#endif
+```
+
+- [ ] **Step 5: Create temporary compile stubs only for this task**
+
+Create `bios/pci_core.c` with this temporary implementation so Task 1 builds before Task 2 replaces it:
+
+```c
+/*
+ * pci_core.c - native pTOS PCI access layer
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "config.h"
+
+#if CONF_WITH_PCI
+
+#include "pci.h"
+
+LONG pci_init(void)
+{
+    return PCI_SUCCESSFUL;
+}
+
+#endif /* CONF_WITH_PCI */
+```
+
+Create `bios/machine/virt-arm/virt_pci.c` with this temporary implementation so Task 1 builds before Task 3 replaces it:
+
+```c
+/*
+ * virt_pci.c - QEMU ARM virt PCI backend
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "config.h"
+
+#ifndef MACHINE_VIRT_ARM
+#error This file must only be compiled for the QEMU ARM virt target
+#endif
+```
+
+- [ ] **Step 6: Verify config selection and builds**
+
+Run:
+
+```bash
+make virt-arm_defconfig
+grep '^CONF_WITH_PCI' .config
+make obj/pci_core.o obj/virt_pci.o
+make rpi2_defconfig
+grep '^CONF_WITH_PCI' .config || true
+make
+```
+
+Expected: `virt-arm_defconfig` selects `CONF_WITH_PCI=y` and `CONF_WITH_PCI_VIRT_ECAM=y`; `obj/pci_core.o` and `obj/virt_pci.o` build; `rpi2_defconfig` does not enable PCI; the Raspberry Pi 2 build still succeeds.
+
+- [ ] **Step 7: Commit API and config wiring**
+
+Run:
+
+```bash
+git add include/pci.h bios/Kconfig bios/build.mk bios/bios.c bios/pci_core.c bios/machine/virt-arm/virt_pci.c
+git commit -m "Add PCI API and configuration wiring"
+```
+
+---
+
+### Task 2: Generic PCI Core Enumeration And Lookup
+
+**Files:**
+- Create: `bios/pci_backend.h`
+- Modify: `bios/pci_core.c`
+
+**Interfaces:**
+- Consumes: public API from Task 1.
+- Produces: backend interface `pci_backend_t`, device enumeration, opaque handle table, lookup by vendor/device, lookup by class code, and config-space read/write helpers.
+
+- [ ] **Step 1: Create the internal backend header**
+
+Create `bios/pci_backend.h` with:
+
+```c
+/*
+ * pci_backend.h - internal PCI host bridge backend interface
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef PCI_BACKEND_H
+#define PCI_BACKEND_H
+
+#include "portab.h"
+#include "pci.h"
+
+typedef struct {
+    ULONG ecam_base;
+    ULONG ecam_size;
+    ULONG mmio_base;
+    ULONG mmio_size;
+    ULONG pio_base;
+    ULONG pio_size;
+} pci_backend_windows_t;
+
+typedef struct {
+    LONG (*init)(void);
+    LONG (*get_windows)(pci_backend_windows_t *windows);
+    LONG (*read_config)(UBYTE bus, UBYTE dev, UBYTE func, UWORD reg, UWORD size, ULONG *value);
+    LONG (*write_config)(UBYTE bus, UBYTE dev, UBYTE func, UWORD reg, UWORD size, ULONG value);
+    LONG (*bus_to_phys)(ULONG bus_address, BOOL io, ULONG *phys_address);
+    LONG (*phys_to_bus)(ULONG phys_address, BOOL io, ULONG *bus_address);
+    LONG (*hook_interrupt)(PCI_HANDLE handle, UBYTE line, pci_interrupt_handler_t handler, void *param);
+    LONG (*unhook_interrupt)(PCI_HANDLE handle, UBYTE line);
+} pci_backend_t;
+
+const pci_backend_t *pci_backend_get(void);
+
+#endif /* PCI_BACKEND_H */
+```
+
+- [ ] **Step 2: Replace the temporary core with enumeration state**
+
+Replace `bios/pci_core.c` with a complete generic core built around these constants and structs:
+
+```c
+#define PCI_MAX_DEVICES 64
+#define PCI_DEVICES_PER_BUS 32
+#define PCI_FUNCTIONS_PER_DEVICE 8
+#define PCI_HEADER_MULTIFUNCTION 0x80U
+
+typedef struct {
+    PCI_HANDLE handle;
+    UBYTE bus;
+    UBYTE dev;
+    UBYTE func;
+    UWORD vendor;
+    UWORD device;
+    ULONG classcode;
+    UBYTE header_type;
+    UBYTE interrupt_line;
+    UBYTE interrupt_pin;
+    pci_resource_t resources[PCI_MAX_BARS];
+    pci_card_callback_t callback;
+    LONG used;
+} pci_device_t;
+```
+
+The file must include:
+
+```c
+#include "config.h"
+
+#if CONF_WITH_PCI
+
+#include "pci.h"
+#include "pci_backend.h"
+#include "kprint.h"
+
+/* implementation */
+
+#endif /* CONF_WITH_PCI */
+```
+
+- [ ] **Step 3: Implement handle validation and config access helpers**
+
+Add internal helpers with these exact signatures:
+
+```c
+static pci_device_t *pci_device_from_handle(PCI_HANDLE handle);
+static LONG pci_check_reg(UWORD reg, UWORD size);
+static LONG pci_read_config_raw(pci_device_t *device, UWORD reg, UWORD size, ULONG *value);
+static LONG pci_write_config_raw(pci_device_t *device, UWORD reg, UWORD size, ULONG value);
+```
+
+Requirements:
+
+- `PCI_HANDLE_NONE` is invalid.
+- A valid handle is `device_index + 1`.
+- `pci_check_reg()` returns `PCI_BAD_REGISTER_NUMBER` when `reg >= 256`, `reg + size > 256`, word accesses are not 2-byte aligned, or long accesses are not 4-byte aligned.
+- Config read/write helpers call backend callbacks only after validating the handle and register.
+
+- [ ] **Step 4: Implement device scanning**
+
+Implement:
+
+```c
+static void pci_scan_bus(UBYTE bus);
+static void pci_scan_device(UBYTE bus, UBYTE dev);
+static void pci_add_function(UBYTE bus, UBYTE dev, UBYTE func);
+```
+
+Requirements:
+
+- Scan bus `0` only in this first implementation.
+- For each device, read function 0 vendor ID at offset `PCI_CONFIG_VENDOR_ID`.
+- Skip absent functions when vendor ID is `PCI_ANY_VENDOR`.
+- Read header type from `PCI_CONFIG_HEADER_TYPE`.
+- Scan functions 1 through 7 only when function 0 has `PCI_HEADER_MULTIFUNCTION` set.
+- Stop adding devices when `PCI_MAX_DEVICES` is reached and log `KINFO(("pci: device table full\n"));` once for the first dropped function.
+- Cache vendor ID, device ID, base/subclass/progif as one `ULONG classcode = (base << 16) | (subclass << 8) | progif`, header type, interrupt line, and interrupt pin.
+- Leave BAR/resource decoding to Task 4 by zeroing `resources`.
+
+- [ ] **Step 5: Implement public init and lookup functions**
+
+Implement these public functions in `bios/pci_core.c`:
+
+```c
+LONG pci_init(void);
+LONG pci_find_device(UWORD vendor, UWORD device, UWORD index, PCI_HANDLE *handle);
+LONG pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle);
+```
+
+Requirements:
+
+- `pci_init()` clears the device table, calls `pci_backend_get()`, calls `backend->init()`, scans bus 0, logs `KINFO(("pci: %u device(s) found\n", pci_device_count));`, and returns `PCI_SUCCESSFUL` when backend init succeeds even if no devices are found.
+- `pci_find_device()` must not return `PCI_BAD_VENDOR_ID` for `vendor == PCI_ANY_VENDOR`; ignore `device` in that case to match the Atari special case.
+- `pci_find_device()` returns `PCI_DEVICE_NOT_FOUND` and sets `*handle = PCI_HANDLE_NONE` when no match exists.
+- `pci_find_classcode()` applies mask bits from the high byte of `classcode`: bit 26 ignores base class, bit 25 ignores subclass, bit 24 ignores programming interface.
+- Both lookup functions treat a null output pointer as `PCI_GENERAL_ERROR`.
+
+- [ ] **Step 6: Implement public config read/write functions**
+
+Implement all config-space functions declared in `include/pci.h`. Byte reads write an `UBYTE`, word reads write a `UWORD`, and long reads write a `ULONG`. Byte/word writes pass the value in the low bits of `ULONG` to the backend.
+
+- [ ] **Step 7: Compile-check the generic core**
+
+Run:
+
+```bash
+make virt-arm_defconfig
+make obj/pci_core.o
+```
+
+Expected: `obj/pci_core.o` builds without C90 declaration-order errors.
+
+- [ ] **Step 8: Commit generic enumeration and lookup**
+
+Run:
+
+```bash
+git add bios/pci_backend.h bios/pci_core.c
+git commit -m "Add generic PCI enumeration and lookup"
+```
+
+---
+
+### Task 3: QEMU ARM Virt ECAM Backend
+
+**Files:**
+- Create: `bios/machine/virt-arm/virt_pci.h`
+- Modify: `bios/machine/virt-arm/virt_memmap.h`
+- Modify: `bios/machine/virt-arm/virt_pci.c`
+
+**Interfaces:**
+- Consumes: `pci_backend_t` from Task 2.
+- Produces: `const pci_backend_t *virt_pci_backend(void);` and `pci_backend_get()` for `CONF_WITH_PCI_VIRT_ECAM` builds.
+
+- [ ] **Step 1: Add QEMU virt PCI memory map constants**
+
+Add these constants to `bios/machine/virt-arm/virt_memmap.h` after `VIRT_UART0_BASE`:
+
+```c
+#define VIRT_PCIE_MMIO_BASE     0x10000000UL
+#define VIRT_PCIE_MMIO_SIZE     0x2eff0000UL
+#define VIRT_PCIE_PIO_BASE      0x3eff0000UL
+#define VIRT_PCIE_PIO_SIZE      0x00010000UL
+#define VIRT_PCIE_ECAM_BASE     0x3f000000UL
+#define VIRT_PCIE_ECAM_SIZE     0x01000000UL
+```
+
+- [ ] **Step 2: Create the backend header**
+
+Create `bios/machine/virt-arm/virt_pci.h` with:
+
+```c
+/*
+ * virt_pci.h - QEMU ARM virt PCI backend
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef VIRT_PCI_H
+#define VIRT_PCI_H
+
+#ifdef MACHINE_VIRT_ARM
+
+#include "pci_backend.h"
+
+const pci_backend_t *virt_pci_backend(void);
+
+#endif /* MACHINE_VIRT_ARM */
+
+#endif /* VIRT_PCI_H */
+```
+
+- [ ] **Step 3: Implement ECAM address calculation and backend callbacks**
+
+Replace the temporary `bios/machine/virt-arm/virt_pci.c` with an implementation that:
+
+- Includes `config.h`, `portab.h`, `endian.h`, `pci.h`, `pci_backend.h`, `virt_memmap.h`, and `virt_pci.h`.
+- Defines `static LONG virt_pci_init(void)` returning `PCI_SUCCESSFUL`.
+- Defines `static LONG virt_pci_get_windows(pci_backend_windows_t *windows)` filling the six constants from Step 1.
+- Defines `static volatile UBYTE *virt_pci_ecam_ptr(UBYTE bus, UBYTE dev, UBYTE func, UWORD reg)` using `VIRT_PCIE_ECAM_BASE + ((ULONG)bus << 20) + ((ULONG)dev << 15) + ((ULONG)func << 12) + reg`.
+- Defines read/write callbacks for size `1`, `2`, and `4` only.
+- Uses `le2cpu16()`, `le2cpu32()`, `cpu2le16()`, and `cpu2le32()` for word/long config accesses.
+- Defines `virt_pci_bus_to_phys()` and `virt_pci_phys_to_bus()` for low MMIO and PIO windows.
+- Defines hook/unhook callbacks that return `PCI_FUNC_NOT_SUPPORTED`.
+- Exposes a static `pci_backend_t virt_pci_backend_ops` and `const pci_backend_t *virt_pci_backend(void)`.
+
+Use this backend selection function at the end of the file:
+
+```c
+const pci_backend_t *pci_backend_get(void)
+{
+    return virt_pci_backend();
+}
+```
+
+- [ ] **Step 4: Compile-check backend config access**
+
+Run:
+
+```bash
+make virt-arm_defconfig
+make obj/virt_pci.o obj/pci_core.o
+```
+
+Expected: both objects build and link-visible `pci_backend_get()` is defined exactly once.
+
+- [ ] **Step 5: Commit QEMU virt backend**
+
+Run:
+
+```bash
+git add bios/machine/virt-arm/virt_pci.h bios/machine/virt-arm/virt_memmap.h bios/machine/virt-arm/virt_pci.c
+git commit -m "Add QEMU virt PCI ECAM backend"
+```
+
+---
+
+### Task 4: BAR Resources, Memory/I/O Access, Ownership, And Translation
+
+**Files:**
+- Modify: `bios/pci_core.c`
+
+**Interfaces:**
+- Consumes: backend config and translation callbacks from Task 3.
+- Produces: decoded `pci_resource_t` descriptors, `pci_get_resource()`, memory/I/O access helpers, interrupt unsupported routing, card-used state, and PMMU/address-translation helpers.
+
+- [ ] **Step 1: Add BAR decoding helpers**
+
+Add these constants and helpers to `bios/pci_core.c`:
+
+```c
+#define PCI_BAR_IO              0x00000001UL
+#define PCI_BAR_MEM_TYPE_MASK   0x00000006UL
+#define PCI_BAR_MEM_TYPE_64     0x00000004UL
+#define PCI_BAR_MEM_PREFETCH    0x00000008UL
+#define PCI_BAR_IO_MASK         0xfffffffcUL
+#define PCI_BAR_MEM_MASK        0xfffffff0UL
+```
+
+Add internal functions:
+
+```c
+static void pci_decode_bars(pci_device_t *device);
+static void pci_decode_bar(pci_device_t *device, UWORD bar);
+static ULONG pci_bar_size(ULONG mask, BOOL io);
+```
+
+Requirements:
+
+- During `pci_add_function()`, call `pci_decode_bars()` after interrupt fields are read.
+- For each BAR, save the original value, write `0xffffffffUL`, read the mask, restore the original value, and skip BARs where original or mask is zero.
+- I/O BAR bus address is `original & PCI_BAR_IO_MASK` and size uses `mask & PCI_BAR_IO_MASK`.
+- Memory BAR bus address is `original & PCI_BAR_MEM_MASK` and size uses `mask & PCI_BAR_MEM_MASK`.
+- Size is computed as `(~masked_size) + 1` after applying the proper mask.
+- For 64-bit memory BARs, mark the low BAR resource as present with the low 32-bit address and skip the next BAR. The first implementation supports only low 32-bit CPU addresses.
+- Set `PCI_RESOURCE_IO` for I/O resources.
+- Set `PCI_RESOURCE_8BIT | PCI_RESOURCE_16BIT | PCI_RESOURCE_32BIT | PCI_RESOURCE_ORDER_INTEL` for all implemented resources.
+- Set `PCI_RESOURCE_LAST` on the last populated descriptor for a device. If no BARs exist, every resource remains zero.
+- Fill `offset` as `phys_address - bus_address` using backend `bus_to_phys()`.
+- Fill `dmaoffset` as `0` for the first backend.
+
+- [ ] **Step 2: Implement resource lookup**
+
+Implement:
+
+```c
+LONG pci_get_resource(PCI_HANDLE handle, UWORD bar, pci_resource_t *resource);
+```
+
+Requirements:
+
+- Return `PCI_BAD_HANDLE` for invalid handles.
+- Return `PCI_BAD_RESOURCE` for `bar >= PCI_MAX_BARS`, null `resource`, or a BAR with `length == 0`.
+- Copy the cached descriptor into `*resource` on success.
+
+- [ ] **Step 3: Implement memory and I/O address validation**
+
+Add helper:
+
+```c
+static LONG pci_find_resource_for_address(pci_device_t *device, BOOL io, ULONG address, UWORD size, pci_resource_t **resource);
+```
+
+Requirements:
+
+- Match resources by `PCI_RESOURCE_IO` flag and `address >= start && address + size <= start + length`.
+- Return `PCI_BAD_RESOURCE` when no matching resource covers the requested range.
+- Avoid overflow by rejecting requests where `address + size < address`.
+
+- [ ] **Step 4: Implement memory and I/O read/write helpers**
+
+Implement all memory and I/O functions declared in `include/pci.h`.
+
+Requirements:
+
+- Validate handle and output pointer before reading.
+- Use `pci_find_resource_for_address()`.
+- Compute CPU address as `address + resource->offset`.
+- Use volatile `UBYTE *`, `UWORD *`, and `ULONG *` casts for loads/stores.
+- Use little-endian conversion for word/long values with `le2cpu16()`, `le2cpu32()`, `cpu2le16()`, and `cpu2le32()`.
+- Return `PCI_SUCCESSFUL` on successful access.
+
+- [ ] **Step 5: Implement interrupt and ownership helpers**
+
+Implement:
+
+```c
+LONG pci_hook_interrupt(PCI_HANDLE handle, pci_interrupt_handler_t handler, void *param);
+LONG pci_unhook_interrupt(PCI_HANDLE handle);
+LONG pci_get_card_used(PCI_HANDLE handle, pci_card_callback_t *callback);
+LONG pci_set_card_used(PCI_HANDLE handle, pci_card_callback_t callback, LONG state);
+```
+
+Requirements:
+
+- Interrupt functions validate the handle and delegate to backend callbacks with the cached interrupt line. The QEMU virt backend returns `PCI_FUNC_NOT_SUPPORTED`.
+- `pci_hook_interrupt()` returns `PCI_GENERAL_ERROR` if `handler == 0`.
+- `pci_get_card_used()` returns the cached `used` state and stores the callback in `*callback` when the output pointer is not null.
+- `pci_set_card_used()` accepts only states `0`, `1`, `2`, and `3`; other values return `PCI_GENERAL_ERROR`.
+- State `2` stores the callback pointer; states `0`, `1`, and `3` clear the callback.
+
+- [ ] **Step 6: Implement PMMU/address helpers**
+
+Implement:
+
+```c
+LONG pci_get_pagesize(ULONG *pagesize);
+LONG pci_virt_to_bus(PCI_HANDLE handle, ULONG address, pci_mem_t *mem);
+LONG pci_bus_to_virt(PCI_HANDLE handle, ULONG address, pci_mem_t *mem);
+LONG pci_virt_to_phys(ULONG address, pci_mem_t *mem);
+LONG pci_phys_to_virt(ULONG address, pci_mem_t *mem);
+```
+
+Requirements:
+
+- `pci_get_pagesize()` writes `0` and returns `PCI_SUCCESSFUL`.
+- Handle-based functions validate the handle before using backend translation.
+- For the first backend, translation is identity unless backend `phys_to_bus()` or `bus_to_phys()` maps the address through a PCI window.
+- Fill `pci_mem_t.address` with the translated address and `pci_mem_t.length` with `0xffffffffUL - address` when translation succeeds.
+
+- [ ] **Step 7: Compile-check resource implementation**
+
+Run:
+
+```bash
+make virt-arm_defconfig
+make obj/pci_core.o
+```
+
+Expected: `obj/pci_core.o` builds without C90 declaration-order errors or missing prototypes.
+
+- [ ] **Step 8: Commit resource and service helpers**
+
+Run:
+
+```bash
+git add bios/pci_core.c
+git commit -m "Add PCI resources and service helpers"
+```
+
+---
+
+### Task 5: Virt-ARM Validation Path And Final Polish
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md` if implementation details changed.
+- Modify: `docs/superpowers/plans/2026-08-02-generic-pci-bios-layer.md` if execution decisions changed the plan.
+- Modify: source files from Tasks 1-4 only for build or review fixes.
+
+**Interfaces:**
+- Consumes: completed Tasks 1-4.
+- Produces: verified branch with documented limits and pushed PR #61 updates.
+
+- [ ] **Step 1: Verify generated configurations**
+
+Run:
+
+```bash
+make virt-arm_defconfig
+grep '^CONF_WITH_PCI' .config
+make rpi2_defconfig
+grep '^CONF_WITH_PCI' .config || true
+make rpi4_defconfig
+grep '^CONF_WITH_PCI' .config || true
+```
+
+Expected: `virt-arm_defconfig` selects `CONF_WITH_PCI=y` and `CONF_WITH_PCI_VIRT_ECAM=y`; Raspberry Pi configs do not select PCI in issue #56.
+
+- [ ] **Step 2: Run build checks**
+
+Run:
+
+```bash
+make virt-arm_defconfig
+make
+make rpi2_defconfig
+make
+make rpi4_defconfig
+make
+```
+
+Expected: all configured builds succeed if the required toolchains are installed. Record exact toolchain errors if a build cannot run locally.
+
+- [ ] **Step 3: Run a QEMU virt-arm smoke boot with a PCI device**
+
+Run the QEMU command appropriate for the produced `virt-arm` image. If the build output says an ELF image is ready, use that image path in this shape:
+
+```bash
+qemu-system-arm -M virt -cpu cortex-a7 -kernel emutos.elf -nographic -serial stdio -device virtio-net-pci
+```
+
+Expected: boot reaches BIOS startup far enough to print PCI initialization, and the log includes `pci: N device(s) found` with `N` greater than zero. If the command line needs this tree's documented virt-arm boot flags, adjust only the machine/image arguments and record the exact command in the report.
+
+- [ ] **Step 4: Verify debug discoverability without adding permanent diagnostics**
+
+Inspect boot output from Step 3. If `pci: N device(s) found` is the only PCI log, keep it. Do not add a permanent CLI command in issue #56 because `virt-arm_defconfig` disables CLI and this feature is a BIOS service, not a user command.
+
+- [ ] **Step 5: Run readiness checks**
+
+Run:
+
+```bash
+make gitready
+git status --short
+git diff --stat master...HEAD
+```
+
+Expected: readiness checks pass or report only pre-existing/toolchain-limited failures; `package-lock.json` remains untracked and unstaged.
+
+- [ ] **Step 6: Update docs only for real deviations**
+
+If implementation differs from `docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md`, update the spec with the exact final behavior. If the human-approved Task 1/Task 4 sequencing changes the plan, update this plan with the exact final task shape. Do not create a documentation-only commit when the docs already match the implementation.
+
+- [ ] **Step 7: Commit any final fixes or documentation changes**
+
+When files changed during Task 5, run:
+
+```bash
+git add include/pci.h bios/Kconfig bios/build.mk bios/bios.c bios/pci_backend.h bios/pci_core.c bios/machine/virt-arm/virt_pci.h bios/machine/virt-arm/virt_pci.c bios/machine/virt-arm/virt_memmap.h docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md docs/superpowers/plans/2026-08-02-generic-pci-bios-layer.md
+git commit -m "Verify generic PCI BIOS layer"
+```
+
+If no files changed, do not create an empty commit.
+
+- [ ] **Step 8: Push PR #61 branch**
+
+Run:
+
+```bash
+git push
+```
+
+Expected: branch `feature/56-generic-pci-bus-support` updates draft PR #61.
+
+---
+
+## Self-Review
+
+- Spec coverage: Task 1 covers public native API, Kconfig, build wiring, and BIOS init; Task 2 covers handles, enumeration, lookup, and config-space helpers; Task 3 covers QEMU ARM `virt` ECAM backend; Task 4 covers BAR resources, memory/I/O helpers, interrupt unsupported paths, ownership, and address translation; Task 5 covers build and QEMU validation.
+- Placeholder scan: No placeholder markers or deferred implementation text remain. Raspberry Pi 4 and inherited PCI-code migration are explicitly excluded because issues #57 and #59 own them.
+- Type consistency: `PCI_HANDLE`, `pci_resource_t`, `pci_mem_t`, `pci_backend_t`, and public function signatures are defined before later tasks consume them and use `portab.h` types consistently.

--- a/docs/superpowers/plans/2026-08-02-generic-pci-bios-layer.md
+++ b/docs/superpowers/plans/2026-08-02-generic-pci-bios-layer.md
@@ -764,7 +764,7 @@ Expected: all configured builds succeed if the required toolchains are installed
 Run the QEMU command appropriate for the produced `virt-arm` image. If the build output says an ELF image is ready, use that image path in this shape:
 
 ```bash
-qemu-system-arm -M virt -cpu cortex-a7 -kernel emutos.elf -nographic -serial stdio -device virtio-net-pci
+qemu-system-arm -M virt,highmem=off -cpu cortex-a7 -m 128 -kernel virt-arm.elf -d guest_errors -display none -serial stdio -device virtio-net-pci
 ```
 
 Expected: boot reaches BIOS startup far enough to print PCI initialization, and the log includes `pci: N device(s) found` with `N` greater than zero. If the command line needs this tree's documented virt-arm boot flags, adjust only the machine/image arguments and record the exact command in the report.

--- a/docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md
+++ b/docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md
@@ -163,7 +163,7 @@ Runtime checks under QEMU ARM `virt`:
 - Confirm invalid handles and invalid config offsets return documented errors.
 - Confirm optional interrupt hook/unhook either work or return `PCI_FUNC_NOT_SUPPORTED`.
 
-Unit-style tests are not established for BIOS code in this tree, so validation should be build checks plus QEMU runtime smoke tests and small diagnostic logging or CLI hooks only if they fit existing project patterns.
+Unit-style tests are not established for BIOS code in this tree, so validation should be build checks plus QEMU runtime smoke tests and small diagnostic logging or CLI hooks only if they fit existing project patterns. The first PCI backend uses a boot-time self-check in the PCI core that reports failures through existing kernel logging and exercises exact lookup, wildcard lookup, class-code mask lookup, invalid handle/register errors, interrupt hook supported-or-unsupported status, and RAM identity DMA translation without adding a user-facing command.
 
 ## Follow-Up Integration
 

--- a/docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md
+++ b/docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md
@@ -119,13 +119,14 @@ The generic core should decode PCI BARs by writing all ones, reading back the si
 - Size.
 - Flags such as prefetchable and 64-bit memory.
 
-The QEMU ARM `virt` backend should describe its PCI windows from QEMU's machine layout:
+The QEMU ARM `virt` backend should describe its low PCI windows from QEMU's
+`virt,highmem=off` machine layout:
 
 - ECAM base `0x3f000000`, size `0x01000000`.
 - PCI MMIO window base `0x10000000`, size `0x2eff0000`.
 - PCI PIO window base `0x3eff0000`, size `0x00010000`.
 
-The backend should implement config-space access through ECAM. Resource translation should map QEMU's low MMIO and PIO windows according to the fixed virt memory map. High PCI windows are not required for the first implementation.
+The backend should implement config-space access through ECAM. Resource translation should map QEMU's low MMIO and PIO windows according to the fixed virt memory map. High PCI windows are not required for the first implementation; validation must run QEMU with `-M virt,highmem=off` so ECAM is available at the low `0x3f000000` address implemented by this backend.
 
 ## Interrupts
 
@@ -154,7 +155,7 @@ Build checks:
 
 Runtime checks under QEMU ARM `virt`:
 
-- Boot the `virt-arm` image under QEMU with at least one PCI device attached.
+- Boot the `virt-arm` image under QEMU with `-M virt,highmem=off` and at least one PCI device attached.
 - Confirm PCI initialization logs at least one discovered device.
 - Confirm vendor/device lookup can find a known QEMU device.
 - Confirm vendor `0xffff` iteration returns discovered devices in stable order.

--- a/docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md
+++ b/docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md
@@ -1,0 +1,179 @@
+# Generic PCI BIOS Layer Design
+
+## Context
+
+Issue #56 adds a generic PCI bus layer for pTOS using the Atari PCI BIOS and device driver specification as the functional model. The goal is not binary compatibility with Atari PCI BIOS programs. pTOS should expose native C interfaces that preserve the useful service semantics: discovery, lookup, configuration-space access, BAR/resource reporting, device ownership, interrupt hooks, and address-translation helpers.
+
+This work is a prerequisite for narrower follow-up work:
+
+- Issue #57 adds the Raspberry Pi 4 BCM2711 PCIe backend to the generic PCI layer.
+- Issue #37 then uses the generic PCI layer to find the VL805 xHCI controller and consume its BAR resources.
+- Issue #59 later audits inherited PCI-related code and moves PCI consumers onto this shared API.
+
+## Goals
+
+- Add a configurable generic PCI subsystem that is disabled for targets without PCI support.
+- Provide a native pTOS PCI API modeled on useful Atari PCI BIOS service semantics.
+- Represent PCI devices with opaque positive 32-bit handles.
+- Enumerate PCI buses/devices/functions and cache discovered metadata.
+- Support lookup by vendor/device ID, including vendor ID `0xffff` for iterating all devices.
+- Support lookup by class code with Atari PCI BIOS-style mask bits.
+- Provide byte, word, and long configuration-space read/write helpers.
+- Provide BAR-backed memory and I/O resource descriptors.
+- Provide memory and I/O read/write helpers through resource descriptors.
+- Provide interrupt hook/unhook entry points that return a documented unsupported error when routing is not implemented.
+- Provide card-used state helpers.
+- Provide PMMU/address-translation helpers with identity behavior on non-MMU or already identity-mapped targets.
+- Add QEMU ARM `virt` as the first real backend using its generic ECAM PCIe host bridge.
+
+## Non-Goals
+
+- Do not implement the Atari PCI BIOS 680x0 register calling convention.
+- Do not install or expose the Atari `_PCI` cookie.
+- Do not implement the Atari PCI BIOS function-table ABI.
+- Do not make pTOS drivers depend on original Atari binary compatibility.
+- Do not add the Raspberry Pi 4 backend in issue #56; that belongs to issue #57.
+- Do not refactor inherited PCI consumers in issue #56 except where needed to avoid duplicate new abstractions; the full audit belongs to issue #59.
+
+## Architecture
+
+The PCI subsystem has three layers:
+
+1. **Driver-facing API:** Shared headers and C functions used by drivers and platform-independent code. This layer owns handles, error codes, lookup semantics, resource descriptors, and card-used state.
+2. **Generic core:** Enumeration and metadata caching. It walks buses/devices/functions through backend config-space callbacks, assigns opaque handles, decodes BARs, and implements API semantics that are independent of a host bridge.
+3. **Backend:** Machine-specific host bridge access. The first backend is QEMU ARM `virt`, using the board's generic ECAM host bridge and fixed PCI resource windows.
+
+Shared PCI code must not know Raspberry Pi 4 or QEMU internals beyond backend-provided window descriptors and config-space access functions. Machine-specific backend files may contain raw host bridge addresses, ECAM layout, and interrupt-routing limitations.
+
+## Configuration And Build
+
+Add a `CONF_WITH_PCI` Kconfig option under BIOS or a new PCI-related menu. It should default to enabled only where a backend exists. For the first implementation, that means `MACHINE_VIRT_ARM`.
+
+Add a backend selection symbol such as `CONF_WITH_PCI_VIRT_ECAM`, defaulting to `y` when `CONF_WITH_PCI && MACHINE_VIRT_ARM`.
+
+Build shared PCI core objects only when `CONF_WITH_PCI` is set. Build the QEMU virt backend only when `CONF_WITH_PCI_VIRT_ECAM` is set. Existing non-PCI targets must not compile PCI core or backend code unless explicitly enabled later.
+
+## API Shape
+
+The public API should live in `include/pci.h` or another shared include path used by BIOS and drivers. The implementation should prefer pTOS fixed-width types from `portab.h`.
+
+Use an opaque positive `ULONG` handle type:
+
+```c
+typedef ULONG PCI_HANDLE;
+
+#define PCI_HANDLE_NONE 0UL
+```
+
+The first pass should expose native functions equivalent to these service groups:
+
+- `pci_init()` scans and caches devices.
+- `pci_find_device(UWORD vendor, UWORD device, UWORD index, PCI_HANDLE *handle)` finds by vendor/device. `vendor == 0xffff` iterates all discovered devices.
+- `pci_find_classcode(ULONG classcode, ULONG mask, UWORD index, PCI_HANDLE *handle)` finds by class code using explicit mask bits.
+- `pci_read_config_byte/word/long()` and `pci_write_config_byte/word/long()` access configuration space through a handle.
+- `pci_get_resource(PCI_HANDLE handle, UWORD bar, pci_resource_t *resource)` returns decoded BAR resources.
+- `pci_read_io_*`, `pci_write_io_*`, `pci_read_mem_*`, and `pci_write_mem_*` access resource-backed regions where implemented.
+- `pci_hook_interrupt()` and `pci_unhook_interrupt()` exist but may return `PCI_FUNC_NOT_SUPPORTED` until routing is implemented.
+- `pci_get_card_used()` and `pci_set_card_used()` expose ownership state.
+- `pci_bus_to_phys()` and `pci_phys_to_bus()` return identity mappings for the first backend unless a backend supplies translation.
+
+Exact function names can be adjusted to match project conventions during planning, but the groups above are required.
+
+## Error Codes
+
+Define documented PCI error/status values in the public header. They should include at least:
+
+- `PCI_OK` for success.
+- `PCI_DEVICE_NOT_FOUND` when lookup misses.
+- `PCI_BAD_HANDLE` for invalid handles.
+- `PCI_BAD_REGISTER` for invalid configuration-space offsets or sizes.
+- `PCI_BAD_RESOURCE` for absent or invalid BAR/resource requests.
+- `PCI_FUNC_NOT_SUPPORTED` for optional services the backend cannot provide.
+
+Use one signed return type consistently for PCI API functions. The plan should choose exact numeric values that are stable within pTOS and easy to test.
+
+## Device Metadata
+
+Each discovered device record should cache:
+
+- Bus, device, and function numbers.
+- Vendor ID and device ID.
+- Class code, subclass, and programming interface.
+- Header type and multifunction state.
+- Decoded BAR resources.
+- Interrupt pin and line if available.
+- Card-used state.
+
+Enumeration should skip absent functions where vendor ID reads as `0xffff`. It should scan function 0 first and scan functions 1-7 only when function 0 reports a multifunction header.
+
+The first implementation may scan bus 0 only if the backend does not yet expose bridge traversal. If bridge traversal is omitted, document that limitation in the code and design notes. QEMU ARM `virt` validation for the first backend can use devices on bus 0.
+
+## Resources And Access
+
+The generic core should decode PCI BARs by writing all ones, reading back the size mask, restoring the original BAR, and recording implemented resources. It must distinguish I/O BARs from memory BARs and record at least:
+
+- BAR number.
+- Resource type: memory or I/O.
+- Bus address.
+- CPU physical address if translated by the backend.
+- Size.
+- Flags such as prefetchable and 64-bit memory.
+
+The QEMU ARM `virt` backend should describe its PCI windows from QEMU's machine layout:
+
+- ECAM base `0x3f000000`, size `0x01000000`.
+- PCI MMIO window base `0x10000000`, size `0x2eff0000`.
+- PCI PIO window base `0x3eff0000`, size `0x00010000`.
+
+The backend should implement config-space access through ECAM. Resource translation should map QEMU's low MMIO and PIO windows according to the fixed virt memory map. High PCI windows are not required for the first implementation.
+
+## Interrupts
+
+The API must expose interrupt hook/unhook entry points because Atari PCI BIOS includes interrupt services and future PCI consumers need a stable contract. The QEMU ARM `virt` backend may initially return `PCI_FUNC_NOT_SUPPORTED` for interrupt hook/unhook if generic PCI IRQ routing is not wired yet.
+
+If basic INTx routing is implemented in the first pass, it must stay in the backend and use the existing `virt_pic` interrupt facilities. Shared PCI code should only see backend callbacks.
+
+## Initialization Flow
+
+BIOS startup should initialize PCI only when `CONF_WITH_PCI` is enabled. The initialization should be safe when no devices are present: it returns success with an empty device list or a documented nonfatal status.
+
+For QEMU ARM `virt`:
+
+1. The backend reports ECAM, MMIO, and PIO windows.
+2. The generic core scans bus/device/function config headers through backend config callbacks.
+3. The core decodes BARs and stores resource descriptors.
+4. Optional debug output reports discovered devices when existing debug logging is enabled.
+
+## Testing And Validation
+
+Build checks:
+
+- `make rpi2_defconfig && make` must continue to build without PCI enabled.
+- `make rpi4_defconfig && make` must continue to build without the generic PCI backend until issue #57 enables it for Pi 4.
+- `make virt-arm_defconfig && make` must build with PCI enabled.
+
+Runtime checks under QEMU ARM `virt`:
+
+- Boot the `virt-arm` image under QEMU with at least one PCI device attached.
+- Confirm PCI initialization logs at least one discovered device.
+- Confirm vendor/device lookup can find a known QEMU device.
+- Confirm vendor `0xffff` iteration returns discovered devices in stable order.
+- Confirm class-code lookup works with mask bits.
+- Confirm invalid handles and invalid config offsets return documented errors.
+- Confirm optional interrupt hook/unhook either work or return `PCI_FUNC_NOT_SUPPORTED`.
+
+Unit-style tests are not established for BIOS code in this tree, so validation should be build checks plus QEMU runtime smoke tests and small diagnostic logging or CLI hooks only if they fit existing project patterns.
+
+## Follow-Up Integration
+
+After #56 lands, issue #57 should add the BCM2711/Raspberry Pi 4 PCIe backend behind the same backend interface. Issue #37 should then replace the private `raspi_vl805_get_resources()` style helper with generic PCI lookup/resource calls for the VL805 xHCI controller.
+
+Issue #59 should audit any inherited PCI-related code and ensure drivers and shared subsystems use the generic PCI API instead of private enumeration, config-space, resource, interrupt, or ownership paths.
+
+## Risks
+
+- The Atari PCI BIOS spec includes ABI details that pTOS intentionally does not implement; the implementation must avoid leaking those binary-compatibility assumptions into native APIs.
+- ECAM and resource-window assumptions are QEMU ARM `virt` specific and must stay in the backend.
+- Interrupt routing may require additional platform work; returning `PCI_FUNC_NOT_SUPPORTED` is acceptable for the first backend if documented and tested.
+- BAR sizing changes device configuration registers temporarily; implementation must restore original BAR values before continuing.
+- `int` size differs between m68k and ARM, so public API types must use `portab.h` fixed-width types.

--- a/docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md
+++ b/docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md
@@ -69,7 +69,7 @@ The first pass should expose native functions equivalent to these service groups
 
 - `pci_init()` scans and caches devices.
 - `pci_find_device(UWORD vendor, UWORD device, UWORD index, PCI_HANDLE *handle)` finds by vendor/device. `vendor == 0xffff` iterates all discovered devices.
-- `pci_find_classcode(ULONG classcode, ULONG mask, UWORD index, PCI_HANDLE *handle)` finds by class code using explicit mask bits.
+- `pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle)` finds by class code using Atari-style mask bits embedded in the high byte of the `classcode` argument.
 - `pci_read_config_byte/word/long()` and `pci_write_config_byte/word/long()` access configuration space through a handle.
 - `pci_get_resource(PCI_HANDLE handle, UWORD bar, pci_resource_t *resource)` returns decoded BAR resources.
 - `pci_read_io_*`, `pci_write_io_*`, `pci_read_mem_*`, and `pci_write_mem_*` access resource-backed regions where implemented.
@@ -83,10 +83,10 @@ Exact function names can be adjusted to match project conventions during plannin
 
 Define documented PCI error/status values in the public header. They should include at least:
 
-- `PCI_OK` for success.
+- `PCI_SUCCESSFUL` for success.
 - `PCI_DEVICE_NOT_FOUND` when lookup misses.
 - `PCI_BAD_HANDLE` for invalid handles.
-- `PCI_BAD_REGISTER` for invalid configuration-space offsets or sizes.
+- `PCI_BAD_REGISTER_NUMBER` for invalid configuration-space offsets or sizes.
 - `PCI_BAD_RESOURCE` for absent or invalid BAR/resource requests.
 - `PCI_FUNC_NOT_SUPPORTED` for optional services the backend cannot provide.
 

--- a/docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md
+++ b/docs/superpowers/specs/2026-08-02-generic-pci-bios-design.md
@@ -69,7 +69,7 @@ The first pass should expose native functions equivalent to these service groups
 
 - `pci_init()` scans and caches devices.
 - `pci_find_device(UWORD vendor, UWORD device, UWORD index, PCI_HANDLE *handle)` finds by vendor/device. `vendor == 0xffff` iterates all discovered devices.
-- `pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle)` finds by class code using Atari-style mask bits embedded in the high byte of the `classcode` argument.
+- `pci_find_classcode(ULONG classcode, ULONG mask, UWORD index, PCI_HANDLE *handle)` finds by class code using a separate mask argument.
 - `pci_read_config_byte/word/long()` and `pci_write_config_byte/word/long()` access configuration space through a handle.
 - `pci_get_resource(PCI_HANDLE handle, UWORD bar, pci_resource_t *resource)` returns decoded BAR resources.
 - `pci_read_io_*`, `pci_write_io_*`, `pci_read_mem_*`, and `pci_write_mem_*` access resource-backed regions where implemented.
@@ -78,6 +78,8 @@ The first pass should expose native functions equivalent to these service groups
 - `pci_bus_to_phys()` and `pci_phys_to_bus()` return identity mappings for the first backend unless a backend supplies translation.
 
 Exact function names can be adjusted to match project conventions during planning, but the groups above are required.
+
+The original Atari PCI BIOS packs class-code ignore bits into the high byte of the class-code register argument. pTOS intentionally uses a separate `mask` parameter in the native C API so callers pass the 24-bit class code and the comparison mask independently. The pTOS mask constants preserve the Atari semantics: `PCI_CLASS_MASK_BASE` ignores base class, `PCI_CLASS_MASK_SUBCLASS` ignores subclass, and `PCI_CLASS_MASK_PROGIF` ignores programming interface.
 
 ## Error Codes
 

--- a/include/pci.h
+++ b/include/pci.h
@@ -1,0 +1,106 @@
+/*
+ * pci.h - native pTOS PCI access layer
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef PCI_H
+#define PCI_H
+
+#include "portab.h"
+
+typedef ULONG PCI_HANDLE;
+
+#define PCI_HANDLE_NONE              0UL
+
+#define PCI_SUCCESSFUL               0L
+#define PCI_FUNC_NOT_SUPPORTED      -2L
+#define PCI_BAD_VENDOR_ID           -3L
+#define PCI_DEVICE_NOT_FOUND        -4L
+#define PCI_BAD_REGISTER_NUMBER     -5L
+#define PCI_SET_FAILED              -6L
+#define PCI_BUFFER_TOO_SMALL        -7L
+#define PCI_GENERAL_ERROR           -8L
+#define PCI_BAD_HANDLE              -9L
+#define PCI_BAD_RESOURCE           -10L
+
+#define PCI_ANY_VENDOR          0xffffU
+
+#define PCI_CLASS_MASK_PROGIF   0x01000000UL
+#define PCI_CLASS_MASK_SUBCLASS 0x02000000UL
+#define PCI_CLASS_MASK_BASE     0x04000000UL
+#define PCI_CLASS_CODE_MASK     0x00ffffffUL
+
+#define PCI_RESOURCE_IO         0x4000U
+#define PCI_RESOURCE_LAST       0x8000U
+#define PCI_RESOURCE_8BIT       0x0100U
+#define PCI_RESOURCE_16BIT      0x0200U
+#define PCI_RESOURCE_32BIT      0x0400U
+#define PCI_RESOURCE_ORDER_MOTOROLA 0x0000U
+#define PCI_RESOURCE_ORDER_INTEL    0x000fU
+
+#define PCI_CONFIG_VENDOR_ID    0x00U
+#define PCI_CONFIG_DEVICE_ID    0x02U
+#define PCI_CONFIG_COMMAND      0x04U
+#define PCI_CONFIG_STATUS       0x06U
+#define PCI_CONFIG_PROGIF       0x09U
+#define PCI_CONFIG_SUBCLASS     0x0aU
+#define PCI_CONFIG_BASE_CLASS   0x0bU
+#define PCI_CONFIG_HEADER_TYPE  0x0eU
+#define PCI_CONFIG_BAR0         0x10U
+#define PCI_CONFIG_INTERRUPT_LINE 0x3cU
+#define PCI_CONFIG_INTERRUPT_PIN  0x3dU
+
+#define PCI_MAX_BARS            6
+
+typedef struct {
+    UWORD next;
+    UWORD flags;
+    ULONG start;
+    ULONG length;
+    ULONG offset;
+    ULONG dmaoffset;
+} pci_resource_t;
+
+typedef struct {
+    ULONG address;
+    ULONG length;
+} pci_mem_t;
+
+typedef void (*pci_interrupt_handler_t)(void *param);
+typedef LONG (*pci_card_callback_t)(LONG function);
+
+LONG pci_init(void);
+LONG pci_find_device(UWORD vendor, UWORD device, UWORD index, PCI_HANDLE *handle);
+LONG pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle);
+LONG pci_read_config_byte(PCI_HANDLE handle, UWORD reg, UBYTE *value);
+LONG pci_read_config_word(PCI_HANDLE handle, UWORD reg, UWORD *value);
+LONG pci_read_config_long(PCI_HANDLE handle, UWORD reg, ULONG *value);
+LONG pci_write_config_byte(PCI_HANDLE handle, UWORD reg, UBYTE value);
+LONG pci_write_config_word(PCI_HANDLE handle, UWORD reg, UWORD value);
+LONG pci_write_config_long(PCI_HANDLE handle, UWORD reg, ULONG value);
+LONG pci_get_resource(PCI_HANDLE handle, UWORD bar, pci_resource_t *resource);
+LONG pci_read_mem_byte(PCI_HANDLE handle, ULONG address, UBYTE *value);
+LONG pci_read_mem_word(PCI_HANDLE handle, ULONG address, UWORD *value);
+LONG pci_read_mem_long(PCI_HANDLE handle, ULONG address, ULONG *value);
+LONG pci_write_mem_byte(PCI_HANDLE handle, ULONG address, UBYTE value);
+LONG pci_write_mem_word(PCI_HANDLE handle, ULONG address, UWORD value);
+LONG pci_write_mem_long(PCI_HANDLE handle, ULONG address, ULONG value);
+LONG pci_read_io_byte(PCI_HANDLE handle, ULONG address, UBYTE *value);
+LONG pci_read_io_word(PCI_HANDLE handle, ULONG address, UWORD *value);
+LONG pci_read_io_long(PCI_HANDLE handle, ULONG address, ULONG *value);
+LONG pci_write_io_byte(PCI_HANDLE handle, ULONG address, UBYTE value);
+LONG pci_write_io_word(PCI_HANDLE handle, ULONG address, UWORD value);
+LONG pci_write_io_long(PCI_HANDLE handle, ULONG address, ULONG value);
+LONG pci_hook_interrupt(PCI_HANDLE handle, pci_interrupt_handler_t handler, void *param);
+LONG pci_unhook_interrupt(PCI_HANDLE handle);
+LONG pci_get_card_used(PCI_HANDLE handle, pci_card_callback_t *callback);
+LONG pci_set_card_used(PCI_HANDLE handle, pci_card_callback_t callback, LONG state);
+LONG pci_get_pagesize(ULONG *pagesize);
+LONG pci_virt_to_bus(PCI_HANDLE handle, ULONG address, pci_mem_t *mem);
+LONG pci_bus_to_virt(PCI_HANDLE handle, ULONG address, pci_mem_t *mem);
+LONG pci_virt_to_phys(ULONG address, pci_mem_t *mem);
+LONG pci_phys_to_virt(ULONG address, pci_mem_t *mem);
+
+#endif /* PCI_H */

--- a/include/pci.h
+++ b/include/pci.h
@@ -73,7 +73,7 @@ typedef LONG (*pci_card_callback_t)(LONG function);
 
 LONG pci_init(void);
 LONG pci_find_device(UWORD vendor, UWORD device, UWORD index, PCI_HANDLE *handle);
-LONG pci_find_classcode(ULONG classcode, UWORD index, PCI_HANDLE *handle);
+LONG pci_find_classcode(ULONG classcode, ULONG mask, UWORD index, PCI_HANDLE *handle);
 LONG pci_read_config_byte(PCI_HANDLE handle, UWORD reg, UBYTE *value);
 LONG pci_read_config_word(PCI_HANDLE handle, UWORD reg, UWORD *value);
 LONG pci_read_config_long(PCI_HANDLE handle, UWORD reg, ULONG *value);


### PR DESCRIPTION
Fixes #56

## Summary

- Adds a native pTOS PCI layer modeled on useful Atari PCI BIOS service semantics without implementing the Atari `_PCI` cookie, function-table ABI, or 680x0 register calling convention.
- Provides generic PCI enumeration, opaque positive 32-bit handles, vendor/device lookup, class-code lookup with mask bits, config-space read/write helpers, BAR resource descriptors, memory/I/O access helpers, card-used state, unsupported interrupt hooks, and identity-style address translation helpers.
- Adds QEMU ARM `virt` as the first PCI backend using the generic ECAM host bridge with low ECAM/MMIO/PIO windows.

## Validation

- `make virt-arm_defconfig && make`
- `make rpi2_defconfig && make`
- `make rpi4_defconfig && make`
- `git diff --check`
- QEMU smoke: `qemu-system-arm -M virt,highmem=off -cpu cortex-a7 -m 128 -kernel virt-arm.elf -d guest_errors -display none -serial stdio -device virtio-net-pci`
- QEMU result: boot logged `pci: 3 device(s) found` and no PCI self-check failures before timeout terminated the VM.

## Notes

- `make gitready` could not run fully in this environment because `dos2unix` is not installed; `git diff --check` passed as the whitespace fallback.
- Raspberry Pi 4 PCIe backend work remains in #57.
- Raspberry Pi 4/400 xHCI/VL805 USB support in #37 should build on this PCI layer after #57.
- Inherited PCI consumer audit/refactor remains in #59.