### PR TITLE
VDI: fix icon byte-swap in transparent raster copy

### DIFF
--- a/vdi/vdi_backend_truecolor.c
+++ b/vdi/vdi_backend_truecolor.c
@@ -554,7 +554,19 @@ static void truecolor_raster_copy(struct raster_t *raster, struct blit_frame *in
             WORD x;
 
             for (x = 0; x < info->b_wd; x++) {
-                BOOL set = (get_src_word(p) & mask) != 0;
+                /*
+                 * Icon mask/data words (unlike font glyph bytes -- see
+                 * get_src_word() above) are stored as WORD *value*
+                 * arrays by the resource compiler (tools/erd.c), which
+                 * the target compiler already lays out in its native
+                 * byte order. A native dereference here matches that,
+                 * and matches how the planar blitter reads the same
+                 * MFDB-sourced words (GetMemW() in vdi_raster.c);
+                 * get_src_word()'s manual big-endian byte reassembly
+                 * would double-handle the byte order and scramble every
+                 * word on a little-endian target.
+                 */
+                BOOL set = (*(const UWORD *)p & mask) != 0;
 
                 switch (raster->mode) {
                 case MD_REPLACE:


### PR DESCRIPTION
Fixes #135

## Problem

`truecolor_raster_copy()`'s transparent-copy branch (`vdi/vdi_backend_truecolor.c`, added in #134) read the 1bpp icon source bitmap with `get_src_word()` — a manual big-endian byte reassembly (`(p[0]<<8)|p[1]`), correct for font glyph data (`bios/fnt_st_8x8.c`'s `dat_table[]` etc. are genuine `UBYTE[]` byte streams) but wrong for icon bitmap words. `ICONBLK.ib_pdata`/`ib_pmask` are `WORD *`, emitted by `tools/erd.c` as `WORD[]` *value* arrays — the target compiler stores each of those values in its own native byte order. On a little-endian target (ARM) that's the opposite of what `get_src_word()`'s manual reassembly assumes, so every source word had its two bytes swapped — visible as each 8-pixel half of every icon glyph landing in the wrong horizontal position.

The existing planar blitter already gets this right: `do_blit()`'s `GetMemW()` (`vdi/vdi_raster.c`) reads the same kind of MFDB-sourced words via a plain native dereference, not manual byte reassembly.

## Fix

Read the source word in the transparent branch with a native `UWORD` dereference instead of `get_src_word()`, matching `GetMemW()`'s convention and matching how the opaque-copy branch already reads its (whole-pixel) words.

## Verification

- rpi1/rpi2/rpi3/rpi4 cross-compile clean.
- `make gitready` passes.
- QEMU rpi2 screendump taken after `AES: EMUDESK: evnt_multi()`: `DISK C` and `TRASH` icons now render correctly (clean disk-drive and trash-can shapes) instead of scrambled in 8-pixel chunks.