### PR TITLE
Raise max AES windows from 8 to 16 for AES > 3.20

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -71,8 +71,18 @@
 /*
  * System configuration definitions
  */
-#define NUM_WIN 8               /* maximum number of windows (the     */
-                                /* desktop itself counts as 1 window) */
+/*
+ * Maximum number of windows (the desktop itself counts as 1 window)
+ *
+ * Later AES versions support more windows; like upstream, we raise
+ * the limit from 8 to 16 when the AES is configured above version
+ * 0x0320 (TOS 2.06/3.06).
+ */
+#if (AES_VERSION > 0x0320)
+# define NUM_WIN 16
+#else
+# define NUM_WIN 8
+#endif
 
 #define NUM_ACCS 6              /* maximum number of desk accessory   */
                                 /* files (.ACC) that will be loaded   */


### PR DESCRIPTION
Fixes #120

Ports upstream EmuTOS commit 8e7f444b: support 16 AES windows (instead of 8) when the AES version is configured above 0x0320 (TOS 2.06/3.06), matching upstream's gating on later AES feature sets. NUM_WIN moves from a fixed limit to a value derived from the AES_VERSION Kconfig option.