### PR TITLE
Add base color icon (CICON) support

### DIFF
--- a/aes/Kconfig
+++ b/aes/Kconfig
@@ -49,6 +49,18 @@ config CONF_WITH_LOADABLE_CURSORS
 	  Allow the mouse cursors to be loaded from A:\EMUCURS.RSC instead
 	  of using the built-in ones.
 
+config CONF_WITH_COLOUR_ICONS
+	bool "Colour icons"
+	default n if TARGET_192
+	default y
+	help
+	  Recognise 'new format' RSC files and render the CICONBLK colour
+	  icon data they may contain, as in Atari TOS 4.  Resources without
+	  colour icon data, and legacy mono ICONBLK icons, are unaffected.
+
+	  Space is tight on the smallest ROM targets, so this is disabled
+	  by default there.
+
 endif
 
 endmenu

--- a/aes/Kconfig
+++ b/aes/Kconfig
@@ -51,7 +51,7 @@ config CONF_WITH_LOADABLE_CURSORS
 
 config CONF_WITH_COLOUR_ICONS
 	bool "Colour icons"
-	default n if TARGET_192
+	default n if TARGET_192 || TARGET_CART
 	default y
 	help
 	  Recognise 'new format' RSC files and render the CICONBLK colour

--- a/aes/gemgraf.c
+++ b/aes/gemgraf.c
@@ -25,6 +25,7 @@
 #include "intmath.h"
 #include "gsxdefs.h"
 #include "funcdef.h"
+#include "gemdos.h"
 
 #include "gemgraf.h"
 #include "gemgsxif.h"
@@ -685,12 +686,70 @@ static void gr_gblt(WORD *pimage, GRECT *pi, WORD col1, WORD col2)
 }
 
 
