### PR TITLE
Use the newer mintelf toolchain for m68k builds

### DIFF
--- a/.claude/skills/ptos-smoketest/SKILL.md
+++ b/.claude/skills/ptos-smoketest/SKILL.md
@@ -26,8 +26,7 @@ the pTOS tree). Relevant outputs:
 Atari configs build with the default mintelf toolchain (`m68k-atari-mintelf-`)
 and produce symbols in `ptos512k.sym` (load in the Hatari debugger with
 `symbols <file>`; there is no `--symbols` CLI option). The virt-m68k image is
-also ELF (`BUILD_TOOLCHAIN_MINTELF=y`), since QEMU's `-kernel` loader needs an
-`elf32-m68k`-format kernel.
+also ELF, since QEMU's `-kernel` loader needs an `elf32-m68k`-format kernel.
 
 ## Hatari smoke test (m68k Atari)
 

--- a/.claude/skills/ptos-smoketest/SKILL.md
+++ b/.claude/skills/ptos-smoketest/SKILL.md
@@ -23,11 +23,10 @@ the pTOS tree). Relevant outputs:
 | `virt-arm_defconfig` | qemu-system-arm | `virt-arm.elf` | `-M virt,highmem=off -cpu cortex-a7` (headless) |
 | `virt-m68k_defconfig` | qemu-system-m68k | `virt-m68k.elf` | `-M virt -cpu m68020` (headless) |
 
-Atari configs build with the default mint toolchain (`m68k-atari-mint-`, a.out)
+Atari configs build with the default mintelf toolchain (`m68k-atari-mintelf-`)
 and produce symbols in `ptos512k.sym` (load in the Hatari debugger with
-`symbols <file>`; there is no `--symbols` CLI option). Only the virt-m68k
-image is pinned to the ELF toolchain (`BUILD_TOOLCHAIN_MINTELF=y`,
-`m68k-atari-mintelf-`), since QEMU's `-kernel` loader needs an
+`symbols <file>`; there is no `--symbols` CLI option). The virt-m68k image is
+also ELF (`BUILD_TOOLCHAIN_MINTELF=y`), since QEMU's `-kernel` loader needs an
 `elf32-m68k`-format kernel.
 
 ## Hatari smoke test (m68k Atari)

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -41,13 +41,14 @@ runs:
     # A second, separate PPA (vriviere/mintelf, not vriviere/ppa) provides
     # the ELF-based toolchain (m68k-atari-mintelf-*, install prefix distinct
     # from cross-mint-essential's a.out one, so both coexist without
-    # conflict). MACHINE_VIRT_M68K is the only target that needs it: it
-    # links a real ELF image for QEMU's -kernel loader (emutos.ld forces
-    # OUTPUT_FORMAT(elf32-m68k) for it), and the a.out toolchain's linker
-    # has no elf32-m68k target compiled in at all. Installed unconditionally
-    # for every m68k job regardless of which configs it happens to build,
-    # rather than threading "does this job's matrix include virt-m68k"
-    # through to this composite action.
+    # conflict). It is the default m68k toolchain (Kconfig.machine), so
+    # every m68k build uses it. It is also the only toolchain that can
+    # produce the real ELF image MACHINE_VIRT_M68K needs for QEMU's -kernel
+    # loader (emutos.ld forces OUTPUT_FORMAT(elf32-m68k) for it, and the
+    # a.out toolchain's linker has no elf32-m68k target compiled in at
+    # all). Installed unconditionally for every m68k job regardless of
+    # which configs it happens to build, rather than threading "does this
+    # job's matrix include virt-m68k" through to this composite action.
     - name: Install the m68k cross toolchain
       if: inputs.arch == 'm68k'
       shell: bash

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -41,14 +41,15 @@ runs:
     # A second, separate PPA (vriviere/mintelf, not vriviere/ppa) provides
     # the ELF-based toolchain (m68k-atari-mintelf-*, install prefix distinct
     # from cross-mint-essential's a.out one, so both coexist without
-    # conflict). It is the default m68k toolchain (Kconfig.machine), so
-    # every m68k build uses it. It is also the only toolchain that can
-    # produce the real ELF image MACHINE_VIRT_M68K needs for QEMU's -kernel
-    # loader (emutos.ld forces OUTPUT_FORMAT(elf32-m68k) for it, and the
-    # a.out toolchain's linker has no elf32-m68k target compiled in at
-    # all). Installed unconditionally for every m68k job regardless of
-    # which configs it happens to build, rather than threading "does this
-    # job's matrix include virt-m68k" through to this composite action.
+    # conflict). It is the default m68k toolchain (Kconfig.machine), so a
+    # default m68k build uses it unless the choice is overridden. It is
+    # also the only toolchain that can produce the real ELF image
+    # MACHINE_VIRT_M68K needs for QEMU's -kernel loader (emutos.ld forces
+    # OUTPUT_FORMAT(elf32-m68k) for it, and the a.out toolchain's linker
+    # has no elf32-m68k target compiled in at all). Installed
+    # unconditionally for every m68k job regardless of which configs it
+    # happens to build, rather than threading "does this job's matrix
+    # include virt-m68k" through to this composite action.
     - name: Install the m68k cross toolchain
       if: inputs.arch == 'm68k'
       shell: bash

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,8 +29,8 @@ make                     # build
 There are no per-target make goals such as `make rpi2` or `make 512`; each is a
 defconfig in `configs/`. Requirements are GNU make, `kconfiglib`
 (`pip3 install kconfiglib`), and a cross toolchain: `arm-none-eabi-*` for the
