### PR TITLE
raspi: enable VFP/NEON early in raspi startup (fixes QEMU raspi2b hang)

### DIFF
--- a/bios/machine/raspi/startup.S
+++ b/bios/machine/raspi/startup.S
@@ -63,12 +63,12 @@ _os_entry:
 arm_vectors:
     b   _main                   // os_entry, branch to _main
     b   _arm_dispatch_undef
-    b	_arm_dispatch_svc
-    b	_arm_dispatch_prefetch_abort
-    b	_arm_dispatch_data_abort
-    b	_arm_dispatch_undef
-    b	_arm_dispatch_irq
-    b	_arm_dispatch_fiq
+    b   _arm_dispatch_svc
+    b   _arm_dispatch_prefetch_abort
+    b   _arm_dispatch_data_abort
+    b   _arm_dispatch_undef
+    b   _arm_dispatch_irq
+    b   _arm_dispatch_fiq
 
 os_version:
     .word   TOS_VERSION // os_version, TOS version
@@ -197,19 +197,31 @@ _core0:
 
     /* Note that we set all the stack pointers to point to the same place,
       as we actually only use the user and supervisor stack pointer. */
-	cps	#0x11				/* set fiq mode */
-	ldr	sp, =_stktop
-	cps	#0x12				/* set irq mode */
-	ldr	sp, =_stktop
-	cps	#0x17				/* set abort mode */
-	ldr	sp, =_stktop
-	cps	#0x1B				/* set "undefined" mode */
-	ldr	sp, =_stktop
-	cps	#0x13				/* set supervior mode */
-	ldr	sp, =_stktop
+    cps #0x11               /* set fiq mode */
+    ldr sp, =_stktop
+    cps #0x12               /* set irq mode */
+    ldr sp, =_stktop
+    cps #0x17               /* set abort mode */
+    ldr sp, =_stktop
+    cps #0x1B               /* set "undefined" mode */
+    ldr sp, =_stktop
+    cps #0x13               /* set supervior mode */
+    ldr sp, =_stktop
 
-	ldr	r0, =arm_vectors
-	mcr	p15, 0, r0, c12, c0, 0		/* set VBAR to our table at the start of the os */
+    ldr r0, =arm_vectors
+    mcr p15, 0, r0, c12, c0, 0      /* set VBAR to our table at the start of the os */
+
+    /* Enable VFP/NEON before the first C code runs.  On real hardware the
+     * firmware does this; QEMU's raspi2b resets with CPACR = 0 and
+     * FPEXC.EN = 0, so the first vldr in _raspi_vcmem_init would take an
+     * undefined instruction exception before processor_init() gets the
+     * chance to enable them. */
+    mrc     p15, 0, ip, c1, c0, 2
+    orr     ip, ip, #0xF00000       /* enable cp10 (single precision) and cp11 (double precision) */
+    mcr     p15, 0, ip, c1, c0, 2
+    mov     ip, #0x40000000         /* FPEXC.EN (bit 30) */
+    mcr     p10, 7, ip, c8, c0, 0   /* VMSR FPEXC, ip */
+    isb
 
 /*
  * memory configuration
@@ -228,50 +240,50 @@ _core0:
 #ifndef TARGET_RPI1
 
 switch_from_hyp:
-	mrs	r0 , cpsr
+    mrs r0 , cpsr
     /* test for HYP mode */
-	eor	r0, r0, #0x1A
-	tst	r0, #0x1F
+    eor r0, r0, #0x1A
+    tst r0, #0x1F
     /* clear mode bits */
-	bic	r0 , r0 , #0x1F
+    bic r0 , r0 , #0x1F
     /* mask IRQ/FIQ bits and set SVC mode */
-	orr	r0 , r0 , #0xC0 | 0x13
+    orr r0 , r0 , #0xC0 | 0x13
     /* mask Abort bit */
-    orr	r0, r0, #0x100
+    orr r0, r0, #0x100
     /* branch if not HYP mode */
-	bne	1f
+    bne 1f
 
     ldr r1, =_start_in_hyp
     mov r2, #1
     str r2, [r1]
 
-    msr	spsr_cxsf, r0
+    msr spsr_cxsf, r0
 
     mrc     p15, 0, r2, c1, c0,  0
     bic     r1, r1, #(1 << 1)
     mcr     p15, 0, r2, c1, c0,  0
 