+#if CONF_WITH_COLOUR_ICONS
+/*
+ *  Blit a previously-transformed colour icon from memory to screen
+ */
+static void gr_colourblit(WORD *pdata, GRECT *pi, WORD num_planes)
+{
+    WORD pxyarray[8];
+
+    gsx_fix(&gl_src, pdata, pi->g_w/8, pi->g_h);
+    gl_src.fd_nplanes = num_planes;
+
+    gsx_fix(&gl_dst, ORGADDR, 0, 0);
+    gl_dst.fd_nplanes = num_planes;
+
+    gsx_moff();
+    pxyarray[0] = 0;
+    pxyarray[1] = 0;
+    pxyarray[2] = pi->g_w - 1;
+    pxyarray[3] = pi->g_h - 1;
+    pxyarray[4] = pi->g_x;
+    pxyarray[5] = pi->g_y;
+    pxyarray[6] = pi->g_x + pi->g_w - 1;
+    pxyarray[7] = pi->g_y + pi->g_h - 1;
+    gsx_mon();
+
+    vro_cpyfm(S_OR_D, pxyarray, &gl_src, &gl_dst);
+}
+
+
+/*
+ *  Create a dithered copy of the specified mask and return its address
+ *
+ *  returns NULL if memory can't be allocated
+ */
+static WORD *dither_mask(WORD *pdata, WORD w, WORD h)
+{
+    WORD width = w / 16;    /* in WORDs */
+    WORD i, j, dither;
+    WORD *mask, *p, *q;
+
+    mask = dos_alloc_anyram((LONG)width * sizeof(WORD) * h);
+    if (!mask)
+        return NULL;
+
+    for (i = 0, p = pdata, q = mask; i < h; i++)
+    {
+        dither = (i & 1) ? 0xaaaa : 0x5555;
+        for (j = 0; j < width; j++)
+            *q++ = *p++ & dither;
+    }
+
+    return mask;
+}
+#endif
+
+
 /*
  *  Routine to draw an icon, which is a graphic image with a text
- *  string underneath it
+ *  string underneath it.  If colour icons are enabled and 'cicon' is
+ *  not NULL, the colour icon data it points to is drawn instead of
+ *  the mono pmask/pdata bitmaps.
  */
 void gr_gicon(WORD state, WORD *pmask, WORD *pdata, BYTE *ptext, WORD ch,
-              WORD chx, WORD chy, GRECT *pi, GRECT *pt)
+              WORD chx, WORD chy, GRECT *pi, GRECT *pt, CICON *cicon)
 {
     WORD    ifgcol, ibgcol;
     WORD    tfgcol, tbgcol, tmp;
@@ -700,13 +759,30 @@ void gr_gicon(WORD state, WORD *pmask, WORD *pdata, BYTE *ptext, WORD ch,
     tbgcol = ibgcol = (ch >> 8) & 0x000f;
     ch &= 0x00ff;
 
+#if CONF_WITH_COLOUR_ICONS
+    if (cicon)
+    {
+        /* use the 'selected' data/mask if available */
+        if ((state & SELECTED) && cicon->sel_data)
+        {
+            pdata = cicon->sel_data;
+            pmask = cicon->sel_mask;
+        }
+        else
+        {
+            pdata = cicon->col_data;
+            pmask = cicon->col_mask;
+        }
+    }
+#endif
+
     /* invert if selected   */
     if (state & SELECTED)
     {
         tmp = tfgcol;
         tfgcol = tbgcol;
         tbgcol = tmp;
-        if (!(state & DRAW3D))
+        if (!cicon && !(state & DRAW3D))
         {
             tmp = ifgcol;
             ifgcol = ibgcol;
@@ -725,18 +801,37 @@ void gr_gicon(WORD state, WORD *pmask, WORD *pdata, BYTE *ptext, WORD ch,
     }
 
     /* draw the image */
-    gr_gblt(pdata, pi, ifgcol, ibgcol);
-
-    if ((state & SELECTED) && (state & DRAW3D))
+#if CONF_WITH_COLOUR_ICONS
+    if (cicon)
     {
-        pi->g_x--;
-        pi->g_y--;
-        gr_gblt(pmask, pi, ifgcol, ibgcol);
-        pi->g_x += 2;
-        pi->g_y += 2;
-        gr_gblt(pmask, pi, ifgcol, ibgcol);
-        pi->g_x--;
-        pi->g_y--;
+        gr_colourblit(pdata, pi, cicon->num_planes);
+        if ((state & SELECTED) && !cicon->sel_data)
+        {
+            /* no dedicated selected asset: darken via a dithered mask */
+            WORD *dmask = dither_mask(pmask, pi->g_w, pi->g_h);
+            if (dmask)
+            {
+                gr_gblt(dmask, pi, BLACK, WHITE);
+                dos_free(dmask);
+            }
+        }
+    }
+    else
+#endif
+    {
+        gr_gblt(pdata, pi, ifgcol, ibgcol);
+
+        if ((state & SELECTED) && (state & DRAW3D))
+        {
+            pi->g_x--;
+            pi->g_y--;
+            gr_gblt(pmask, pi, ifgcol, ibgcol);
+            pi->g_x += 2;
+            pi->g_y += 2;
+            gr_gblt(pmask, pi, ifgcol, ibgcol);
+            pi->g_x--;
+            pi->g_y--;
+        }
     }
 
     /* draw the character */

--- a/aes/gemgraf.h
+++ b/aes/gemgraf.h
@@ -11,6 +11,7 @@
 #define GEMGRAF_H
 
 #include "gsxdefs.h"
+#include "obdefs.h"
 
 WORD gsx_chkclip(GRECT *pt);
 void gsx_cline(UWORD x1, UWORD y1, UWORD x2, UWORD y2);

--- a/aes/gemgraf.h
+++ b/aes/gemgraf.h
@@ -26,7 +26,7 @@ WORD gr_just(WORD just, WORD font, BYTE *ptext, WORD w, WORD h, GRECT *pt);
 void gr_gtext(WORD just, WORD font, BYTE *ptext, GRECT *pt);
 void gr_crack(UWORD color, WORD *pbc, WORD *ptc, WORD *pip, WORD *pic, WORD *pmd);
 void gr_gicon(WORD state, WORD *pmask, WORD *pdata, BYTE *ptext, WORD ch,
-              WORD chx, WORD chy, GRECT *pi, GRECT *pt);
+              WORD chx, WORD chy, GRECT *pi, GRECT *pt, CICON *cicon);
 void gr_box(WORD x, WORD y, WORD w, WORD h, WORD th);
 
 #endif

--- a/aes/gemoblib.c
+++ b/aes/gemoblib.c
@@ -209,6 +209,7 @@ static void just_draw(OBJECT *tree, WORD obj, WORD sx, WORD sy)
     TEDINFO edblk;
     BITBLK bi;
     ICONBLK ib;
+    CICON *cicon;
 
     ch = ob_sst(tree, obj, &spec, &state, &obtype, &flags, &t, &th);
 
@@ -331,6 +332,12 @@ static void just_draw(OBJECT *tree, WORD obj, WORD sx, WORD sy)
                     bi.bi_hl, MD_TRANS, bi.bi_color, WHITE);
             break;
         case G_ICON:
+            cicon = NULL;
+#if CONF_WITH_COLOUR_ICONS
+        case G_CICON:   /* a CICONBLK starts with an ICONBLK */
+            if (obtype == G_CICON)
+                cicon = spec.ciconblk->mainlist;
+#endif
             ib = *(spec.iconblk);
             ib.ib_xicon += t.g_x;
             ib.ib_yicon += t.g_y;
@@ -338,7 +345,7 @@ static void just_draw(OBJECT *tree, WORD obj, WORD sx, WORD sy)
             ib.ib_ytext += t.g_y;
             gr_gicon(state, ib.ib_pmask, ib.ib_pdata, ib.ib_ptext,
                     ib.ib_char, ib.ib_xchar, ib.ib_ychar,
-                    (GRECT *)&ib.ib_xicon, (GRECT *)&ib.ib_xtext);  /* FIXME: Ugly typecasting */
+                    (GRECT *)&ib.ib_xicon, (GRECT *)&ib.ib_xtext, cicon);  /* FIXME: Ugly typecasting */
             state &= ~SELECTED;
             break;
         case G_USERDEF:
@@ -715,6 +722,9 @@ void ob_change(OBJECT *tree, WORD obj, UWORD new_state, WORD redraw)
         else
         {
             if ((obtype != G_ICON) &&
+#if CONF_WITH_COLOUR_ICONS
+               (obtype != G_CICON) &&
+#endif
                ((new_state ^ curr_state) & SELECTED) )
             {
                 bb_fill(MD_XOR, FIS_SOLID, IP_SOLID, t.g_x+th, t.g_y+th,

--- a/aes/gemoblib.c
+++ b/aes/gemoblib.c
@@ -333,6 +333,7 @@ static void just_draw(OBJECT *tree, WORD obj, WORD sx, WORD sy)
             break;
         case G_ICON:
             cicon = NULL;
+            /* drop thru */
 #if CONF_WITH_COLOUR_ICONS
         case G_CICON:   /* a CICONBLK starts with an ICONBLK */
             if (obtype == G_CICON)

--- a/aes/gemrslib.c
+++ b/aes/gemrslib.c
@@ -30,6 +30,7 @@
 #include "gemgraf.h"
 #include "geminit.h"
 #include "gemrslib.h"
+#include "gemgsxif.h"
 
 #include "string.h"
 #include "nls.h"
@@ -199,6 +200,366 @@ static void *get_addr(UWORD rstype, UWORD rsindex)
 } /* get_addr() */
 
 
+#if CONF_WITH_COLOUR_ICONS
+/*
+ * fixup all of the CICONs for a CICONBLK
+ *
+ * returns a pointer to the next CICONBLK
+ */
+static CICONBLK *fixup_colour_icons(LONG num_cicons, LONG mono_words, CICON *start)
+{
+    CICON *p = start;
+    WORD *q;
+    LONG i;
+
+    /*
+     * loop through all the CICONs for one CICONBLK
+     *
+     * p points to the current CICON; q tracks sections of CICON data.
+     * at the end, p will point to the start of the next CICONBLK
+     */
+    for (i = 0; i < num_cicons; i++)
+    {
+        q = (WORD *)(p+1);                  /* point to start of data area */
+        p->col_data = q;
+        q += mono_words * p->num_planes;
+        p->col_mask = q;
+        q += mono_words;                    /* mask is one plane */
+        if (p->sel_data)
+        {
+            p->sel_data = q;
+            q += mono_words * p->num_planes;
+            p->sel_mask = q;
+            q += mono_words;                /* mask is one plane */
+        }
+        if (p->next_res == (CICON *)1L)     /* more CICONs follow */
+            p->next_res = (CICON *)q;
+        else
+            p->next_res = NULL;
+        p = (CICON *)q;
+    }
+
+    return (CICONBLK *)p;
+}
+
+/*
+ * this fixes up all of the CICONBLK-related pointers:
+ *  . the CICONBLK pointer table
+ *  . the pointers in the ICONBLK contained in the CICONBLK
+ *  . the pointers in the CICON
+ */
+static void fixup_all_ciconblks(LONG num_blks, CICONBLK **ciconblkptr, CICON *cicondata)
+{
+    CICONBLK *p = (CICONBLK *)cicondata;
+    WORD *q;
+    LONG i, num_cicons, mono_words;
+
+    for (i = 0; i < num_blks; i++)
+    {
+        ciconblkptr[i] = p;
+        num_cicons = (LONG)(p->mainlist);   /* number of colour icons for this CICONBLK */
+        mono_words = (LONG)(p->monoblk.ib_wicon/16) * p->monoblk.ib_hicon;
+        q = (WORD *)(p+1);                  /* point to start of data area */
+
+        p->monoblk.ib_pdata = q;            /* fixup mono icon */
+        q += mono_words;
+        p->monoblk.ib_pmask = q;
+        q += mono_words;
+        p->monoblk.ib_ptext = (BYTE *)q;
+        q += 12 / 2;                        /* length of icon text */
+        if (num_cicons)
+        {
+            p->mainlist = (CICON *)q;
+            p = fixup_colour_icons(num_cicons, mono_words, (CICON *)q);
+        }
+        else
+        {
+            p->mainlist = NULL;
+            p = (CICONBLK *)q;
+        }
+    }
+}
+
+/*
+ * returns pointer to a CICON that best matches the current resolution
+ *
+ * the order of preference is as follows:
+ *  1. the CICON with the same number of planes as the current resolution
+ *  2. of those CICONS with fewer planes than the current resolution, the
+ *     one with the most number of planes
+ * if neither applies, NULL is returned
+ */
+static CICON *best_match(CICONBLK *start)
+{
+    CICON *p, *found = NULL;
+
+    for (p = start->mainlist; p; p = p->next_res)
+    {
+        if (p->num_planes > gl_nplanes)     /* too many planes */
+            continue;
+        if (p->num_planes == gl_nplanes)    /* exact match */
+            return p;
+        if (!found || (p->num_planes > found->num_planes))
+            found = p;                      /* best so far */
+    }
+
+    return found;
+}
+
+/*
+ * expand cicon data from S to D planes (S is strictly less than D)
+ *
+ * we use the same algorithm as Atari TOS:
+ *  1. copy the source to the first S (0 to S-1) planes of the
+ *     destination data
+ *  2. create the Sth plane of the destination data by ANDing
+ *     together all the source planes
+ *  3. copy the Sth plane of the destination data to the remaining
+ *     destination planes
+ *  4. AND all the destination planes with the mask plane
+ */
+static void expand_cicondata(WORD *src, WORD *dst, WORD *mask, WORD w, WORD h, WORD src_planes, WORD dst_planes)
+{
+    WORD *p, *q;
+    WORD plane_words, src_words;
+    WORD i, j;
+
+    plane_words = w / 16 * h;           /* in WORDS */
+    src_words = plane_words * src_planes;
+
+    /*
+     * 1. the first src_planes of dst are the same as src
+     */
+    memcpy(dst, src, src_words*sizeof(WORD));
+
+    /*
+     * 2. copy the zeroth src plane to the next dst plane,
+     *    then AND in the remaining planes
+     */
+    memcpy(dst+src_words, src, plane_words*sizeof(WORD));
+    p = src + plane_words;      /* p -> start of remainder */
+    for (i = 1; i < src_planes; i++)
+    {
+        q = dst + src_words;    /* q -> target */
+        for (j = 0; j < plane_words; j++, p++, q++)
+            *q = *p & *q;
+    }
+
+    /*
+     * 3. copy the ANDed plane to the rest of the destination planes
+     */
+    p = dst + src_words;        /* p -> source (ANDed) plane */
+    q = p + plane_words;        /* q -> start of remaining planes */
+    for (i = 1; i < (dst_planes-src_planes); i++, q += plane_words)
+    {
+        memcpy(q, p, plane_words*sizeof(WORD));
+    }
+
+    /*
+     * 4. AND the mask plane into all destination planes
+     */
+    q = dst;
+    for (i = 0; i < dst_planes; i++)
+    {
+        p = mask;
+        for (j = 0; j < plane_words; j++, p++, q++)
+            *q &= *p;
+    }
+}
+
+/*
+ * transform a colour icon from device-independent to device-dependent form
+ */
+static void transform_cicon(WORD *src, WORD *dest, WORD w, WORD h, WORD planes)
+{
+    gsx_fix(&gl_src, src, w/8, h);
+    gl_src.fd_stand = TRUE;
+    gl_src.fd_nplanes = planes;
+
+    gsx_fix(&gl_dst, dest, w/8, h);
+    gl_dst.fd_nplanes = planes;
+
+    vrn_trnfm(&gl_src, &gl_dst);
+}
+
+/*
+ * for each CICONBLK in the resource, select the CICON with the number of
+ * planes that best matches the current resolution.  then expand the icon
+ * if necessary, and transform it from standard to device-dependent format
+ */
+static void transform_all_cicons(LONG num_cicons, CICONBLK **ciconblkptr)
+{
+    CICONBLK *ciconblk;
+    CICON *cicon;
+    WORD *colbuf, *selbuf, *expandbuf, *src;
+    LONG data_size, n;
+    BOOL expand;
+    WORD i, w, h;
+
+    for (i = 0; i < num_cicons; i++)
+    {
+        ciconblk = ciconblkptr[i];
+        cicon = best_match(ciconblk);   /* find a suitable CICON */
+        ciconblk->mainlist = cicon;
+        if (!cicon)                     /* nothing suitable ... */
+            continue;
+        w = ciconblk->monoblk.ib_wicon;
+        h = ciconblk->monoblk.ib_hicon;
+        data_size = (LONG)(w/8*gl_nplanes) * h;
+        expand = (cicon->num_planes != gl_nplanes); /* boolean */
+
+        /* if we need to expand the icon, we need a temp buffer */
+        expandbuf = NULL;
+        if (expand)
+        {
+            expandbuf = dos_alloc_anyram(data_size);
+            if (!expandbuf)
+            {
+                ciconblk->mainlist = NULL;  /* no colour for this icon */
+                continue;
+            }
+        }
+
+        /* we always allocate a data buffer so we avoid transform-in-place */
+        n = cicon->sel_data ? 2*data_size : data_size;
+        colbuf = dos_alloc_anyram(n);
+        if (!colbuf)
+        {
+            if (expandbuf)
+                dos_free(expandbuf);
+            ciconblk->mainlist = NULL;      /* no colour for this icon */
+            continue;
+        }
+
+        /* handle standard icon */
+        src = cicon->col_data;
+        if (expand)
+        {
+            expand_cicondata(src, expandbuf, cicon->col_mask, w, h, cicon->num_planes, gl_nplanes);
+            src = expandbuf;
+        }
+        transform_cicon(src, colbuf, w, h, gl_nplanes);
+        cicon->col_data = colbuf;
+
+        /* handle 'selected' icon (if present) */
+        if (cicon->sel_data)
+        {
+            selbuf = colbuf + data_size/sizeof(WORD);
+            src = cicon->sel_data;
+            if (expand)
+            {
+                expand_cicondata(src, expandbuf, cicon->sel_mask, w, h, cicon->num_planes, gl_nplanes);
+                src = expandbuf;
+            }
+            transform_cicon(src, selbuf, w, h, gl_nplanes);
+            cicon->sel_data = selbuf;
+        }
+
+        cicon->num_planes = gl_nplanes;     /* neatness only */
+        cicon->next_res = NULL;
+
+        if (expandbuf)
+            dos_free(expandbuf);
+    }
+}
+
+/*
+ * return pointer to start of CICONBLK pointer table
+ *
+ * returns NULL if none
+ */
+static CICONBLK **get_ciconblkptr(RSHDR *hdr)
+{
+    LONG *extarray;
+    LONG cptr_offset;
+
+    /* check if we could have CICONs */
+    if ((hdr->rsh_vrsn & NEW_FORMAT_RSC) == 0)
+        return NULL;
+
+    /*
+     * locate extension array, which has the following format (all longs):
+     *  extarray[0]     true length of RSC file
+     *  extarray[1]     offset of CICON table (-1L => none present)
+     *  extarray[2]...  other extensions
+     *  extarray[n]     0L indicates end of array
+     */
+    extarray = (LONG *)((char *)hdr + hdr->rsh_rssize);
+
+    /* do we have CICONs? */
+    cptr_offset = extarray[1];
+    if ((cptr_offset == 0L) || (cptr_offset == -1L))
+        return NULL;
+
+    return (CICONBLK **)((char *)hdr + cptr_offset);
+}
+
+/*
+ * free the CICON-related buffers allocated by transform_all_cicons()
+ *
+ * returns -1 iff dos_free() failed
+ */
+static WORD free_cicon_buffers(RSHDR *hdr)
+{
+    CICONBLK **ciconblkptr, **p;
+    CICON *cicon;
+    WORD rc = 0;
+
+    /* find the CICONBLK ptr table & count the CICONBLKs */
+    ciconblkptr = get_ciconblkptr(hdr);
+    if (!ciconblkptr)   /* yes, we have no CICONBLKs */
+        return 0;
+
+    /* free any buffers allocated by transform_all_cicons() */
+    for (p = ciconblkptr; *p != (CICONBLK *)-1L; p++)
+    {
+        cicon = (*p)->mainlist;
+        if (cicon)
+            if (dos_free(cicon->col_data))
+                rc = -1;
+    }
+
+    return rc;
+}
+
+/*
+ * initialise the colour icon stuff
+ *
+ * this includes:
+ *  . filling in the CICONBLK pointer table
+ *  . for each CICONBLK:
+ *      . fixing up all of the internal data/mask/text pointers
+ *      . determining the appropriate icon for the current resolution
+ *      . expanding the icon if necessary
+ *      . converting the icon to device-dependent form
+ */
+static void fix_cicons(void)
+{
+    RSHDR *hdr = rs_hdr;
+    CICONBLK **ciconblkptr, **p;
+    CICON *cicondata;
+    LONG num_ciconblks;
+
+    /* find the CICONBLK ptr table & count the CICONBLKs */
+    ciconblkptr = get_ciconblkptr(hdr);
+    if (!ciconblkptr)   /* yes, we have no CICONBLKs */
+        return;
+
+    for (num_ciconblks = 0, p = ciconblkptr; *p != (CICONBLK *)-1L; p++)
+        num_ciconblks++;
+
+    /* the CICON data area starts immediately after the pointer table */
+    cicondata = (CICON *)(p+1);
+
+    /* fixup the pointers in the resource */
+    fixup_all_ciconblks(num_ciconblks, ciconblkptr, cicondata);
+
+    /* transform all the icons to device-dependent format */
+    transform_all_cicons(num_ciconblks, ciconblkptr);
+}
+#endif
+
+
 static BOOL fix_long(LONG *plong)
 {
     LONG lngval;
@@ -234,14 +595,31 @@ static void fix_objects(void)
     WORD ii;
     WORD obtype;
     OBJECT *obj;
+#if CONF_WITH_COLOUR_ICONS
+    CICONBLK **ciconblkptr = get_ciconblkptr(rs_hdr);
+#endif
 
     for (ii = 0; ii < rs_hdr->rsh_nobs; ii++)
     {
         obj = (OBJECT *)get_addr(R_OBJECT, ii);
         rs_obfix(obj, 0);
         obtype = obj->ob_type & 0x00ff;
-        if ((obtype != G_BOX) && (obtype != G_IBOX) && (obtype != G_BOXCHAR))
+        switch (obtype)
+        {
+#if CONF_WITH_COLOUR_ICONS
+        case G_CICON:
+            if (ciconblkptr)
+                obj->ob_spec.index = (LONG)ciconblkptr[obj->ob_spec.index];
+            break;
+#endif
+        case G_BOX:
+        case G_IBOX:
+        case G_BOXCHAR:
+            break;
+        default:
             fix_long(&obj->ob_spec.index);
+            break;
+        }
     }
 }
 
@@ -293,9 +671,19 @@ static void rs_sglobe(AESGLOBAL *pglobal)
  */
 WORD rs_free(AESGLOBAL *pglobal)
 {
-    rs_global = pglobal;
+    WORD rc = 1;    /* default rc => OK */
 
-    return !dos_free(rs_global->ap_rscmem);
+    rs_sglobe(pglobal);
+
+#if CONF_WITH_COLOUR_ICONS
+    if (free_cicon_buffers(rs_hdr) < 0)
+        rc = 0;
+#endif
+
+    if (dos_free(rs_global->ap_rscmem))
+        rc = 0;
+
+    return rc;
 }
 
 
@@ -342,7 +730,7 @@ WORD rs_saddr(AESGLOBAL *pglobal, UWORD rtype, UWORD rindex, void *rsaddr)
 static WORD rs_readit(AESGLOBAL *pglobal,UWORD fd)
 {
     WORD ibcnt;
-    UWORD rslsize;
+    LONG rslsize;
     RSHDR hdr_buff;
 
     /* read the header */
@@ -351,6 +739,18 @@ static WORD rs_readit(AESGLOBAL *pglobal,UWORD fd)
 
     /* get size of resource & allocate memory */
     rslsize = hdr_buff.rsh_rssize;
+
+#if CONF_WITH_COLOUR_ICONS
+    /* for 'new format' resource files, get actual resource size */
+    if (hdr_buff.rsh_vrsn & NEW_FORMAT_RSC)
+    {
+        if (dos_lseek(fd, 0, rslsize) < 0L)
+            return FALSE;
+        if (dos_read(fd, sizeof(rslsize), &rslsize) != sizeof(rslsize))
+            return FALSE;
+    }
+#endif
+
     rs_hdr = (RSHDR *)dos_alloc_anyram(rslsize);
     if (!rs_hdr)
         return FALSE;
@@ -371,6 +771,9 @@ static WORD rs_readit(AESGLOBAL *pglobal,UWORD fd)
      * base of file into pointers
      */
     fix_trindex();
+#if CONF_WITH_COLOUR_ICONS
+    fix_cicons();
+#endif
     fix_tedinfo();
     ibcnt = rs_hdr->rsh_nib;
     fix_nptrs(ibcnt, R_IBPMASK);

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -471,34 +471,39 @@ static WORD setup_iconblks(const ICONBLK *ibstart, WORD count)
 }
 
 /*
- * try to load icons from user-supplied resource
+ * try to load user-supplied resource
  */
-static WORD load_user_icons(void)
+static WORD load_icon_file(void)
 {
-    RSHDR *hdr;
-    ICONBLK *ibptr, *ib;
-    WORD i, n, rc, w, h;
     BYTE icon_rsc_name[sizeof(ICON_RSC_NAME)];
 
     /* Do not load user icons if Control was held on startup */
     if (bootflags & BOOTFLAG_SKIP_AUTO_ACC)
         return -1;
 
-    /*
-     * determine the number of icons in the user's icon resource
-     */
     strcpy(icon_rsc_name, ICON_RSC_NAME);
     icon_rsc_name[0] += G.g_stdrv;  /* Adjust drive letter  */
-    if (!rsrc_load(icon_rsc_name))
-    {
-        KDEBUG(("can't load user desktop icons from %s\n",icon_rsc_name));
-        return -1;
-    }
+    if (rsrc_load(icon_rsc_name))
+        return 0;
+
+    KDEBUG(("can't load user desktop icon file %s\n",icon_rsc_name));
+    return -1;
+}
+
+
+/*
+ * try to set up mono icons
+ */
+static WORD setup_mono_icons(void)
+{
+    RSHDR *hdr;
+    ICONBLK *ibptr, *ib;
+    WORD i, n, rc, w, h;
 
     hdr = (RSHDR *)(AP_1RESV);
     if (hdr->rsh_nib < BUILTIN_IBLKS)   /* must have at least the minimum set */
     {
-        KDEBUG(("too few user desktop icons (%d)\n",hdr->rsh_nib));
+        KDEBUG(("too few user desktop mono icons (%d)\n",hdr->rsh_nib));
         rsrc_free();
         return -1;
     }
@@ -515,7 +520,7 @@ static WORD load_user_icons(void)
     {
         if ((ib->ib_wicon != w) || (ib->ib_hicon != h))
         {
-            KDEBUG(("user desktop icon %d has wrong size (%dx%d)\n",
+            KDEBUG(("user desktop mono icon %d has wrong size (%dx%d)\n",
                     i,ib->ib_wicon,ib->ib_hicon));
             rsrc_free();
             return -1;
@@ -591,10 +596,13 @@ static WORD app_rdicon(void)
     /*
      * try to load user icons; if that fails, use builtin
      */
-    if (load_user_icons() < 0)
-        return setup_iconblks(icon_rs_iconblk, BUILTIN_IBLKS);
+    if (load_icon_file() == 0)
+    {
+        if (setup_mono_icons() == 0)
+            return 0;
+    }
 
-    return 0;
+    return setup_iconblks(icon_rs_iconblk, BUILTIN_IBLKS);
 }
 
 

--- a/doc/status.txt
+++ b/doc/status.txt
@@ -570,7 +570,7 @@ AES v3.40 (TOS >= v4):
  -      objc_sysvar            (3D look)
 
 TOS v4 extended AES functionality:
- -      RSC file color icon support
+ >      RSC file color icon support   (planar only; truecolor rendering: #107)
 
 
  Misc desktop functions

--- a/include/obdefs.h
+++ b/include/obdefs.h
@@ -85,6 +85,7 @@
 #define G_FBOXTEXT  30
 #define G_ICON      31
 #define G_TITLE     32
+#define G_CICON     33
 
 #define NONE        0x0000      /* Object flags */
 #define SELECTABLE  0x0001
@@ -174,6 +175,22 @@ typedef struct
         WORD    ib_htext;
 } ICONBLK;
 
+typedef struct _CICON
+{
+        WORD    num_planes;     /* number of planes for this version */
+        WORD    *col_data;      /* ptrs to colour icon mask & data */
+        WORD    *col_mask;
+        WORD    *sel_data;      /* ptrs to optional icon/mask for SELECTED state */
+        WORD    *sel_mask;
+        struct  _CICON *next_res;
+} CICON;
+
+typedef struct
+{
+        ICONBLK monoblk;        /* mono version of icon */
+        CICON   *mainlist;
+} CICONBLK;
+
 typedef struct
 {
         void    *bi_pdata;      /* ptr to bit forms data        */
@@ -234,6 +251,7 @@ typedef union obspecptr
         bfobspec    obspec;
         TEDINFO     *tedinfo;
         ICONBLK     *iconblk;
+        CICONBLK    *ciconblk;
         BITBLK      *bitblk;
         USERBLK     *userblk;
         char        *free_string;


### PR DESCRIPTION
## Summary

Ports the mergeable base of upstream EmuTOS's color icon (CICONBLK) support: resource parsing, data structures, desktop integration, and mono/planar-safe rendering. This is the part of #105 that has no dependency on the in-progress truecolor VDI backend work.

- `include/obdefs.h`: `CICON`/`CICONBLK` structs, `G_CICON` object type, `ciconblk` member on `OBSPEC`.
- `aes/Kconfig`: new `CONF_WITH_COLOUR_ICONS` option, default `y` except `TARGET_192`.
- `aes/gemrslib.c`: 'new format' RSC recognition, CICONBLK pointer-table fixup, per-resolution CICON selection, expand/transform to device-dependent form, buffer cleanup on `rsrc_free()`.
- `aes/gemgraf.c` / `gemgraf.h`: `gr_gicon()` gains an optional `CICON *cicon` parameter; colour data is blitted via `vro_cpyfm()` (`gr_colourblit()`), with a dithered-mask fallback for the selected state when no dedicated selected asset exists.
- `aes/gemoblib.c`: `just_draw()`/`ob_change()` handle `G_CICON` alongside `G_ICON` (including using full redraw instead of XOR-fill on selection change).
- `desk/deskapp.c`: splits `load_user_icons()` into `load_icon_file()`/`setup_mono_icons()`, matching upstream's prep-for-colour-icons refactor.
- `doc/status.txt`: "RSC file color icon support" marked partially implemented.

## Adaptations from upstream

pTOS's `gr_gicon()`/`just_draw()`/RSC loader diverged from upstream before this fork's baseline (raw-field `gr_gicon()` signature, `OBSPEC` union, `DRAW3D` icon style, no `fix_tedinfo_std()` split, no `dos_sfirst()` RSC pre-check). The 6 source commits were adapted to that structure rather than applied verbatim; `muls()`-based multiplies were replaced with plain `(LONG)` casts since pTOS's `intmath.h` doesn't carry that m68k-only helper.

## Not in scope (tracked in #107)

Truecolor-correct rendering. `expand_cicondata()`'s plane-AND expansion algorithm assumes an indexed/planar palette; on the truecolor VDI backend this needs the raster-copy path to gain backend dispatch first (currently planar-only per `vdi/vdi_backend.h`).

## Testing

- `make gitready` passes.
- `rpi2_defconfig` builds clean (no new warnings) with both `CONF_WITH_COLOUR_ICONS=y` (default) and `=n` (`atari192_defconfig`, m68k toolchain unavailable in this sandbox so not build-verified there, but no arch-specific constructs were introduced).
- Booted the rpi2 image in `qemu-system-arm -M raspi2b`: desktop reaches `evnt_multi()` with no resource-loading errors, confirming the `fix_objects()`/`rs_free()`/`rs_readit()` changes (which run for every RSC load, not just colour ones) don't regress the existing mono-icon path.
- No RSC file containing actual CICONBLK data was available to exercise the new rendering path end-to-end.

Fixes #106