-Raspberry Pi, and for m68k one of `m68k-atari-mint-` (the default),
-`m68k-atari-mintelf-` or a bare `m68k-elf-`, picked under "m68k toolchain" in
+Raspberry Pi, and for m68k one of `m68k-atari-mintelf-` (the default),
+`m68k-atari-mint-` or a bare `m68k-elf-`, picked under "m68k toolchain" in
 the Toolchain menu. See `doc/install.txt` for where to get them.
 
 ## Configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,8 @@ make                     # build the image named in the "is ready" line
 
 Requirements: GNU make, `pip3 install kconfiglib`, and a cross toolchain —
 `arm-none-eabi-*` for the Raspberry Pi, and for everything else one of the
-three offered under "m68k toolchain" in the Toolchain menu: `m68k-atari-mint-`
-(cross-mint, the default), `m68k-atari-mintelf-`, or a bare `m68k-elf-`.  That
+three offered under "m68k toolchain" in the Toolchain menu: `m68k-atari-mintelf-`
+(the default), `m68k-atari-mint-` (cross-mint), or a bare `m68k-elf-`.  That
 choice sets both the prefix and the flags; `doc/install.txt` says where to get
 them.
 

--- a/Kconfig.machine
+++ b/Kconfig.machine
@@ -289,11 +289,16 @@ choice
 
 config BUILD_TOOLCHAIN_MINT
 	bool "m68k-atari-mint (cross-mint)"
+	depends on !MACHINE_VIRT_M68K
 	help
 	  Vincent Rivière's cross-mint tools, the older a.out toolchain
 	  EmuTOS has traditionally been built with.  It emits a.out objects
 	  and already gives external symbols a leading underscore, so it
 	  needs no special flags.
+
+	  Not available for MACHINE_VIRT_M68K, whose link is forced to
+	  OUTPUT_FORMAT(elf32-m68k) by emutos.ld (QEMU's -kernel loader
+	  needs a real ELF image) -- this toolchain's linker cannot emit it.
 
 	  http://vincent.riviere.free.fr/soft/m68k-atari-mint/
 

--- a/Kconfig.machine
+++ b/Kconfig.machine
@@ -281,7 +281,7 @@ menu "Toolchain"
 choice
 	prompt "m68k toolchain"
 	depends on ARCH_M68K
-	default BUILD_TOOLCHAIN_MINT
+	default BUILD_TOOLCHAIN_MINTELF
 	help
 	  Which of the m68k toolchains to build with.  This selects the
 	  compiler prefix and the flags the toolchain needs; both can still
@@ -290,21 +290,22 @@ choice
 config BUILD_TOOLCHAIN_MINT
 	bool "m68k-atari-mint (cross-mint)"
 	help
-	  Vincent Rivière's cross-mint tools, the toolchain EmuTOS has always
-	  been built with.  It emits a.out objects and already gives external
-	  symbols a leading underscore, so it needs no special flags.
+	  Vincent Rivière's cross-mint tools, the older a.out toolchain
+	  EmuTOS has traditionally been built with.  It emits a.out objects
+	  and already gives external symbols a leading underscore, so it
+	  needs no special flags.
 
 	  http://vincent.riviere.free.fr/soft/m68k-atari-mint/
 
 config BUILD_TOOLCHAIN_MINTELF
 	bool "m68k-atari-mintelf"
 	help
-	  Vincent Rivière's newer ELF based toolchain for MiNT.  Being an ELF
-	  toolchain it is built with the same flags as the bare m68k-elf one
-	  below: -fleading-underscore to match the hand written assembler,
-	  --register-prefix-optional to let it write d0 rather than %d0, and
-	  -DELF_TOOLCHAIN for the parts of the sources and of emutos.ld that
-	  differ between a.out and ELF.
+	  Vincent Rivière's newer ELF based toolchain for MiNT, the default.
+	  Being an ELF toolchain it is built with the same flags as the bare
+	  m68k-elf one below: -fleading-underscore to match the hand written
+	  assembler, --register-prefix-optional to let it write d0 rather
+	  than %d0, and -DELF_TOOLCHAIN for the parts of the sources and of
+	  emutos.ld that differ between a.out and ELF.
 
 	  http://vincent.riviere.free.fr/soft/m68k-atari-mintelf/
 

