### PR TITLE
skill: document the rpi1 QEMU smoke-test invocation (-M raspi1ap)

### DIFF
--- a/.claude/skills/ptos-smoketest/SKILL.md
+++ b/.claude/skills/ptos-smoketest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ptos-smoketest
-description: Use when smoke-testing or verifying that a built pTOS (Portable EmuTOS) image boots under an emulator. Covers Hatari for m68k Atari targets (atari512/STE/Falcon/TT configs) and QEMU for the raspi2 (QEMU machine `raspi2b`), virt-arm and virt-m68k machines. Use when asked to boot a pTOS build, check it reaches the GEM desktop, diagnose a slow/hung boot, or when you need emulator invocations, --run-vbls/--avirecord/--trace flags, the Hatari debugger gotchas (spurious breakpoints, echo crash), or the Falcon IDE 31s boot wait.
+description: Use when smoke-testing or verifying that a built pTOS (Portable EmuTOS) image boots under an emulator. Covers Hatari for m68k Atari targets (atari512/STE/Falcon/TT configs) and QEMU for the raspi1 (QEMU machine `raspi1ap`), raspi2 (QEMU machine `raspi2b`), virt-arm and virt-m68k machines. Use when asked to boot a pTOS build, check it reaches the GEM desktop, diagnose a slow/hung boot, or when you need emulator invocations, --run-vbls/--avirecord/--trace flags, the Hatari debugger gotchas (spurious breakpoints, echo crash), or the Falcon IDE 31s boot wait.
 ---
 
 # pTOS Smoke Testing
@@ -18,6 +18,7 @@ the pTOS tree). Relevant outputs:
 | Config | Emulator | Image | Machine |
 |---|---|---|---|
 | `atari512_defconfig` | hatari | `ptos512k.img` (+ `.sym` `.map`) | `--machine ste`, `--machine falcon`, `--machine tt` |
+| `rpi1_defconfig` | qemu-system-arm | `kernel.img` | `-M raspi1ap` (video + serial) |
 | `rpi2_defconfig` | qemu-system-arm | `kernel7.img` | `-M raspi2b` (video + serial) |
 | `virt-arm_defconfig` | qemu-system-arm | `virt-arm.elf` | `-M virt,highmem=off -cpu cortex-a7` (headless) |
 | `virt-m68k_defconfig` | qemu-system-m68k | `virt-m68k.elf` | `-M virt -cpu m68020` (headless) |
@@ -106,13 +107,19 @@ time; e.g. the 31 s IDE wait polls `_hz_200` at `0x4ba`, `addq.l #1,$4ba` at
 - No `info breakpoints` command; list breakpoints with bare `b`.
 - Trust only: `--run-vbls` + `--trace ...` output and AVI frames.
 
-## QEMU smoke test (raspi2 / virt-arm / virt-m68k)
+## QEMU smoke test (raspi1 / raspi2 / virt-arm / virt-m68k)
 
 The pTOS `readme.md` is the user-facing source; this skill is the agent-facing
 copy. Invocations (verified in-tree):
 
 ```sh
-# raspi2 — only target with real video output; reads KDEBUG on the serial console.
+# raspi1 — only the A+ exists as a QEMU machine (`raspi1ap`); there is no Pi 1
+# Model B machine. Same BCM2835/ARM1176 silicon, boots to the desktop. Requires
+# the FPU-enable fix (#98) — without it the first vldr in _raspi_vcmem_init traps.
+make rpi1_defconfig && make
+qemu-system-arm -M raspi1ap -bios kernel.img -d guest_errors -serial stdio
+
+# raspi2 — real video output like raspi1; reads KDEBUG on the serial console.
 # NOTE: the machine is `raspi2b` on QEMU >= 9 (`-M raspi2` is gone). Requires the
 # FPU-enable fix (#98) — without it the first vldr in _raspi_vcmem_init traps.
 make rpi2_defconfig && make
@@ -153,6 +160,9 @@ timeout 5 qemu-system-arm -M virt,highmem=off -cpu cortex-a7 -m 128 -kernel virt
 cat /tmp/qemu.log
 ```
 
+- **raspi1** (booted with `-M raspi1ap`): serial KDEBUG shows `vdi_v_opnwk: mode layout=1 color_model=0
+  bpp=8 backend=none` (later `color_model=1 ... backend=selected`); no
+  `guest_errors`; screen draws.
 - **raspi2** (booted with `-M raspi2b`): serial KDEBUG shows `vdi_v_opnwk: mode layout=1 color_model=0
   bpp=8 backend=none` (later `color_model=1 ... backend=selected`); no
   `guest_errors`; screen draws.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,14 +59,15 @@ them.
 
 To smoke-test a build, use the `ptos-smoketest` skill
 (`.claude/skills/ptos-smoketest/SKILL.md`). It has the verified QEMU
-invocations for the raspi2 (QEMU machine `raspi2b`), virt-arm and virt-m68k
-machines and the Hatari
+invocations for the raspi1 (QEMU machine `raspi1ap`), raspi2 (QEMU machine
+`raspi2b`), virt-arm and virt-m68k machines and the Hatari
 invocations for the Atari m68k targets, with pass signals and emulator
 gotchas (unreliable Hatari debugger breakpoints, the Falcon IDE 31 s boot
-wait). Minimal raspi2 smoke test, for reference:
+wait). Minimal raspi1 smoke test, for reference:
 
 ```sh
-qemu-system-arm -M raspi2b -bios kernel7.img -d guest_errors -serial stdio
+make rpi1_defconfig && make
+qemu-system-arm -M raspi1ap -bios kernel.img -d guest_errors -serial stdio
 ```
 
 ## How the configuration works


### PR DESCRIPTION
Fixes #102

The `ptos-smoketest` skill documented the QEMU invocation for raspi2 (`-M raspi2b`) and the virt targets, but had no raspi1 entry — and QEMU >= 9 has no Pi 1 Model B machine.

`raspi1ap` (Raspberry Pi A+, BCM2835 / ARM1176) is the closest machine to the Pi 1 Model B the `rpi1_defconfig` targets, and boots the `kernel.img` build to the GEM desktop event loop.

Changes:
- SKILL.md: add the `rpi1_defconfig` row (image `kernel.img`, machine `-M raspi1ap`) to the config table; add the verified invocation to the QEMU smoke-test section with the \#98 FPU-dependency note; add the raspi1 pass signal; update the frontmatter description and fix the now-inaccurate "only target with real video output" raspi2 comment.
- CLAUDE.md: extend the smoke-test pointer to include raspi1, with the raspi1 invocation as the minimal reference.

Verified in-tree (QEMU 10.1.0):

```sh
make rpi1_defconfig && make
qemu-system-arm -M raspi1ap -bios kernel.img -d guest_errors -serial stdio
```

Serial KDEBUG reaches `AES: EMUDESK: evnt_multi()` with zero guest_errors, matching the raspi2 desktop; `make gitready` passes.