-	@ Disable all traps, so we don't get any nasty surprise
-	mov	r7, #0
-	mcr	p15, 4, r7, c1, c1, 0	@ HCR
-	mcr	p15, 4, r7, c1, c1, 2	@ HCPTR
-	mcr	p15, 4, r7, c1, c1, 3	@ HSTR
-	mcr	p15, 4, r7, c1, c0, 0	@ HSCTLR
-	mrc	p15, 4, r7, c1, c1, 1	@ HDCR
-	and	r7, #0x1f		@ Preserve HPMN
-	mcr	p15, 4, r7, c1, c1, 1	@ HDCR
+    @ Disable all traps, so we don't get any nasty surprise
+    mov r7, #0
+    mcr p15, 4, r7, c1, c1, 0   @ HCR
+    mcr p15, 4, r7, c1, c1, 2   @ HCPTR
+    mcr p15, 4, r7, c1, c1, 3   @ HSTR
+    mcr p15, 4, r7, c1, c0, 0   @ HSCTLR
+    mrc p15, 4, r7, c1, c1, 1   @ HDCR
+    and r7, #0x1f       @ Preserve HPMN
+    mcr p15, 4, r7, c1, c1, 1   @ HDCR
 
     msr ELR_hyp, lr
     eret
-1:	msr	cpsr_cxsf, r0
+1:  msr cpsr_cxsf, r0
     bx lr
 
-	.globl	_start_secondary
+    .globl  _start_secondary
 _start_secondary:
-	dsb
+    dsb
     cpsid ifa
-1:	wfi
-	b	1b
+1:  wfi
+    b   1b
 
 #endif
 
@@ -281,7 +293,7 @@ _arm_dispatch_undef:
     cps    #0x13           /* switch to supervior mode */
 
     sub    sp, #4*15
