### PR TITLE
vdi: default hardware mouse cursor on RPi 1-3, with runtime software fallback

### DIFF
--- a/vdi/Kconfig
+++ b/vdi/Kconfig
@@ -56,9 +56,17 @@ config CONF_WITH_VDI_EXTENSIONS
 config CONF_RASPI_MOUSE_CURSOR
 	bool "Use the Raspberry Pi hardware mouse cursor"
 	depends on MACHINE_RPI
+	default y if TARGET_RPI1 || TARGET_RPI2 || TARGET_RPI3
 	default n
 	help
 	  Draw the mouse pointer using the hardware cursor of the VideoCore
 	  GPU instead of drawing it into the framebuffer.
+
+	  Enabled by default on real Pi 1-3 hardware, where it works. RPi4's
+	  mailbox/GPU differences haven't been verified yet, so it defaults
+	  off there (see issue #131). QEMU does not emulate the cursor
+	  mailbox property tags; when they fail at runtime, the software
+	  cursor is used instead regardless of this setting, so it is safe
+	  to leave enabled for QEMU-targeted configs too.
 
 endmenu

--- a/vdi/machine/raspi/raspi_mouse.c
+++ b/vdi/machine/raspi/raspi_mouse.c
@@ -33,22 +33,24 @@ static ULONG last_sprite_checksum;
 static ULONG pointer_image[16][16];
 
 static ULONG raspi_cur_calc_checksum(Mcdb *sprite);
-static void raspi_hw_cur_set_sprite(Mcdb *sprite);
+static BOOL raspi_hw_cur_set_sprite(Mcdb *sprite);
 
-void raspi_hw_cur_display(Mcdb *sprite, WORD x, WORD y)
+BOOL raspi_hw_cur_display(Mcdb *sprite, WORD x, WORD y)
 {
     ULONG checksum = raspi_cur_calc_checksum(sprite);
+    prop_tag_cursor_state_t tag;
+
     if (checksum != last_sprite_checksum)
     {
-        raspi_hw_cur_set_sprite(sprite);
+        if (!raspi_hw_cur_set_sprite(sprite))
+            return FALSE;
         last_sprite_checksum = checksum;
     }
-    prop_tag_cursor_state_t tag;
     tag.enable = 1;
     tag.pos_x = x;
     tag.pos_y = y;
     tag.flags = CURSOR_FLAGS_FB_COORDS;
-    raspi_prop_get_tag(PROPTAG_SET_CURSOR_STATE, &tag, sizeof(prop_tag_cursor_state_t), 4*4);
+    return raspi_prop_get_tag(PROPTAG_SET_CURSOR_STATE, &tag, sizeof(prop_tag_cursor_state_t), 4*4);
 }
 
 
@@ -64,7 +66,7 @@ static ULONG raspi_cur_calc_checksum(Mcdb *sprite)
     return res;
 }
 
-static void raspi_hw_cur_set_sprite(Mcdb *sprite)
+static BOOL raspi_hw_cur_set_sprite(Mcdb *sprite)
 {
     int x,y;
     ULONG fg = raspi_dflt_palette[sprite->fg_col] | 0xff000000;
@@ -72,6 +74,8 @@ static void raspi_hw_cur_set_sprite(Mcdb *sprite)
     ULONG clear = 0x00000000;
     UWORD* mask = sprite->maskdata;
     UWORD* data = sprite->maskdata+1;
+    prop_tag_cursor_info_t tag;
+
     for(y=0; y<16; y++, mask += 2, data += 2)
     {
         UWORD pixel_mask = 0x8000;
@@ -81,10 +85,9 @@ static void raspi_hw_cur_set_sprite(Mcdb *sprite)
         }
     }
 
-    prop_tag_cursor_info_t tag;
     tag.width = tag.height = 16;
     tag.pixels = phys_to_bus((ULONG)pointer_image);
     tag.hotspot_x = sprite->xhot;
     tag.hotspot_y = sprite->yhot;
-    raspi_prop_get_tag(PROPTAG_SET_CURSOR_INFO, &tag, sizeof(prop_tag_cursor_info_t), 6*4);
+    return raspi_prop_get_tag(PROPTAG_SET_CURSOR_INFO, &tag, sizeof(prop_tag_cursor_info_t), 6*4);
 }

--- a/vdi/machine/raspi/raspi_mouse.h
+++ b/vdi/machine/raspi/raspi_mouse.h
@@ -11,7 +11,12 @@
 #   define RASPI_MOUSE_H
 #   ifdef MACHINE_RPI
 
-void raspi_hw_cur_display(Mcdb *sprite, WORD x, WORD y);
+/*
+ * Draws the hardware cursor via the VideoCore mailbox. Returns FALSE if the
+ * firmware doesn't implement the cursor property tags (e.g. under QEMU),
+ * so callers can fall back to a software-drawn cursor.
+ */
+BOOL raspi_hw_cur_display(Mcdb *sprite, WORD x, WORD y);
 
 #   endif /* MACHINE_RPI */
 #endif /* RASPI_MOUSE_H */

