### PR TITLE
VDI: raster operations (vro_cpyfm/vrt_cpyfm/vr_trnfm/bit_blt) through the backend

### DIFF
--- a/vdi/vdi_backend.h
+++ b/vdi/vdi_backend.h
@@ -11,6 +11,7 @@
 #include "screen_mode.h"
 #include "vdi_defs.h"
 #include "vdi_textblit.h"
+#include "vdi_raster.h"
 
 /*
  * A NULL slot means "this backend does not implement this primitive" --
@@ -19,10 +20,9 @@
  * supports (see vdi_backend_select()), so an incompatible fallback can
  * never happen by construction.
  *
- * This table currently only covers the primitives this slice converts.
- * Follow-up slices (line/vline, raster copy, mouse cursor, full palette
- * -- issue #35 parts 2b/5) add their own slots when they actually
- * implement them.
+ * This table currently covers the primitives converted so far. Follow-up
+ * slices (line/vline, mouse cursor, full palette -- issue #35 parts 2b/5)
+ * add their own slots when they actually implement them.
  */
 typedef struct vdi_backend_ops {
     BOOL (*open)(Vwk *vwk);
@@ -33,6 +33,7 @@ typedef struct vdi_backend_ops {
     void (*put_pixel)(WORD x, WORD y, UWORD color);
     void (*fill_rect)(const VwkAttrib *attr, const Rect *rect);
     void (*text_blit)(LOCALVARS *vars);
+    void (*raster_copy)(struct raster_t *raster, struct blit_frame *info);
 } vdi_backend_ops;
 
 /*

--- a/vdi/vdi_backend_planar.c
+++ b/vdi/vdi_backend_planar.c
@@ -29,4 +29,5 @@ const vdi_backend_ops planar_backend_ops = {
     planar_put_pixel,
     planar_fill_rect,
     planar_text_blit,
+    planar_raster_copy,
 };

--- a/vdi/vdi_backend_truecolor.c
+++ b/vdi/vdi_backend_truecolor.c
@@ -480,6 +480,146 @@ static void truecolor_text_blit(LOCALVARS *vars)
     }
 }
 
+/*
+ * apply a VDI boolean raster-op (see BM_* in vdi_raster.h) to a source
+ * and destination pixel, a whole 16-bit RGB565 word at a time -- the
+ * same semantics the planar blitter emulator's do_blit() applies per
+ * bitplane in vdi_raster.c, just applied once per pixel since this
+ * backend has no planes to loop over.
+ */
+static UWORD apply_raster_op(WORD op, UWORD src, UWORD dst)
+{
+    switch (op & 0x0f) {
+    case BM_ALL_WHITE:  return 0x0000;
+    case BM_S_AND_D:    return (UWORD)(src & dst);
+    case BM_S_AND_NOTD: return (UWORD)(src & ~dst);
+    case BM_S_ONLY:     return src;
+    case BM_NOTS_AND_D: return (UWORD)(~src & dst);
+    case BM_D_ONLY:     return dst;
+    case BM_S_XOR_D:    return (UWORD)(src ^ dst);
+    case BM_S_OR_D:     return (UWORD)(src | dst);
+    case BM_NOT_SORD:   return (UWORD)~(src | dst);
+    case BM_NOT_SXORD:  return (UWORD)~(src ^ dst);
+    case BM_NOT_D:      return (UWORD)~dst;
+    case BM_S_OR_NOTD:  return (UWORD)(src | ~dst);
+    case BM_NOT_S:      return (UWORD)~src;
+    case BM_NOTS_OR_D:  return (UWORD)(~src | dst);
+    case BM_NOT_SANDD:  return (UWORD)~(src & dst);
+    case BM_ALL_BLACK:  return 0xffff;
+    default:            return dst;
+    }
+}
+
+/*
+ * truecolor raster copy: backs vro_cpyfm()/vrt_cpyfm()/linea_raster()
+ * (see cpy_raster() in vdi_raster.c) for the packed RGB565 screen.
+ *
+ * setup_info() only ever reports s_nxwd/d_nxwd == 2 and plane_ct == 1 for
+ * a screen-side MFDB with this backend selected -- a screen word is
+ * already one whole pixel, there are no bitplanes to interleave.
+ * Anything else (a multi-plane colour-icon MFDB, see gr_colourblit() in
+ * aes/gemgraf.c) falls outside what this backend can interpret; rather
+ * than misreading plane-interleaved memory as packed pixels, it is
+ * silently skipped -- colour icons don't render via this path yet, which
+ * is no worse than the memory corruption the planar blitter emulator
+ * would otherwise produce here.
+ */
+static void truecolor_raster_copy(struct raster_t *raster, struct blit_frame *info)
+{
+    WORD y;
+
+    if (info->d_nxwd != 2)
+        return;
+
+    if (raster->transparent) {
+        /*
+         * 1bpp source (an icon shape/mask) to packed colour destination.
+         * fg_col/bg_col are hardware palette indices; raster->mode is the
+         * write mode requested by INTIN[0] (MD_REPLACE/TRANS/XOR/ERASE)
+         * -- see the switch in cpy_raster() this mirrors, and
+         * truecolor_text_blit() above for the same source-bit-walking
+         * idiom applied to glyphs instead of icons.
+         */
+        UWORD fgpix = truecolor_pixel_for_index((WORD)raster->fg_col);
+        UWORD bgpix = truecolor_pixel_for_index((WORD)raster->bg_col);
+
+        for (y = 0; y < info->b_ht; y++) {
+            const UBYTE *srow = (const UBYTE *)info->s_form
+                + (LONG)(info->s_ymin + y) * info->s_nxln;
+            UBYTE *drow = (UBYTE *)info->d_form
+                + (LONG)(info->d_ymin + y) * info->d_nxln;
+            const UBYTE *p = srow + (LONG)(info->s_xmin >> 4) * info->s_nxwd;
+            UWORD *q = (UWORD *)(drow + (LONG)info->d_xmin * info->d_nxwd);
+            UWORD mask = 0x8000 >> (info->s_xmin & 0x0f);
+            WORD x;
+
+            for (x = 0; x < info->b_wd; x++) {
+                BOOL set = (get_src_word(p) & mask) != 0;
+
+                switch (raster->mode) {
+                case MD_REPLACE:
+                    *q = set ? fgpix : bgpix;
+                    break;
+                case MD_TRANS:
+                    if (set)
+                        *q = fgpix;
+                    break;
+                case MD_XOR:
+                    if (set)
+                        *q = ~*q;
+                    break;
+                case MD_ERASE:
+                    if (!set)
+                        *q = bgpix;
+                    break;
+                }
+                q++;
+
+                rorw1(mask);
+                if (mask == 0x8000)
+                    p += 2;
+            }
+        }
+        return;
+    }
+
+    /* COPY RASTER OPAQUE: packed destination word == packed source word */
+    if (info->s_nxwd != 2)
+        return;
+
+    {
+        BOOL forward_y = TRUE, forward_x = TRUE;
+
+        /*
+         * Source and destination can be the same screen buffer (e.g. a
+         * window drag or scroll) with overlapping rectangles -- pick a
+         * scan direction that never overwrites source pixels before
+         * they've been read, the same way bit_blt() picks a starting
+         * corner for the planar blitter.
+         */
+        if (info->s_form == info->d_form) {
+            if (info->d_ymin > info->s_ymin)
+                forward_y = FALSE;
+            else if ((info->d_ymin == info->s_ymin) && (info->d_xmin > info->s_xmin))
+                forward_x = FALSE;
+        }
+
+        for (y = 0; y < info->b_ht; y++) {
+            WORD row = forward_y ? y : (info->b_ht - 1 - y);
+            const UWORD *srow = (const UWORD *)((const UBYTE *)info->s_form
+                + (LONG)(info->s_ymin + row) * info->s_nxln + (LONG)info->s_xmin * info->s_nxwd);
+            UWORD *drow = (UWORD *)((UBYTE *)info->d_form
+                + (LONG)(info->d_ymin + row) * info->d_nxln + (LONG)info->d_xmin * info->d_nxwd);
+            WORD x;
+
+            for (x = 0; x < info->b_wd; x++) {
+                WORD col = forward_x ? x : (info->b_wd - 1 - x);
+                drow[col] = apply_raster_op(info->op_tab[0], srow[col], drow[col]);
+            }
+        }
+    }
+}
+
 static BOOL truecolor_open(Vwk *vwk)
 {
     (void)vwk;
@@ -499,4 +639,5 @@ const vdi_backend_ops packed_truecolor_backend_ops = {
     truecolor_put_pixel,
     truecolor_fill_rect,
     truecolor_text_blit,
+    truecolor_raster_copy,
 };

--- a/vdi/vdi_raster.c
+++ b/vdi/vdi_raster.c
@@ -982,8 +982,10 @@ cpy_raster(struct raster_t *raster, struct blit_frame *info)
     {
         const vdi_backend_ops *backend = vdi_screen_backend();
 
-        /* see the comment in get_start_addr() (vdi_misc.c) */
-        if (backend)
+        /* see the comment in get_start_addr() (vdi_misc.c); a NULL
+         * raster_copy slot means a backend that doesn't implement this
+         * primitive (see the vdi_backend_ops comment in vdi_backend.h) */
+        if (backend && backend->raster_copy)
             backend->raster_copy(raster, info);
     }
 #else

--- a/vdi/vdi_raster.c
+++ b/vdi/vdi_raster.c
@@ -13,6 +13,8 @@
 #include "config.h"
 #include "portab.h"
 #include "vdi_defs.h"
+#include "vdi_raster.h"
+#include "vdi_backend.h"
 #include "blitter.h"
 #include "../bios/lineavars.h"
 #include "../bios/tosvars.h"
@@ -100,24 +102,6 @@ static const UBYTE skew_flags[8] = {
 #endif
 
 
-/* bitblt modes */
-#define BM_ALL_WHITE   0
-#define BM_S_AND_D     1
-#define BM_S_AND_NOTD  2
-#define BM_S_ONLY      3
-#define BM_NOTS_AND_D  4
-#define BM_D_ONLY      5
-#define BM_S_XOR_D     6
-#define BM_S_OR_D      7
-#define BM_NOT_SORD    8
-#define BM_NOT_SXORD   9
-#define BM_NOT_D      10
-#define BM_S_OR_NOTD  11
-#define BM_NOT_S      12
-#define BM_NOTS_OR_D  13
-#define BM_NOT_SANDD  14
-#define BM_ALL_BLACK  15
-
 /* flag:1 SOURCE and PATTERN   flag:0 SOURCE only */
 #define PAT_FLAG        16
 
@@ -132,44 +116,6 @@ static const UBYTE skew_flags[8] = {
 #define XMAX_D  6       /* x of lower right of destination rectangle */
 #define YMAX_D  7       /* y of lower right of destination rectangle */
 
-
-/* 76-byte line-A BITBLT struct passing parameters to bitblt */
-struct blit_frame {
-    WORD b_wd;          /* +00 width of block in pixels */
-    WORD b_ht;          /* +02 height of block in pixels */
-    WORD plane_ct;      /* +04 number of consecutive planes to blt */
-    UWORD fg_col;       /* +06 foreground color (logic op table index:hi bit) */
-    UWORD bg_col;       /* +08 background color (logic op table index:lo bit) */
-    UBYTE op_tab[4];    /* +10 logic ops for all fore and background combos */
-    WORD s_xmin;        /* +14 minimum X: source */
-    WORD s_ymin;        /* +16 minimum Y: source */
-    UWORD * s_form;     /* +18 source form base address */
-    WORD s_nxwd;        /* +22 offset to next word in line  (in bytes) */
-    WORD s_nxln;        /* +24 offset to next line in plane (in bytes) */
-    WORD s_nxpl;        /* +26 offset to next plane from start of current plane */
-    WORD d_xmin;        /* +28 minimum X: destination */
-    WORD d_ymin;        /* +30 minimum Y: destination */
-    UWORD * d_form;     /* +32 destination form base address */
-    WORD d_nxwd;        /* +36 offset to next word in line  (in bytes) */
-    WORD d_nxln;        /* +38 offset to next line in plane (in bytes) */
-    WORD d_nxpl;        /* +40 offset to next plane from start of current plane */
-    UWORD * p_addr;     /* +42 address of pattern buffer   (0:no pattern) */
-    WORD p_nxln;        /* +46 offset to next line in pattern  (in bytes) */
-    WORD p_nxpl;        /* +48 offset to next plane in pattern (in bytes) */
-    WORD p_mask;        /* +50 pattern index mask */
-
-    /* these frame parameters are internally set */
-    WORD p_indx;        /* +52 initial pattern index */
-    UWORD * s_addr;     /* +54 initial source address */
-    WORD s_xmax;        /* +58 maximum X: source */
-    WORD s_ymax;        /* +60 maximum Y: source */
-    UWORD * d_addr;     /* +62 initial destination address */
-    WORD d_xmax;        /* +66 maximum X: destination */
-    WORD d_ymax;        /* +68 maximum Y: destination */
-    WORD inner_ct;      /* +70 blt inner loop initial count */
-    WORD dst_wr;        /* +72 destination form wrap (in bytes) */
-    WORD src_wr;        /* +74 source form wrap (in bytes) */
-};
 
 /* Raster definitions */
 typedef struct {
@@ -723,16 +669,6 @@ bit_blt (void)
 #endif
 
 
-/* common settings needed both by VDI and line-A raster
- * operations, but being given through different means.
- */
-struct raster_t {
-    VwkClip *clipper;
-    int clip;
-    int multifill;
-    int transparent;
-};
-
 /*
  * setup_pattern - if bit 5 of mode is set, use pattern with blit
  */
@@ -871,7 +807,18 @@ setup_info (struct raster_t *raster, struct blit_frame * info)
     else {
         /* source form is screen */
         info->s_form = (UWORD*) v_bas_ad;
-        info->s_nxwd = linea_vars.v_planes * 2;
+#if CONF_WITH_VDI_TRUECOLOR
+        /*
+         * The packed-truecolor backend has no bitplanes: each screen word
+         * is already one whole pixel, so the "next word" step is 2 bytes
+         * and there is a single conceptual plane -- see the comment on
+         * plane_ct below.
+         */
+        if (vdi_screen_is_truecolor())
+            info->s_nxwd = 2;
+        else
+#endif
+            info->s_nxwd = linea_vars.v_planes * 2;
         info->s_nxln = linea_vars.v_lin_wr;
     }
 
@@ -886,8 +833,17 @@ setup_info (struct raster_t *raster, struct blit_frame * info)
     else {
         /* destination form is screen */
         info->d_form = (UWORD*) v_bas_ad;
-        info->plane_ct = linea_vars.v_planes;
-        info->d_nxwd = linea_vars.v_planes * 2;
+#if CONF_WITH_VDI_TRUECOLOR
+        if (vdi_screen_is_truecolor()) {
+            info->plane_ct = 1;
+            info->d_nxwd = 2;
+        }
+        else
+#endif
+        {
+            info->plane_ct = linea_vars.v_planes;
+            info->d_nxwd = linea_vars.v_planes * 2;
+        }
         info->d_nxln = linea_vars.v_lin_wr;
 
         /* check if clipping is enabled, when destination is screen */
@@ -904,6 +860,14 @@ setup_info (struct raster_t *raster, struct blit_frame * info)
 
     info->s_nxpl = 2;           /* next plane offset (source) */
     info->d_nxpl = 2;           /* next plane offset (destination) */
+
+#if CONF_WITH_VDI_TRUECOLOR
+    /* the packed-truecolor backend's single conceptual plane above is
+     * always valid -- the check below only applies to the planar
+     * per-plane blitter. */
+    if (vdi_screen_is_truecolor())
+        return FALSE;
+#endif
 
     /* only 8, 4, 2 and 1 planes are valid (destination) */
     return info->plane_ct & ~0x000f;
@@ -930,6 +894,8 @@ cpy_raster(struct raster_t *raster, struct blit_frame *info)
         mode &= ~PAT_FLAG;      /* set bit to 0! */
         setup_pattern(raster, info);   /* fill in pattern related stuff */
     }
+
+    raster->mode = mode;        /* raw request, for the truecolor backend */
 
     /* if true, the plane count is invalid or clipping took all! */
     if (setup_info(raster, info))
@@ -973,6 +939,9 @@ cpy_raster(struct raster_t *raster, struct blit_frame *info)
             bg_col = 1;
         bg_col = MAP_COL[bg_col];
 
+        raster->fg_col = fg_col;    /* raw colors, for the truecolor backend */
+        raster->bg_col = bg_col;
+
         switch(mode) {
         case MD_TRANS:
             info->op_tab[0] = 04;    /* fg:0 bg:0  D' <- [not S] and D */
@@ -1009,12 +978,39 @@ cpy_raster(struct raster_t *raster, struct blit_frame *info)
         }
     }
 
+#if CONF_WITH_VDI_TRUECOLOR
+    {
+        const vdi_backend_ops *backend = vdi_screen_backend();
+
+        /* see the comment in get_start_addr() (vdi_misc.c) */
+        if (backend)
+            backend->raster_copy(raster, info);
+    }
+#else
     /*
-     * call assembler blit routine or C-implementation.  we call the
-     * assembler version if we're not on ColdFire and either
-     * (a) the blitter isn't configured, or
-     * (b) it's configured but not available.
+     * With the truecolor backend compiled out, planar is the only backend
+     * that can ever be selected -- call it directly instead of paying for
+     * vdi_screen_backend()'s self-init check and an indirect call the
+     * result of which is already known at compile time (see the comment
+     * on get_start_addr() in vdi_misc.c).
      */
+    planar_raster_copy(raster, info);
+#endif
+}
+
+/*
+ * planar_raster_copy - dispatch a fully-set-up blit_frame to the hardware
+ * blitter or its C/assembler emulation
+ *
+ * call assembler blit routine or C-implementation.  we call the
+ * assembler version if we're not on ColdFire and either
+ * (a) the blitter isn't configured, or
+ * (b) it's configured but not available.
+ */
+void
+planar_raster_copy(struct raster_t *raster, struct blit_frame *info)
+{
+    (void)raster;
     blit_info = info;
 
 #if ASM_BLIT_IS_AVAILABLE

--- a/vdi/vdi_raster.h
+++ b/vdi/vdi_raster.h
@@ -1,0 +1,110 @@
+/*
+ * vdi_raster.h - shared types for raster-copy backend dispatch
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+#ifndef VDI_RASTER_H
+#define VDI_RASTER_H
+
+#include "portab.h"
+#include "vdi_defs.h"
+
+/*
+ * Boolean raster-op codes (the 16 possible functions of source and
+ * destination bits), shared between the planar blitter emulator
+ * (do_blit() in vdi_raster.c) and the packed-truecolor backend's
+ * word-at-a-time copy (truecolor_raster_copy() in
+ * vdi_backend_truecolor.c).
+ */
+#define BM_ALL_WHITE   0
+#define BM_S_AND_D     1
+#define BM_S_AND_NOTD  2
+#define BM_S_ONLY      3
+#define BM_NOTS_AND_D  4
+#define BM_D_ONLY      5
+#define BM_S_XOR_D     6
+#define BM_S_OR_D      7
+#define BM_NOT_SORD    8
+#define BM_NOT_SXORD   9
+#define BM_NOT_D      10
+#define BM_S_OR_NOTD  11
+#define BM_NOT_S      12
+#define BM_NOTS_OR_D  13
+#define BM_NOT_SANDD  14
+#define BM_ALL_BLACK  15
+
+/* 76-byte line-A BITBLT struct passing parameters to bitblt */
+struct blit_frame {
+    WORD b_wd;          /* +00 width of block in pixels */
+    WORD b_ht;          /* +02 height of block in pixels */
+    WORD plane_ct;      /* +04 number of consecutive planes to blt */
+    UWORD fg_col;       /* +06 foreground color (logic op table index:hi bit) */
+    UWORD bg_col;       /* +08 background color (logic op table index:lo bit) */
+    UBYTE op_tab[4];    /* +10 logic ops for all fore and background combos */
+    WORD s_xmin;        /* +14 minimum X: source */
+    WORD s_ymin;        /* +16 minimum Y: source */
+    UWORD * s_form;     /* +18 source form base address */
+    WORD s_nxwd;        /* +22 offset to next word in line  (in bytes) */
+    WORD s_nxln;        /* +24 offset to next line in plane (in bytes) */
+    WORD s_nxpl;        /* +26 offset to next plane from start of current plane */
+    WORD d_xmin;        /* +28 minimum X: destination */
+    WORD d_ymin;        /* +30 minimum Y: destination */
+    UWORD * d_form;     /* +32 destination form base address */
+    WORD d_nxwd;        /* +36 offset to next word in line  (in bytes) */
+    WORD d_nxln;        /* +38 offset to next line in plane (in bytes) */
+    WORD d_nxpl;        /* +40 offset to next plane from start of current plane */
+    UWORD * p_addr;     /* +42 address of pattern buffer   (0:no pattern) */
+    WORD p_nxln;        /* +46 offset to next line in pattern  (in bytes) */
+    WORD p_nxpl;        /* +48 offset to next plane in pattern (in bytes) */
+    WORD p_mask;        /* +50 pattern index mask */
+
+    /* these frame parameters are internally set */
+    WORD p_indx;        /* +52 initial pattern index */
+    UWORD * s_addr;     /* +54 initial source address */
+    WORD s_xmax;        /* +58 maximum X: source */
+    WORD s_ymax;        /* +60 maximum Y: source */
+    UWORD * d_addr;     /* +62 initial destination address */
+    WORD d_xmax;        /* +66 maximum X: destination */
+    WORD d_ymax;        /* +68 maximum Y: destination */
+    WORD inner_ct;      /* +70 blt inner loop initial count */
+    WORD dst_wr;        /* +72 destination form wrap (in bytes) */
+    WORD src_wr;        /* +74 source form wrap (in bytes) */
+};
+
+/*
+ * common settings needed both by VDI and line-A raster operations, but
+ * being given through different means.
+ */
+struct raster_t {
+    VwkClip *clipper;
+    int clip;
+    int multifill;
+    int transparent;
+
+    /*
+     * Raw request parameters, alongside the op_tab/fg_col/bg_col encoding
+     * cpy_raster() derives for the planar per-plane blitter emulator --
+     * the packed-truecolor backend works a whole pixel at a time and
+     * needs the original values instead of that per-plane encoding (see
+     * truecolor_raster_copy() in vdi_backend_truecolor.c). mode is the
+     * raw VDI raster-op index for an opaque copy, or one of
+     * MD_TRANS/MD_REPLACE/MD_XOR/MD_ERASE for a transparent copy;
+     * fg_col/bg_col are MAP_COL-mapped hardware palette indices,
+     * meaningful only for a transparent copy.
+     */
+    WORD mode;
+    UWORD fg_col;
+    UWORD bg_col;
+};
+
+/*
+ * Planar raster-copy backend: dispatches info (already fully set up by
+ * cpy_raster()) to the hardware blitter or its C/assembler emulation.
+ * Exposed here so vdi_backend_planar.c's ops table can reference it, and
+ * so cpy_raster() can call it directly when CONF_WITH_VDI_TRUECOLOR is
+ * off (see the comment on vdi_backend_ops in vdi_backend.h).
+ */
+void planar_raster_copy(struct raster_t *raster, struct blit_frame *info);
+
+#endif /* VDI_RASTER_H */


### PR DESCRIPTION
Fixes #88

## Problem

`vdi/vdi_raster.c`'s `cpy_raster()` (shared by `vro_cpyfm()`, `vrt_cpyfm()`, and `linea_raster()`) assumed the destination was always Atari-style interleaved bitplanes. On the Raspberry Pi's packed RGB565 truecolor screen, the screen-form geometry was derived from `linea_vars.v_planes` (16, the bit depth — not a plane count), which the existing "only 8/4/2/1 planes are valid" sanity check in `setup_info()` already rejected outright. As a result, icons and other raster-copied images never drew at all on the truecolor backend.

## Fix

- Moved the two structs `cpy_raster()` builds (`blit_frame`, `raster_t`) into a new `vdi/vdi_raster.h` so the truecolor backend can share them.
- Added a `raster_copy` slot to `vdi_backend_ops`.
- Gave `setup_info()` a truecolor-aware branch: a packed screen word is already one whole pixel, so it now reports a 2-byte pixel stride and a single conceptual plane instead of bitplane-oriented geometry.
- The existing planar blitter dispatch moved into `planar_raster_copy()` (`vdi_raster.c`), referenced from `vdi_backend_planar.c`'s ops table, and called directly when `CONF_WITH_VDI_TRUECOLOR` is off — unchanged in behavior.
- Added `truecolor_raster_copy()` in `vdi_backend_truecolor.c`: a word-at-a-time boolean raster-op loop for opaque copies (direction-aware to handle same-buffer overlap, e.g. window scroll), and a 1bpp-source-to-packed-destination loop for transparent copies (`MD_REPLACE`/`TRANS`/`XOR`/`ERASE`), mirroring the bit-walking idiom `truecolor_text_blit()` already uses for glyphs.
- `vr_trnfm()` needed no changes: its plane-transpose algorithm already degenerates to a plain copy for a single-plane (packed) form.

Multi-plane colour-icon MFDBs (`CONF_WITH_COLOUR_ICONS`) fall outside what this backend can currently interpret and are safely skipped (no draw) rather than misread as packed pixels — colour icons don't render via this path yet; a known follow-up.

## Verification

- rpi1/rpi2/rpi3/rpi4 cross-compile clean, no new warnings.
- rpi2 boots under QEMU; a screendump taken after `AES: EMUDESK: evnt_multi()` shows the desktop's `DISK C` and `TRASH` icons rendering correctly (previously they never drew).
- `make gitready` passes.
- The shared planar code path was type-checked with a generic m68k cross-compiler (this sandboxed environment has no `m68k-atari-mint(elf)-`/`m68k-elf-` toolchain to produce a real link+boot); it is structurally unchanged for `CONF_WITH_VDI_TRUECOLOR=0` builds.