### PR TITLE
Fix gitready safety

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ indent_size = 4
 
 [Makefile]
 indent_style = tab
+
+[*.mk]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ include tools/kconfig.mk
 # Goals that must work without a configuration, either because they are
 # what produces one, or because they do not compile anything.
 UNCONFIGURED_GOALS = $(CONFIG_TARGETS) help version clean distclean \
-                     expand crlf charset gitready indent checkindent \
+                     charset gitready indent checkindent \
                      bugready coldfire-sources
 
 ifeq (,$(filter $(UNCONFIGURED_GOALS),$(MAKECMDGOALS))$(filter release%,$(MAKECMDGOALS)))
@@ -919,21 +919,6 @@ indent:
 # gitready
 #
 
-EXPAND_FILES = $(wildcard */*.[chS] */*/*.[chS] */*/*/*.[chS] */*.awk */*.sh)
-EXPAND_NOFILES = vdi/arch/coldfire/vdi_tblit.S
-
-.PHONY: expand
-expand:
-	@for i in `grep -l '	' $(filter-out $(EXPAND_NOFILES), $(EXPAND_FILES))` ; do \
-		echo expanding $$i; \
-		expand <$$i >expand.tmp; \
-		mv expand.tmp $$i; \
-	done
-
-.PHONY: crlf
-crlf:
-	find . -type f '!' -path './.git/*' '!' -name '*.rsc' '!' -name '*.def' | xargs dos2unix
-
 # Check the sources charset (no automatic fix)
 .PHONY: charset
 charset:
@@ -941,7 +926,8 @@ charset:
 	find . -type f '!' -path '*/.git/*' '!' -path './obj/*' '!' -path './*.img' '!' -path './?rd*' '!' -path './draft*' '!' -path './bug*' '!' -path './mkrom*' '!' -name '*.def' '!' -name '*.rsc' '!' -name '*.icn' '!' -name '*.po' -print0 | xargs -0 file -i |grep -v us-ascii
 
 .PHONY: gitready
-gitready: expand crlf
+gitready:
+	tools/check-gitready.sh
 
 #
 # ColdFire autoconverted sources.

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -218,9 +218,7 @@ Git-related targets
 clean       remove the generated files, keeping .config
 distclean   remove everything, including .config
 charset     check the charset of all the source files
-crlf        convert all end-of-lines to LF
-expand      expand tabs to spaces
-gitready    ensure the files have a proper format for Git (crlf + expand)
+gitready    check changed files for Git formatting problems
 checkindent try 'indent' without altering the files
 indent      indent all files - never done yet :-(
 

--- a/tools/check-gitready.sh
+++ b/tools/check-gitready.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -eu
+
+status=0
+
+check_diff()
+{
+    label=$1
+    shift
+
+    if ! git diff "$@" --check -- .; then
+        status=1
+    fi
+
+    if ! git diff "$@" --unified=0 --no-ext-diff -- '*.c' '*.h' '*.S' '*.awk' '*.sh' | \
+        awk -v label="$label" '
+            /^\+\+\+ b\// { file = substr($0, 7); next }
+            /^\+\+\+ / { file = $0; next }
+            /^\+[^+]/ {
+                line = substr($0, 2)
+                if (index(line, "\t")) {
+                    printf "%s: %s: added line contains a tab\n", label, file
+                    failed = 1
+                }
+                if (line ~ /\r$/) {
+                    printf "%s: %s: added line contains CRLF\n", label, file
+                    failed = 1
+                }
+            }
+            END { exit failed ? 1 : 0 }
+        '
+    then
+        status=1
+    fi
+}
+
+check_diff staged --cached
+check_diff unstaged
+
+if [ $status -eq 0 ]; then
+    echo 'gitready checks passed.'
+fi
+
+exit $status

--- a/tools/check-gitready.sh
+++ b/tools/check-gitready.sh
@@ -47,6 +47,10 @@ check_crlf_files()
     files=$(check_worktree_crlf | sort -u)
 
     for file in $files; do
+        if [ -f "$file" ] && awk '/\t/ { found = 1 } END { exit found ? 0 : 1 }' "$file"; then
+            printf '%s: contains tab\n' "$file"
+            status=1
+        fi
         if [ -f "$file" ] && awk '/\r$/ { found = 1 } END { exit found ? 0 : 1 }' "$file"; then
             printf '%s: contains CRLF\n' "$file"
             status=1

--- a/tools/check-gitready.sh
+++ b/tools/check-gitready.sh
@@ -54,9 +54,21 @@ check_crlf_files()
     done
 }
 
+check_tracked_crlf()
+{
+    files=$(git ls-files --eol -- '*.c' '*.h' '*.S' '*.awk' '*.sh' | \
+        awk -F '\t' '$1 ~ /w\/crlf/ { print $2 }')
+
+    for file in $files; do
+        printf '%s: contains CRLF\n' "$file"
+        status=1
+    done
+}
+
 check_diff staged --cached
 check_diff unstaged
 check_crlf_files
+check_tracked_crlf
 
 if [ $status -eq 0 ]; then
     echo 'gitready checks passed.'

--- a/tools/check-gitready.sh
+++ b/tools/check-gitready.sh
@@ -35,8 +35,28 @@ check_diff()
     fi
 }
 
+check_worktree_crlf()
+{
+    git diff --name-only --diff-filter=ACMRT -- '*.c' '*.h' '*.S' '*.awk' '*.sh'
+    git diff --cached --name-only --diff-filter=ACMRT -- '*.c' '*.h' '*.S' '*.awk' '*.sh'
+    git ls-files --others --exclude-standard -- '*.c' '*.h' '*.S' '*.awk' '*.sh'
+}
+
+check_crlf_files()
+{
+    files=$(check_worktree_crlf | sort -u)
+
+    for file in $files; do
+        if [ -f "$file" ] && awk '/\r$/ { found = 1 } END { exit found ? 0 : 1 }' "$file"; then
+            printf '%s: contains CRLF\n' "$file"
+            status=1
+        fi
+    done
+}
+
 check_diff staged --cached
 check_diff unstaged
+check_crlf_files
 
 if [ $status -eq 0 ]; then
     echo 'gitready checks passed.'

--- a/tools/test-gitready-safety.sh
+++ b/tools/test-gitready-safety.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+tmpdir=${TMPDIR:-/tmp}/ptos-gitready-test.$$
+
+cleanup()
+{
+    rm -rf "$tmpdir"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$tmpdir/src" "$tmpdir/tools" "$tmpdir/po"
+cp "$repo_root/Makefile" "$tmpdir/Makefile"
+cp "$repo_root/version.mk" "$tmpdir/version.mk"
+cp "$repo_root/country.mk" "$tmpdir/country.mk"
+cp "$repo_root/release.mk" "$tmpdir/release.mk"
+cp "$repo_root/tools/kconfig.mk" "$tmpdir/tools/kconfig.mk"
+cp "$repo_root/po/POTFILES.in" "$tmpdir/po/POTFILES.in"
+for dir in aes bdos bios cli desk usb util vdi; do
+    mkdir -p "$tmpdir/$dir"
+    cp "$repo_root/$dir/build.mk" "$tmpdir/$dir/build.mk"
+done
+if [ -f "$repo_root/tools/check-gitready.sh" ]; then
+    cp "$repo_root/tools/check-gitready.sh" "$tmpdir/tools/check-gitready.sh"
+    chmod +x "$tmpdir/tools/check-gitready.sh"
+fi
+
+cd "$tmpdir"
+git init -q
+git config user.email test@example.invalid
+git config user.name 'gitready test'
+
+printf 'int\tuntouched;\n' >src/untouched.c
+cp src/untouched.c src/untouched.c.orig
+git add src/untouched.c
+git commit -q -m baseline
+
+printf 'int changed;\n' >src/changed.c
+git add src/changed.c
+
+if ! make -s gitready >gitready-clean.log 2>&1; then
+    cat gitready-clean.log
+    echo 'gitready failed for a clean staged change'
+    exit 1
+fi
+
+if ! cmp -s src/untouched.c src/untouched.c.orig; then
+    echo 'gitready modified an unrelated tracked file'
+    exit 1
+fi
+
+git reset -q -- src/changed.c
+rm -f src/changed.c
+printf 'int\tbad;\r\n' >src/changed.c
+git add src/changed.c
+
+if make -s gitready >gitready-bad.log 2>&1; then
+    echo 'gitready accepted a staged tab/CRLF change'
+    exit 1
+fi
+
+if ! cmp -s src/untouched.c src/untouched.c.orig; then
+    echo 'gitready modified an unrelated tracked file while rejecting bad input'
+    exit 1
+fi
+
+echo 'gitready safety test passed'

--- a/tools/test-gitready-safety.sh
+++ b/tools/test-gitready-safety.sh
@@ -19,6 +19,9 @@ cp "$repo_root/country.mk" "$tmpdir/country.mk"
 cp "$repo_root/release.mk" "$tmpdir/release.mk"
 cp "$repo_root/tools/kconfig.mk" "$tmpdir/tools/kconfig.mk"
 cp "$repo_root/po/POTFILES.in" "$tmpdir/po/POTFILES.in"
+if [ -f "$repo_root/.gitattributes" ]; then
+    cp "$repo_root/.gitattributes" "$tmpdir/.gitattributes"
+fi
 for dir in aes bdos bios cli desk usb util vdi; do
     mkdir -p "$tmpdir/$dir"
     cp "$repo_root/$dir/build.mk" "$tmpdir/$dir/build.mk"
@@ -55,7 +58,7 @@ fi
 git reset -q -- src/changed.c
 rm -f src/changed.c
 printf 'int\tbad;\r\n' >src/changed.c
-git add src/changed.c
+git add src/changed.c 2>/dev/null
 
 if make -s gitready >gitready-tab.log 2>&1; then
     echo 'gitready accepted a staged tab/CRLF change'
@@ -70,7 +73,7 @@ fi
 git reset -q -- src/changed.c
 rm -f src/changed.c
 printf 'int crlf_only;\r\n' >src/changed.c
-git add src/changed.c
+git add src/changed.c 2>/dev/null
 
 if make -s gitready >gitready-crlf.log 2>&1; then
     echo 'gitready accepted a staged CRLF-only change'
@@ -79,6 +82,23 @@ fi
 
 if ! cmp -s src/untouched.c src/untouched.c.orig; then
     echo 'gitready modified an unrelated tracked file while rejecting CRLF input'
+    exit 1
+fi
+
+git reset -q -- src/changed.c
+rm -f src/changed.c
+printf 'int tracked_crlf;\n' >src/tracked_crlf.c
+git add src/tracked_crlf.c
+git commit -q -m tracked-crlf-baseline
+printf 'int tracked_crlf;\r\n' >src/tracked_crlf.c
+
+if make -s gitready >gitready-tracked-crlf.log 2>&1; then
+    echo 'gitready accepted a tracked CRLF-only rewrite'
+    exit 1
+fi
+
+if ! cmp -s src/untouched.c src/untouched.c.orig; then
+    echo 'gitready modified an unrelated tracked file while rejecting tracked CRLF input'
     exit 1
 fi
 

--- a/tools/test-gitready-safety.sh
+++ b/tools/test-gitready-safety.sh
@@ -57,13 +57,28 @@ rm -f src/changed.c
 printf 'int\tbad;\r\n' >src/changed.c
 git add src/changed.c
 
-if make -s gitready >gitready-bad.log 2>&1; then
+if make -s gitready >gitready-tab.log 2>&1; then
     echo 'gitready accepted a staged tab/CRLF change'
     exit 1
 fi
 
 if ! cmp -s src/untouched.c src/untouched.c.orig; then
     echo 'gitready modified an unrelated tracked file while rejecting bad input'
+    exit 1
+fi
+
+git reset -q -- src/changed.c
+rm -f src/changed.c
+printf 'int crlf_only;\r\n' >src/changed.c
+git add src/changed.c
+
+if make -s gitready >gitready-crlf.log 2>&1; then
+    echo 'gitready accepted a staged CRLF-only change'
+    exit 1
+fi
+
+if ! cmp -s src/untouched.c src/untouched.c.orig; then
+    echo 'gitready modified an unrelated tracked file while rejecting CRLF input'
     exit 1
 fi
 

--- a/tools/test-gitready-safety.sh
+++ b/tools/test-gitready-safety.sh
@@ -102,4 +102,17 @@ if ! cmp -s src/untouched.c src/untouched.c.orig; then
     exit 1
 fi
 
+git checkout -q -- src/tracked_crlf.c
+printf 'int\tuntracked_tab;\n' >src/untracked_tab.c
+
+if make -s gitready >gitready-untracked-tab.log 2>&1; then
+    echo 'gitready accepted an untracked tabbed source file'
+    exit 1
+fi
+
+if ! cmp -s src/untouched.c src/untouched.c.orig; then
+    echo 'gitready modified an unrelated tracked file while rejecting untracked tab input'
+    exit 1
+fi
+
 echo 'gitready safety test passed'


### PR DESCRIPTION
Fixes #64

## Summary
- Replace the mutating `gitready: expand crlf` workflow with a non-mutating scoped checker.
- Add `.gitattributes` and `.editorconfig` so LF normalization and space indentation are handled preventively.
- Add regression coverage for missing `dos2unix`, unrelated-file mutation, staged tab/CRLF changes, and tracked CRLF-only rewrites.
- Update install docs to remove obsolete `expand` / `crlf` target descriptions.

## Validation
- `tools/test-gitready-safety.sh`
- `make gitready`
- `make help`
- `git diff --check`

## Notes
- The old `expand` and `crlf` Makefile targets are removed instead of repaired because their tree-wide mutation model was the root problem.
- `gitready` now checks staged, unstaged, and untracked source/script changes without modifying files.