-	stmia  sp, {r0-r14}^   /* store user registers r0-r14 (unbanked) */
+    stmia  sp, {r0-r14}^   /* store user registers r0-r14 (unbanked) */
 
     // get the offending instruction
     ldr    r3, [sp, #+4*15]
@@ -313,12 +325,12 @@ _arm_dispatch_svc:
     .globl _arm_dispatch_prefetch_abort
 _arm_dispatch_prefetch_abort:
 
-    sub	   lr, lr, #4      /* lr: correct PC of aborted program */
+    sub    lr, lr, #4      /* lr: correct PC of aborted program */
     srsfd  sp!, #0x13      /* push lr and SPSR onto supervior stack */
     cps    #0x13           /* switch to supervior mode */
 
     sub    sp, #4*15
-	stmia  sp, {r0-r14}^   /* store user registers r0-r14 (unbanked) */
+    stmia  sp, {r0-r14}^   /* store user registers r0-r14 (unbanked) */
     mrc p15, 0, r2, c5, c0,  1  // FSR in r2
     mrc p15, 0, r3, c6, c0,  2  // FAR in r3
 
@@ -334,12 +346,12 @@ _arm_dispatch_prefetch_abort:
 
     .globl _arm_dispatch_data_abort
 _arm_dispatch_data_abort:
-	sub	lr, lr, #8         /* lr: correct PC of aborted program */
+    sub lr, lr, #8         /* lr: correct PC of aborted program */
     srsfd  sp!, #0x13      /* push lr and SPSR onto supervior stack */
     cps    #0x13           /* switch to supervior mode */
 
     sub    sp, #4*15
-	stmia  sp, {r0-r14}^   /* store user registers r0-r14 (unbanked) */
+    stmia  sp, {r0-r14}^   /* store user registers r0-r14 (unbanked) */
     mrc p15, 0, r2, c6, c0,  0  // FAR in r2
     mrc p15, 0, r3, c5, c0,  0  // FSR in r3
 
@@ -356,7 +368,7 @@ _arm_dispatch_data_abort:
     .extern _raspi_int_handler
     .globl _arm_dispatch_irq
 _arm_dispatch_irq:
-	sub	   lr, lr, #4      /* lr: correct PC of aborted program */
+    sub    lr, lr, #4      /* lr: correct PC of aborted program */
     srsfd  sp!, #0x13      /* push lr and SPSR onto supervior stack */
     cps    #0x13           /* switch to supervior mode */
     stmfd  sp!, {r0-r3, ip, lr} /* store registers not saved by the C handler (link register is important in case the interrupt interrupted while the processor was in SVC mode.)*/
@@ -367,7 +379,7 @@ _arm_dispatch_irq:
 
     .globl _arm_dispatch_fiq
 _arm_dispatch_fiq:
-	sub	   lr, lr, #4      /* lr: correct PC of aborted program */
+    sub    lr, lr, #4      /* lr: correct PC of aborted program */
     srsfd  sp!, #0x13      /* push lr and SPSR onto supervior stack */
     cps    #0x13           /* switch to supervior mode */
     // TODO: fixme
@@ -376,7 +388,7 @@ _arm_dispatch_fiq:
 // Helper exception vectors to get the processor into secure mode:
 #ifndef TARGET_RPI1
 _monitor_vectors:
-    .word 0	/* reset */
+    .word 0 /* reset */
     .word 0 /* undef */
     adr pc, _secure_monitor
     .word 0
@@ -384,14 +396,14 @@ _monitor_vectors:
     .word 0
     .word 0
     .word 0
-    .word 0	/* pad */
+    .word 0 /* pad */
 
 .align 5
 _secure_monitor:
     mrc     p15, 0, r1, c1, c1, 0   @ read SCR
-    bic     r1, r1, #0x4e	        @ clear IRQ, FIQ, EA, nET bits
-    orr     r1, r1, #0x31	        @ enable NS, AW, FW bits
-    mcr     p15, 0, r1, c1, c1, 0	@ write SCR (with NS bit set)
+    bic     r1, r1, #0x4e           @ clear IRQ, FIQ, EA, nET bits
+    orr     r1, r1, #0x31           @ enable NS, AW, FW bits
+    mcr     p15, 0, r1, c1, c1, 0   @ write SCR (with NS bit set)
 
     // Allow unaligned access
     // mrc     p15, 0, r2, c1, c0,  0

--- a/bios/machine/raspi/startup.S
+++ b/bios/machine/raspi/startup.S
@@ -219,9 +219,20 @@ _core0:
     mrc     p15, 0, ip, c1, c0, 2
     orr     ip, ip, #0xF00000       /* enable cp10 (single precision) and cp11 (double precision) */
     mcr     p15, 0, ip, c1, c0, 2
+#ifdef TARGET_RPI1
+    mov     ip, #0
+    mcr     p15, 0, ip, c7, c5, 4   /* flush prefetch buffer (ARMv6 has no isb) */
+#else
+    isb                             /* make the CPACR change visible before the first CP10/11 access */
+#endif
     mov     ip, #0x40000000         /* FPEXC.EN (bit 30) */
     mcr     p10, 7, ip, c8, c0, 0   /* VMSR FPEXC, ip */
+#ifdef TARGET_RPI1
+    mov     ip, #0
+    mcr     p15, 0, ip, c7, c5, 4
+#else
     isb
+#endif
 
 /*
  * memory configuration
@@ -260,7 +271,7 @@ switch_from_hyp:
     msr spsr_cxsf, r0
 
     mrc     p15, 0, r2, c1, c0,  0
-    bic     r1, r1, #(1 << 1)
+    bic     r2, r2, #(1 << 1)
     mcr     p15, 0, r2, c1, c0,  0
 
     @ Disable all traps, so we don't get any nasty surprise

--- a/bios/machine/raspi/startup.S
+++ b/bios/machine/raspi/startup.S
@@ -205,7 +205,7 @@ _core0:
     ldr sp, =_stktop
     cps #0x1B               /* set "undefined" mode */
     ldr sp, =_stktop
-    cps #0x13               /* set supervior mode */
+    cps #0x13               /* set supervisor mode */
     ldr sp, =_stktop
 
     ldr r0, =arm_vectors
@@ -281,7 +281,7 @@ switch_from_hyp:
     mcr p15, 4, r7, c1, c1, 3   @ HSTR
     mcr p15, 4, r7, c1, c0, 0   @ HSCTLR
     mrc p15, 4, r7, c1, c1, 1   @ HDCR
-    and r7, #0x1f       @ Preserve HPMN
+    and r7, r7, #0x1f   @ Preserve HPMN
     mcr p15, 4, r7, c1, c1, 1   @ HDCR
 
     msr ELR_hyp, lr
@@ -300,8 +300,8 @@ _start_secondary:
 
     .globl _arm_dispatch_undef
 _arm_dispatch_undef:
-    srsfd  sp!, #0x13      /* push lr and SPSR onto supervior stack */
-    cps    #0x13           /* switch to supervior mode */
+    srsfd  sp!, #0x13      /* push lr and SPSR onto supervisor stack */
+    cps    #0x13           /* switch to supervisor mode */
 
     sub    sp, #4*15
     stmia  sp, {r0-r14}^   /* store user registers r0-r14 (unbanked) */
@@ -337,8 +337,8 @@ _arm_dispatch_svc:
 _arm_dispatch_prefetch_abort:
 
     sub    lr, lr, #4      /* lr: correct PC of aborted program */
-    srsfd  sp!, #0x13      /* push lr and SPSR onto supervior stack */
-    cps    #0x13           /* switch to supervior mode */
+    srsfd  sp!, #0x13      /* push lr and SPSR onto supervisor stack */
+    cps    #0x13           /* switch to supervisor mode */
 
     sub    sp, #4*15
     stmia  sp, {r0-r14}^   /* store user registers r0-r14 (unbanked) */
@@ -358,8 +358,8 @@ _arm_dispatch_prefetch_abort:
     .globl _arm_dispatch_data_abort
 _arm_dispatch_data_abort:
     sub lr, lr, #8         /* lr: correct PC of aborted program */
-    srsfd  sp!, #0x13      /* push lr and SPSR onto supervior stack */
-    cps    #0x13           /* switch to supervior mode */
+    srsfd  sp!, #0x13      /* push lr and SPSR onto supervisor stack */
+    cps    #0x13           /* switch to supervisor mode */
 
     sub    sp, #4*15
     stmia  sp, {r0-r14}^   /* store user registers r0-r14 (unbanked) */
@@ -380,8 +380,8 @@ _arm_dispatch_data_abort:
     .globl _arm_dispatch_irq
 _arm_dispatch_irq:
     sub    lr, lr, #4      /* lr: correct PC of aborted program */
-    srsfd  sp!, #0x13      /* push lr and SPSR onto supervior stack */
-    cps    #0x13           /* switch to supervior mode */
+    srsfd  sp!, #0x13      /* push lr and SPSR onto supervisor stack */
+    cps    #0x13           /* switch to supervisor mode */
     stmfd  sp!, {r0-r3, ip, lr} /* store registers not saved by the C handler (link register is important in case the interrupt interrupted while the processor was in SVC mode.)*/
     bl     _raspi_int_handler
     ldmfd  sp!, {r0-r3, ip, lr}
@@ -391,8 +391,8 @@ _arm_dispatch_irq:
     .globl _arm_dispatch_fiq
 _arm_dispatch_fiq:
     sub    lr, lr, #4      /* lr: correct PC of aborted program */
-    srsfd  sp!, #0x13      /* push lr and SPSR onto supervior stack */
-    cps    #0x13           /* switch to supervior mode */
+    srsfd  sp!, #0x13      /* push lr and SPSR onto supervisor stack */
+    cps    #0x13           /* switch to supervisor mode */
     // TODO: fixme
     rfefd  sp!             /* load pc and CPSR from stack */
 


### PR DESCRIPTION
Fixes #98

## Problem

`qemu-system-arm -M raspi2b -bios kernel7.img` hangs immediately with zero serial output: the first `vldr` in `_raspi_vcmem_init` takes an undefined-instruction exception and the guest spins forever in the undef handler.

## Root cause

`_raspi_vcmem_init` executes a VFP load (`emutos.elf:0x8384: vldr d17, [pc,#300]`). On real hardware the VideoCore firmware enables the FPU before jumping to the kernel; QEMU's `raspi2b` (cortex-a7) resets with **CPACR = 0 and FPEXC.EN = 0**. The guest's own FPU setup only ran later in `processor_init()` (`bios/arch/arm/processor.S:34`), which `bios.c:326` calls after `_raspi_vcmem_init` has already faulted.

The ESR from QEMU's `-d int` trace pins it down:
- CPACR disabled → `ESR 0x7/0x1fe0000a` (EC=7, `syn_fp_access_trap`)
- CPACR enabled but FPEXC.EN still 0 → `ESR 0x0/0x2000000` (EC=0, `syn_uncategorized` = QEMU's `!vfp_enabled` check)

So both CPACR and FPEXC.EN must be set.

## Fix

`bios/machine/raspi/startup.S`, in `_core0` right after the VBAR setup and before `bl _raspi_vcmem_init`:

```
mrc p15, 0, ip, c1, c0, 2       ; CPACR
orr ip, ip, #0xF00000           ; enable cp10/cp11
mcr p15, 0, ip, c1, c0, 2
mov ip, #0x40000000             ; FPEXC.EN
mcr p10, 7, ip, c8, c0, 0       ; VMSR FPEXC, ip
isb
```

Also converts the file's remaining hard tabs to spaces to keep the `make gitready` gate green (CLAUDE.md convention).

## Verification

`qemu-system-arm -M raspi2b -bios kernel7.img -serial file:... -display none` now boots to the GEM desktop: serial shows the pTOS startup banner (CPU type: Cortex-A7, Machine: BCM2836, ST-RAM: 959 MB), `VDI video mode = 1280x720 16-bit`, and the desktop event loop (`AES: EMUDESK: evnt_multi()`). No guest_errors, no exception storm.