--- a/configs/virt-m68k_defconfig
+++ b/configs/virt-m68k_defconfig
@@ -30,5 +30,6 @@ CONF_WITH_IDE=n
 # OUTPUT_FORMAT(elf32-m68k) for MACHINE_VIRT_M68K (QEMU's -kernel loader
 # needs a real ELF image, not a flat binary), and the a.out toolchain's
 # linker has no elf32-m68k target compiled in at all ("target elf32-m68k
-# not found").  The default mintelf toolchain provides it, so nothing needs
-# to be set here; only a hand-picked cross-mint choice would break this.
+# not found").  Kconfig forbids the cross-mint toolchain for this machine
+# (BUILD_TOOLCHAIN_MINT depends on !MACHINE_VIRT_M68K), so the default
+# mintelf is guaranteed; nothing needs pinning in this defconfig.

--- a/configs/virt-m68k_defconfig
+++ b/configs/virt-m68k_defconfig
@@ -26,11 +26,9 @@ CPUFLAGS="-m68020"
 # to the same override already used by MACHINE_RPI and MACHINE_VIRT_ARM.
 CONF_WITH_IDE=n
 
-# Unlike every other m68k target, this one is pinned to the ELF toolchain
-# rather than leaving the choice to the environment: emutos.ld forces
+# This target must be built with an ELF-capable toolchain: emutos.ld forces
 # OUTPUT_FORMAT(elf32-m68k) for MACHINE_VIRT_M68K (QEMU's -kernel loader
-# needs a real ELF image, not a flat binary), and the default a.out
-# toolchain's linker has no elf32-m68k target compiled in at all ("target
-# elf32-m68k not found" -- found via CI, which only installs the a.out
-# toolchain and has no ELF-capable one without this).
-BUILD_TOOLCHAIN_MINTELF=y
+# needs a real ELF image, not a flat binary), and the a.out toolchain's
+# linker has no elf32-m68k target compiled in at all ("target elf32-m68k
+# not found").  The default mintelf toolchain provides it, so nothing needs
+# to be set here; only a hand-picked cross-mint choice would break this.

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -3,24 +3,25 @@ Installing:
 You will need a (cross-)GCC toolchain for the machine you are building for:
 
   Atari, ARAnyM, Amiga, ColdFire (m68k)
-      Vincent Rivière's m68k-atari-mint cross-tools, which is what the
-      build expects by default:
-      http://vincent.riviere.free.fr/soft/m68k-atari-mint/
+      Vincent Rivière's m68k-atari-mintelf ELF-based tools, which is what
+      the build expects by default:
+      http://vincent.riviere.free.fr/soft/m68k-atari-mintelf/
 
       On Debian and Ubuntu they are packaged, which is by far the quickest
       way to get a working toolchain.  This is also what the CI build
       installs, see .github/actions/setup-toolchain/action.yml:
 
-          sudo add-apt-repository ppa:vriviere/ppa
+          sudo add-apt-repository ppa:vriviere/mintelf
           sudo apt-get update
-          sudo apt-get install cross-mint-essential
+          sudo apt-get install cross-mintelf-essential
 
       Two other m68k toolchains are supported, chosen under "m68k
       toolchain" in the Toolchain menu:
 
-          m68k-atari-mint       cross-mint, the default, as above
-          m68k-atari-mintelf    Vincent Rivière's newer ELF based tools,
+          m68k-atari-mintelf    the newer ELF based tools, the default,
                                 http://vincent.riviere.free.fr/soft/m68k-atari-mintelf/
+          m68k-atari-mint       the older cross-mint a.out tools,
+                                http://vincent.riviere.free.fr/soft/m68k-atari-mint/
           bare m68k-elf         a plain m68k-elf toolchain, no MiNT at all
 
       Picking one selects both the compiler prefix and the flags it needs;

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -8,14 +8,15 @@ You will need a (cross-)GCC toolchain for the machine you are building for:
       http://vincent.riviere.free.fr/soft/m68k-atari-mintelf/
 
       On Debian and Ubuntu they are packaged, which is by far the quickest
-      way to get a working toolchain.  The CI build installs this package
-      from the same PPA too, plus the older cross-mint one for the a.out
-      choice and the tools "make release" needs, see
-      .github/actions/setup-toolchain/action.yml:
+      way to get a working toolchain:
 
           sudo add-apt-repository ppa:vriviere/mintelf
           sudo apt-get update
           sudo apt-get install cross-mintelf-essential