--- a/vdi/vdi_mouse.c
+++ b/vdi/vdi_mouse.c
@@ -871,8 +871,11 @@ static void cur_display_clip(WORD op,Mcdb *sprite,MCS *mcs,UWORD *mask_start,UWO
  * within one screen word (per plane), so we only save 32 bytes/plane.
  */
 
-#if defined(MACHINE_RPI) && !CONF_RASPI_MOUSE_CURSOR
-/* The mcs struct is not big enough for a 16bpp packed truecolor cursor */
+#ifdef MACHINE_RPI
+/* The mcs struct is not big enough for a 16bpp packed truecolor cursor.
+ * Also serves as the software cursor's fallback save area when
+ * CONF_RASPI_MOUSE_CURSOR is set but the hardware cursor is unavailable at
+ * runtime -- see raspi_hw_cursor_available below. */
 static struct {
     WORD x;
     WORD y;
@@ -880,19 +883,39 @@ static struct {
     WORD height;
     UWORD buffer[16*16];
 } mouse_save;
+
+#if CONF_RASPI_MOUSE_CURSOR
+/*
+ * Starts TRUE and latches to FALSE the first time the hardware cursor's
+ * mailbox calls fail (e.g. under QEMU, or firmware that doesn't implement
+ * the cursor property tags). Once latched off, cur_display() stops trying
+ * the hardware cursor and uses the software cursor for the rest of the
+ * session -- a failed mailbox round-trip is not worth repeating on every
+ * draw call.
+ */
+static BOOL raspi_hw_cursor_available = TRUE;
+#endif
 #endif
 
 static void cur_display (Mcdb *sprite, MCS *mcs, WORD x, WORD y)
 {
 #ifdef MACHINE_RPI
-#if CONF_RASPI_MOUSE_CURSOR
-    raspi_hw_cur_display(sprite, x, y);
-#else
     int row_count;
     UWORD *addr;
     UWORD *data;
     UWORD cdb_fg, cdb_bg, current_bit, start_bit, end_bit;
     UWORD *save_data = mouse_save.buffer;
+
+#if CONF_RASPI_MOUSE_CURSOR
+    if (raspi_hw_cursor_available && raspi_hw_cur_display(sprite, x, y))
+    {
+        mouse_save.height = 0;  /* hardware overlay drawn; nothing to restore */
+        return;
+    }
+    /* First failure (or already latched off): use the software cursor
+     * below, and don't try the hardware cursor again this session. */
+    raspi_hw_cursor_available = FALSE;
+#endif
 
     x -= sprite->xhot;          /* x = left side of destination block */
     y -= sprite->yhot;          /* y = top of destination block */
@@ -953,7 +976,6 @@ static void cur_display (Mcdb *sprite, MCS *mcs, WORD x, WORD y)
         }
         data += 2;
     }
-#endif
 #else
     int row_count, plane, inc, op, dst_inc;
     UWORD * addr, * mask_start;
@@ -1148,11 +1170,14 @@ static void cur_replace (MCS *mcs)
             dst += dst_inc;         /* next row of screen */
         }
     }
-#elif !CONF_RASPI_MOUSE_CURSOR
+#else
     int row, col;
     UWORD* addr;
     UWORD* data = mouse_save.buffer;
 
+    /* mouse_save.height is 0 whenever the hardware cursor drew this frame
+     * (see cur_display()), so this is a no-op in that case -- there is
+     * nothing to restore. */
     for (row = 0; row<mouse_save.height; row++)
     {
         addr = get_start_addr(mouse_save.x, mouse_save.y+row);


### PR DESCRIPTION
Fixes #131

## What changed

- `CONF_RASPI_MOUSE_CURSOR` now defaults to `y` for `TARGET_RPI1`,
  `TARGET_RPI2`, and `TARGET_RPI3` (real hardware, where it works today).
  `TARGET_RPI4` stays at `default n` pending separate verification of its
  mailbox/GPU differences.
- `raspi_hw_cur_display()` (and the sprite-upload helper it calls,
  `raspi_hw_cur_set_sprite()`) now return `BOOL` and propagate mailbox
  failure instead of discarding `raspi_prop_get_tag()`'s result.
- `cur_display()` in `vdi/vdi_mouse.c` tries the hardware cursor first when
  `CONF_RASPI_MOUSE_CURSOR=y`. If the VideoCore firmware rejects the cursor
  property tags (as QEMU does, since it doesn't emulate them), it latches a
  static flag off and uses the software cursor for the rest of the session
  -- no repeated failing mailbox round-trips on every draw.
- `cur_replace()`'s software-restore path is now unconditional for
  `MACHINE_RPI` (it was previously compiled out under
  `CONF_RASPI_MOUSE_CURSOR=y`); it's a no-op whenever the hardware cursor
  drew the frame, since `mouse_save.height` is left at 0 in that case.

This means one build (`CONF_RASPI_MOUSE_CURSOR=y`, now the default on Pi
1-3) runs correctly on both real hardware and QEMU, rather than needing a
separate QEMU-oriented config just to turn the option off.

## Testing

- Built and booted `rpi1_defconfig`, `rpi2_defconfig`, `rpi3_defconfig`,
  `rpi4_defconfig` (`arm-none-eabi-gcc`), confirming `CONF_RASPI_MOUSE_CURSOR`
  lands as `y`/`y`/`y`/`n` respectively.
- Booted `rpi1_defconfig` and `rpi2_defconfig` under QEMU (`raspi1ap` /
  `raspi2b`) -- these don't emulate the cursor mailbox tags, so this
  exercises the new runtime fallback. Both reach `AES: EMUDESK:
  evnt_multi()` with no `guest_errors`.
- `make gitready` passes.
- Real-hardware verification of the hardware cursor itself is out of scope
  here (tracked under #35's hardware-validation work), same as #87.