+
+      The CI build installs this package from the same PPA too, plus the
+      older cross-mint one for the a.out choice and the tools "make
+      release" needs, see .github/actions/setup-toolchain/action.yml.
 
       Three m68k toolchains are offered, chosen under "m68k toolchain"
       in the Toolchain menu:

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -8,8 +8,10 @@ You will need a (cross-)GCC toolchain for the machine you are building for:
       http://vincent.riviere.free.fr/soft/m68k-atari-mintelf/
 
       On Debian and Ubuntu they are packaged, which is by far the quickest
-      way to get a working toolchain.  This is also what the CI build
-      installs, see .github/actions/setup-toolchain/action.yml:
+      way to get a working toolchain.  The CI build installs this package
+      from the same PPA too, plus the older cross-mint one for the a.out
+      choice and the tools "make release" needs, see
+      .github/actions/setup-toolchain/action.yml:
 
           sudo add-apt-repository ppa:vriviere/mintelf
           sudo apt-get update

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -17,8 +17,8 @@ You will need a (cross-)GCC toolchain for the machine you are building for:
           sudo apt-get update
           sudo apt-get install cross-mintelf-essential
 
-      Two other m68k toolchains are supported, chosen under "m68k
-      toolchain" in the Toolchain menu:
+      Three m68k toolchains are offered, chosen under "m68k toolchain"
+      in the Toolchain menu:
 
           m68k-atari-mintelf    the newer ELF based tools, the default,
                                 http://vincent.riviere.free.fr/soft/m68k-atari-mintelf/

--- a/emutos.ld
+++ b/emutos.ld
@@ -274,6 +274,7 @@ ELF_LIB_REF(__divsi3)
 ELF_LIB_REF(__modsi3)
 ELF_LIB_REF(__udivsi3)
 ELF_LIB_REF(__umodsi3)
+ELF_LIB_REF(__bswapsi2)
 ELF_LIB_REF(__aeabi_udiv)
 ELF_LIB_REF(__aeabi_udivmod)
 #endif


### PR DESCRIPTION
## What

Switch the default m68k toolchain from Vincent Rivière's older a.out
cross-mint tools (`m68k-atari-mint-`, `BUILD_TOOLCHAIN_MINT`) to his newer
ELF-based toolchain (`m68k-atari-mintelf-`, `BUILD_TOOLCHAIN_MINTELF`, GCC
13.x), so a fresh `make <config>_defconfig && make` for any m68k target
builds the same way `virt-m68k_defconfig` already did.

## Changes

- `Kconfig.machine`: make `BUILD_TOOLCHAIN_MINTELF` the default m68k
  toolchain choice, and forbid the cross-mint choice for
  `MACHINE_VIRT_M68K` — that target links `OUTPUT_FORMAT(elf32-m68k)`
  for QEMU's `-kernel` loader, which the a.out linker can't emit, so the
  combination could never link; it's now unselectable instead of failing
  at link time. cross-mint stays available for every other m68k target.
- `emutos.ld`: add `ELF_LIB_REF(__bswapsi2)` under the ELF toolchain.
  `ELF_LIB_REF(sym)` defines `_<sym>` as an alias for libgcc's `<sym>`,
  because EmuTOS is built with `-fleading-underscore` while libgcc isn't.
  Newer libgcc emits references to `__bswapsi2` (a byte-swap helper), so
  the leading-underscore alias `___bswapsi2` must be provided for the link
  to resolve.
- `virt-m68k_defconfig`: drop the now-redundant toolchain pin (`make
  savedefconfig` strips it, since it equals the new default); keep an
  updated comment on why this target needs an ELF-capable linker and that
  Kconfig now enforces one.
- Docs (`doc/install.txt`, CLAUDE.md, `.github/copilot-instructions.md`,
  `.claude/skills/ptos-smoketest/SKILL.md`) and the CI setup
  (`setup-toolchain/action.yml`) comments now present mintelf as the default.

## Verification

- ROM size limits (the key risk of a newer compiler) all hold, built with
  mintelf:
  - `atari192_defconfig` — 192 K exactly
  - `atari256_defconfig` — 256 K exactly
  - `atari512_defconfig` — 512 K exactly
- `atari512_defconfig` mintelf build smoke-tested under Hatari
  (`--machine ste`): boots to the GEM desktop.
- `virt-m68k.elf` builds with mintelf and boots to the AES `evnt_multi()`
  idle loop under QEMU (single benign FPU-probe illegal instruction).
- `kconfiglib`: `virt-m68k_defconfig` resolves to `BUILD_TOOLCHAIN_MINTELF`
  with cross-mint hidden; an explicit `BUILD_TOOLCHAIN_MINT=y` in a
  virt-m68k defconfig is rejected; atari512 still lists cross-mint as a
  selectable choice.

Fixes #128
