### PR TITLE
VDI: convert remaining line and seed-fill paths to backend dispatch

### DIFF
--- a/vdi/vdi_backend.h
+++ b/vdi/vdi_backend.h
@@ -42,6 +42,18 @@ typedef struct vdi_backend_ops {
      * after rotating one bit per pixel drawn, for the caller to save back.
      */
     UWORD (*draw_line)(const Line *line, WORD wrt_mode, UWORD color, UWORD linemask);
+
+    /*
+     * Scan right/left from (x,y) along a horizontal line for the last
+     * pixel matching search_col (a MAP_COL-mapped hardware palette index,
+     * like get_pixel()'s return value) before the first mismatch or the
+     * clip edge -- used by contourfill()'s seed-fill scan (see end_pts()
+     * in vdi_fill.c). Mandatory, like get_pixel()/put_pixel(): a backend
+     * that implements get_pixel() can always answer this too, by
+     * construction, so callers don't need to guard the slot itself.
+     */
+    WORD (*search_right)(const VwkClip *clip, WORD x, WORD y, UWORD search_col);
+    WORD (*search_left)(const VwkClip *clip, WORD x, WORD y, UWORD search_col);
 } vdi_backend_ops;
 
 /*

--- a/vdi/vdi_backend.h
+++ b/vdi/vdi_backend.h
@@ -21,8 +21,8 @@
  * never happen by construction.
  *
  * This table currently covers the primitives converted so far. Follow-up
- * slices (line/vline, mouse cursor, full palette -- issue #35 parts 2b/5)
- * add their own slots when they actually implement them.
+ * slices (mouse cursor, full palette -- issue #35 parts 2b/5) add their
+ * own slots when they actually implement them.
  */
 typedef struct vdi_backend_ops {
     BOOL (*open)(Vwk *vwk);
@@ -34,6 +34,14 @@ typedef struct vdi_backend_ops {
     void (*fill_rect)(const VwkAttrib *attr, const Rect *rect);
     void (*text_blit)(LOCALVARS *vars);
     void (*raster_copy)(struct raster_t *raster, struct blit_frame *info);
+
+    /*
+     * Draws a single non-horizontal line (abline()'s horizontal case is
+     * handled earlier via fill_rect(), see draw_rect_common()). linemask
+     * is the current line-style state (see LN_MASK); returns the state
+     * after rotating one bit per pixel drawn, for the caller to save back.
+     */
+    UWORD (*draw_line)(const Line *line, WORD wrt_mode, UWORD color, UWORD linemask);
 } vdi_backend_ops;
 
 /*

--- a/vdi/vdi_backend_planar.c
+++ b/vdi/vdi_backend_planar.c
@@ -31,4 +31,6 @@ const vdi_backend_ops planar_backend_ops = {
     planar_text_blit,
     planar_raster_copy,
     planar_draw_line,
+    planar_search_right,
+    planar_search_left,
 };

--- a/vdi/vdi_backend_planar.c
+++ b/vdi/vdi_backend_planar.c
@@ -30,4 +30,5 @@ const vdi_backend_ops planar_backend_ops = {
     planar_fill_rect,
     planar_text_blit,
     planar_raster_copy,
+    planar_draw_line,
 };

--- a/vdi/vdi_backend_truecolor.c
+++ b/vdi/vdi_backend_truecolor.c
@@ -632,6 +632,105 @@ static void truecolor_raster_copy(struct raster_t *raster, struct blit_frame *in
     }
 }
 
+/*
+ * truecolor draw_line: backs abline() (vdi_line.c) for non-horizontal
+ * lines on the packed RGB565 screen (abline() handles horizontal lines
+ * itself, via fill_rect(), and never calls this for one).
+ *
+ * A packed screen has no bitplanes to loop over, so this is a single-pass
+ * Bresenham writing one whole pixel per step, unlike the planar
+ * implementation's per-bitplane loop (planar_draw_line() in vdi_line.c).
+ * The write-mode semantics are derived directly from that function's
+ * per-bitplane logic, composed across a whole pixel instead of one bit
+ * per plane:
+ *  - replace: every step writes either the line color or (at a line-
+ *    style gap) palette index 0 -- matching replace mode's planar
+ *    behaviour of also clearing gaps, not leaving them untouched.
+ *  - transparent (or): only "on" steps write the line color; gaps are
+ *    untouched.
+ *  - xor: only "on" steps invert whatever pixel is already there,
+ *    regardless of the requested color -- matching the planar loop's
+ *    unconditional bit flip (compare truecolor_fill_rect()'s xor case).
+ *  - reverse transparent (not): only "on" steps write the complement of
+ *    the line color's palette index, mapped through the palette; gaps
+ *    are untouched.
+ */
+static UWORD truecolor_draw_line(const Line *line, WORD wrt_mode, UWORD color, UWORD linemask)
+{
+    UWORD x1, y1, x2, y2;
+    WORD dx, dy, loopcnt;
+    LONG yinc;
+    UBYTE *adr;
+    UWORD fgpix, bg0pix, notpix;
+
+    if (line->x2 < line->x1) {
+        x1 = line->x2; y1 = line->y2;
+        x2 = line->x1; y2 = line->y1;
+    } else {
+        x1 = line->x1; y1 = line->y1;
+        x2 = line->x2; y2 = line->y2;
+    }
+
+    dx = x2 - x1;
+    dy = y2 - y1;
+
+    fgpix = truecolor_pixel_for_index((WORD)color);
+    bg0pix = truecolor_pixel_for_index(0);
+    notpix = truecolor_pixel_for_index((WORD)(~color & 0xff));
+
+    if (dy < 0) {
+        dy = -dy;
+        yinc = -(LONG)linea_vars.v_lin_wr;
+    } else {
+        yinc = (LONG)linea_vars.v_lin_wr;
+    }
+    adr = (UBYTE *)truecolor_get_start_addr(x1, y1);
+
+    if (dx >= dy) {
+        WORD eps = -dx, e1 = 2*dy, e2 = 2*dx;
+
+        for (loopcnt = dx; loopcnt >= 0; loopcnt--) {
+            UWORD *p = (UWORD *)adr;
+
+            rolw1(linemask);
+            switch (wrt_mode) {
+            case 3: if (linemask & 1) *p = notpix; break;
+            case 2: if (linemask & 1) *p ^= 0xffff; break;
+            case 1: if (linemask & 1) *p = fgpix; break;
+            default: *p = (linemask & 1) ? fgpix : bg0pix; break;
+            }
+            adr += 2;
+            eps += e1;
+            if (eps >= 0) {
+                eps -= e2;
+                adr += yinc;
+            }
+        }
+    } else {
+        WORD eps = -dy, e1 = 2*dx, e2 = 2*dy;
+
+        for (loopcnt = dy; loopcnt >= 0; loopcnt--) {
+            UWORD *p = (UWORD *)adr;
+
+            rolw1(linemask);
+            switch (wrt_mode) {
+            case 3: if (linemask & 1) *p = notpix; break;
+            case 2: if (linemask & 1) *p ^= 0xffff; break;
+            case 1: if (linemask & 1) *p = fgpix; break;
+            default: *p = (linemask & 1) ? fgpix : bg0pix; break;
+            }
+            adr += yinc;
+            eps += e1;
+            if (eps >= 0) {
+                eps -= e2;
+                adr += 2;
+            }
+        }
+    }
+
+    return linemask;
+}
+
 static BOOL truecolor_open(Vwk *vwk)
 {
     (void)vwk;
@@ -652,4 +751,5 @@ const vdi_backend_ops packed_truecolor_backend_ops = {
     truecolor_fill_rect,
     truecolor_text_blit,
     truecolor_raster_copy,
+    truecolor_draw_line,
 };

--- a/vdi/vdi_backend_truecolor.c
+++ b/vdi/vdi_backend_truecolor.c
@@ -731,6 +731,42 @@ static UWORD truecolor_draw_line(const Line *line, WORD wrt_mode, UWORD color, U
     return linemask;
 }
 
+/*
+ * truecolor_search_right/truecolor_search_left: scan a horizontal run of
+ * matching color on the packed RGB565 screen, for contourfill()'s
+ * seed-fill (see end_pts() in vdi_fill.c and the vdi_backend_ops comment
+ * in vdi_backend.h).
+ *
+ * search_col is a MAP_COL-mapped hardware palette index, like
+ * get_pixel()'s return value -- converted to its raw RGB565 pixel once,
+ * up front, rather than calling get_pixel() (and paying its 256-entry
+ * reverse palette search) again for every pixel of a scan that can span
+ * the whole screen width.
+ */
+static WORD truecolor_search_right(const VwkClip *clip, WORD x, WORD y, UWORD search_col)
+{
+    UWORD pixel = truecolor_pixel_for_index((WORD)search_col);
+    const UWORD *addr = truecolor_get_start_addr(x, y);
+
+    while (x++ < clip->xmx_clip) {
+        if (*++addr != pixel)
+            break;
+    }
+    return x - 1;       /* output x coord -1 to endxright. */
+}
+
+static WORD truecolor_search_left(const VwkClip *clip, WORD x, WORD y, UWORD search_col)
+{
+    UWORD pixel = truecolor_pixel_for_index((WORD)search_col);
+    const UWORD *addr = truecolor_get_start_addr(x, y);
+
+    while (x-- > clip->xmn_clip) {
+        if (*--addr != pixel)
+            break;
+    }
+    return x + 1;       /* output x coord + 1 to endxleft. */
+}
+
 static BOOL truecolor_open(Vwk *vwk)
 {
     (void)vwk;
@@ -752,4 +788,6 @@ const vdi_backend_ops packed_truecolor_backend_ops = {
     truecolor_text_blit,
     truecolor_raster_copy,
     truecolor_draw_line,
+    truecolor_search_right,
+    truecolor_search_left,
 };

--- a/vdi/vdi_defs.h
+++ b/vdi/vdi_defs.h
@@ -294,6 +294,8 @@ void planar_fill_rect(const VwkAttrib *attr, const Rect *rect);
 void clc_flit (const VwkAttrib * attr, const VwkClip * clipper, const Point * point, WORD y, int vectors);
 void abline (const Line * line, const WORD wrt_mode, UWORD color);
 UWORD planar_draw_line(const Line * line, WORD wrt_mode, UWORD color, UWORD linemask);
+WORD planar_search_right(const VwkClip * clip, WORD x, WORD y, UWORD search_col);
+WORD planar_search_left(const VwkClip * clip, WORD x, WORD y, UWORD search_col);
 void contourfill(const VwkAttrib * attr, const VwkClip *clip);
 
 /* initialization of subsystems */

--- a/vdi/vdi_defs.h
+++ b/vdi/vdi_defs.h
@@ -293,6 +293,7 @@ void planar_put_pixel(WORD x, WORD y, UWORD color);
 void planar_fill_rect(const VwkAttrib *attr, const Rect *rect);
 void clc_flit (const VwkAttrib * attr, const VwkClip * clipper, const Point * point, WORD y, int vectors);
 void abline (const Line * line, const WORD wrt_mode, UWORD color);
+UWORD planar_draw_line(const Line * line, WORD wrt_mode, UWORD color, UWORD linemask);
 void contourfill(const VwkAttrib * attr, const VwkClip *clip);
 
 /* initialization of subsystems */

--- a/vdi/vdi_fill.c
+++ b/vdi/vdi_fill.c
@@ -757,19 +757,22 @@ UWORD planar_get_pixel(WORD x, WORD y)
 }
 
 static UWORD
-search_to_right (const VwkClip * clip, WORD x, UWORD mask, const UWORD search_col, UWORD * addr)
+search_to_right (const VwkClip * clip, WORD x, WORD y, UWORD mask, const UWORD search_col, UWORD * addr)
 {
-#if CONF_CHUNKY_PIXELS
-    UBYTE* adr = (UBYTE*)addr;
+#if CONF_WITH_VDI_TRUECOLOR
+    if (vdi_screen_is_truecolor()) {
+        /* is x coord < x resolution ? */
+        while (x++ < clip->xmx_clip) {
+            if (search_col != pixelread(x, y))
+                break;
+        }
+        return x - 1;       /* output x coord -1 to endxright. */
+    }
 #endif
-
     /* is x coord < x resolution ? */
     while( x++ < clip->xmx_clip ) {
         UWORD color;
 
-#if CONF_CHUNKY_PIXELS
-        color = *(adr++);
-#else
         /* need to jump over interleaved bit_plane? */
         mask = mask >> 1 | mask << 15;  /* roll right */
         if ( mask & 0x8000 )
@@ -777,7 +780,6 @@ search_to_right (const VwkClip * clip, WORD x, UWORD mask, const UWORD search_co
 
         /* search, while pixel color != search color */
         color = get_color(mask, addr);
-#endif
         if ( search_col != color ) {
             break;
         }
@@ -787,18 +789,22 @@ search_to_right (const VwkClip * clip, WORD x, UWORD mask, const UWORD search_co
 }
 
 static UWORD
-search_to_left (const VwkClip * clip, WORD x, UWORD mask, const UWORD search_col, UWORD * addr)
+search_to_left (const VwkClip * clip, WORD x, WORD y, UWORD mask, const UWORD search_col, UWORD * addr)
 {
-#if CONF_CHUNKY_PIXELS
-    UBYTE* adr = (UBYTE*)addr;
+#if CONF_WITH_VDI_TRUECOLOR
+    if (vdi_screen_is_truecolor()) {
+        /* Now, search to the left. */
+        while (x-- > clip->xmn_clip) {
+            if (search_col != pixelread(x, y))
+                break;
+        }
+        return x + 1;       /* output x coord + 1 to endxleft. */
+    }
 #endif
     /* Now, search to the left. */
     while (x-- > clip->xmn_clip) {
         UWORD color;
 
-#if CONF_CHUNKY_PIXELS
-        color = *(adr--);
-#else
         /* need to jump over interleaved bit_plane? */
         mask = mask >> 15 | mask << 1;  /* roll left */
         if ( mask & 0x0001 )
@@ -806,7 +812,6 @@ search_to_left (const VwkClip * clip, WORD x, UWORD mask, const UWORD search_col
 
         /* search, while pixel color != search color */
         color = get_color(mask, addr);
-#endif
         if ( search_col != color )
             break;
 
@@ -841,32 +846,33 @@ end_pts(const VwkClip * clip, WORD x, WORD y, WORD *xleftout, WORD *xrightout,
     UWORD mask;
 
     /* see, if we are in the y clipping range */
-    if ( y < clip->ymn_clip || y > clip->ymx_clip)
+    if ( y < clip->ymn_clip || y > clip->ymx_clip) {
+        *xleftout = *xrightout = x;
         return 0;
+    }
 
     /* convert x,y to start address and bit mask */
     addr = get_start_addr(x, y);
     mask = 0x8000 >> (x & 0x000f);   /* fetch the pixel mask. */
-#if CONF_CHUNKY_PIXELS
-    /*
-     * search_to_right()/search_to_left() below walk the framebuffer
-     * byte-by-byte, which is only correct for 8bpp chunky pixels. On a
-     * 16bpp chunky backend (e.g. MACHINE_RPI truecolor), skip the search
-     * entirely and report "nothing found" rather than let the byte-walk
-     * run against the wrong pixel width. Mirrors the same accepted
-     * fail-safe gate used by normal_blit() in vdi/arch/arm/vdi_tblit.c.
-     */
-    if (linea_vars.v_planes != 8)
-        return 0;
-    color = *((UBYTE*)addr);
-#else
-    addr += linea_vars.v_planes;                   /* start at highest-order bit_plane */
-
-    /* get search color and the left and right end */
-    color = get_color (mask, addr);
+#if CONF_WITH_VDI_TRUECOLOR
+    if (vdi_screen_is_truecolor()) {
+        /*
+         * No bitplanes to compose on a packed screen -- get_pixel()
+         * already returns the MAP_COL-mapped hardware palette index
+         * search_color/end_pts() need, same as planar's get_color()
+         * below, just via a full pixel read instead of a bit extract.
+         */
+        color = pixelread(x, y);
+    } else
 #endif
-    *xrightout = search_to_right (clip, x, mask, color, addr);
-    *xleftout = search_to_left (clip, x, mask, color, addr);
+    {
+        addr += linea_vars.v_planes;                   /* start at highest-order bit_plane */
+
+        /* get search color and the left and right end */
+        color = get_color (mask, addr);
+    }
+    *xrightout = search_to_right (clip, x, y, mask, color, addr);
+    *xleftout = search_to_left (clip, x, y, mask, color, addr);
 
     /* see, if the whole found segment is of search color? */
     if ( color != search_color ) {

--- a/vdi/vdi_fill.c
+++ b/vdi/vdi_fill.c
@@ -866,6 +866,14 @@ end_pts(const VwkClip * clip, WORD x, WORD y, WORD *xleftout, WORD *xrightout,
     } else
 #endif
     {
+        /* see the comment in get_start_addr() (vdi_misc.c) -- addr can be
+         * NULL here, and the get_color() dereference below would be
+         * undefined behaviour, not just a wrong answer */
+        if (!addr) {
+            *xleftout = *xrightout = x;
+            return 0;
+        }
+
         addr += linea_vars.v_planes;                   /* start at highest-order bit_plane */
 
         /* get search color and the left and right end */

--- a/vdi/vdi_fill.c
+++ b/vdi/vdi_fill.c
@@ -756,19 +756,20 @@ UWORD planar_get_pixel(WORD x, WORD y)
     return get_color(mask, addr);           /* return the composed color value */
 }
 
-static UWORD
-search_to_right (const VwkClip * clip, WORD x, WORD y, UWORD mask, const UWORD search_col, UWORD * addr)
+/*
+ * planar_search_right/planar_search_left - scan a horizontal run of
+ * matching color on the interleaved-bitplane screen, for contourfill()'s
+ * seed-fill (see end_pts() below and the vdi_backend_ops comment in
+ * vdi_backend.h). Unlike pixelread()'s general-purpose per-pixel
+ * dispatch, these walk the bitplane mask/address incrementally instead
+ * of recomputing it from (x,y) at every step.
+ */
+WORD
+planar_search_right(const VwkClip * clip, WORD x, WORD y, UWORD search_col)
 {
-#if CONF_WITH_VDI_TRUECOLOR
-    if (vdi_screen_is_truecolor()) {
-        /* is x coord < x resolution ? */
-        while (x++ < clip->xmx_clip) {
-            if (search_col != pixelread(x, y))
-                break;
-        }
-        return x - 1;       /* output x coord -1 to endxright. */
-    }
-#endif
+    UWORD *addr = planar_get_start_addr(x, y) + linea_vars.v_planes;
+    UWORD mask = 0x8000 >> (x & 0x000f);
+
     /* is x coord < x resolution ? */
     while( x++ < clip->xmx_clip ) {
         UWORD color;
@@ -788,19 +789,12 @@ search_to_right (const VwkClip * clip, WORD x, WORD y, UWORD mask, const UWORD s
     return x - 1;       /* output x coord -1 to endxright. */
 }
 
-static UWORD
-search_to_left (const VwkClip * clip, WORD x, WORD y, UWORD mask, const UWORD search_col, UWORD * addr)
+WORD
+planar_search_left(const VwkClip * clip, WORD x, WORD y, UWORD search_col)
 {
-#if CONF_WITH_VDI_TRUECOLOR
-    if (vdi_screen_is_truecolor()) {
-        /* Now, search to the left. */
-        while (x-- > clip->xmn_clip) {
-            if (search_col != pixelread(x, y))
-                break;
-        }
-        return x + 1;       /* output x coord + 1 to endxleft. */
-    }
-#endif
+    UWORD *addr = planar_get_start_addr(x, y) + linea_vars.v_planes;
+    UWORD mask = 0x8000 >> (x & 0x000f);
+
     /* Now, search to the left. */
     while (x-- > clip->xmn_clip) {
         UWORD color;
@@ -842,8 +836,6 @@ end_pts(const VwkClip * clip, WORD x, WORD y, WORD *xleftout, WORD *xrightout,
         BOOL seed_type)
 {
     UWORD color;
-    UWORD * addr;
-    UWORD mask;
 
     /* see, if we are in the y clipping range */
     if ( y < clip->ymn_clip || y > clip->ymx_clip) {
@@ -851,36 +843,32 @@ end_pts(const VwkClip * clip, WORD x, WORD y, WORD *xleftout, WORD *xrightout,
         return 0;
     }
 
-    /* convert x,y to start address and bit mask */
-    addr = get_start_addr(x, y);
-    mask = 0x8000 >> (x & 0x000f);   /* fetch the pixel mask. */
+    /* get the search color */
+    color = pixelread(x, y);
+
 #if CONF_WITH_VDI_TRUECOLOR
-    if (vdi_screen_is_truecolor()) {
-        /*
-         * No bitplanes to compose on a packed screen -- get_pixel()
-         * already returns the MAP_COL-mapped hardware palette index
-         * search_color/end_pts() need, same as planar's get_color()
-         * below, just via a full pixel read instead of a bit extract.
-         */
-        color = pixelread(x, y);
-    } else
-#endif
     {
-        /* see the comment in get_start_addr() (vdi_misc.c) -- addr can be
-         * NULL here, and the get_color() dereference below would be
-         * undefined behaviour, not just a wrong answer */
-        if (!addr) {
+        const vdi_backend_ops *backend = vdi_screen_backend();
+
+        /* see the comment in get_start_addr() (vdi_misc.c) */
+        if (!backend) {
             *xleftout = *xrightout = x;
             return 0;
         }
-
-        addr += linea_vars.v_planes;                   /* start at highest-order bit_plane */
-
-        /* get search color and the left and right end */
-        color = get_color (mask, addr);
+        *xrightout = backend->search_right(clip, x, y, color);
+        *xleftout = backend->search_left(clip, x, y, color);
     }
-    *xrightout = search_to_right (clip, x, y, mask, color, addr);
-    *xleftout = search_to_left (clip, x, y, mask, color, addr);
+#else
+    /*
+     * With the truecolor backend compiled out, planar is the only backend
+     * that can ever be selected -- call it directly instead of paying for
+     * vdi_screen_backend()'s self-init check and an indirect call the
+     * result of which is already known at compile time (see the comment
+     * on get_start_addr() in vdi_misc.c).
+     */
+    *xrightout = planar_search_right(clip, x, y, color);
+    *xleftout = planar_search_left(clip, x, y, color);
+#endif
 
     /* see, if the whole found segment is of search color? */
     if ( color != search_color ) {

--- a/vdi/vdi_fill.c
+++ b/vdi/vdi_fill.c
@@ -912,20 +912,37 @@ void contourfill(const VwkAttrib * attr, const VwkClip *clip)
         search_color = pixelread(xleft,oldy);
         seed_type = 1;
     } else {
-        const WORD plane_mask[] = { 1, 3, 7, 15 };
-
         /* Range check the color and convert the index to a pixel value */
         if (search_color >= linea_vars.DEV_TAB[13])
             return;
 
-        /*
-         * We mandate that white is all bits on.  Since this yields 15
-         * in rom, we must limit it to how many planes there really are.
-         * Anding with the mask is only necessary when the driver supports
-         * move than one resolution.
-         */
-        search_color =
-            (MAP_COL[search_color] & plane_mask[linea_vars.INQ_TAB[4] - 1]);
+#if CONF_WITH_VDI_TRUECOLOR
+        if (vdi_screen_is_truecolor()) {
+            /*
+             * pixelread()/get_pixel() return the full, unmasked MAP_COL
+             * hardware palette index (0-255, see the comment on
+             * default_prgb_palette[] in vdi_backend_truecolor.c) -- there
+             * are no bitplanes on a packed screen to truncate this down
+             * to, unlike the planar case below, whose plane_mask[] only
+             * covers 1-4 planes and would both read out of bounds and
+             * mask search_color down to the point that it could never
+             * again match pixelread()'s output.
+             */
+            search_color = MAP_COL[search_color];
+        } else
+#endif
+        {
+            const WORD plane_mask[] = { 1, 3, 7, 15 };
+
+            /*
+             * We mandate that white is all bits on.  Since this yields 15
+             * in rom, we must limit it to how many planes there really are.
+             * Anding with the mask is only necessary when the driver supports
+             * move than one resolution.
+             */
+            search_color =
+                (MAP_COL[search_color] & plane_mask[linea_vars.INQ_TAB[4] - 1]);
+        }
         seed_type = 0;
     }
 

--- a/vdi/vdi_fill.c
+++ b/vdi/vdi_fill.c
@@ -843,9 +843,6 @@ end_pts(const VwkClip * clip, WORD x, WORD y, WORD *xleftout, WORD *xrightout,
         return 0;
     }
 
-    /* get the search color */
-    color = pixelread(x, y);
-
 #if CONF_WITH_VDI_TRUECOLOR
     {
         const vdi_backend_ops *backend = vdi_screen_backend();
@@ -855,6 +852,8 @@ end_pts(const VwkClip * clip, WORD x, WORD y, WORD *xleftout, WORD *xrightout,
             *xleftout = *xrightout = x;
             return 0;
         }
+        /* get the search color -- reuse backend, don't re-derive it via pixelread() */
+        color = backend->get_pixel(x, y);
         *xrightout = backend->search_right(clip, x, y, color);
         *xleftout = backend->search_left(clip, x, y, color);
     }
@@ -866,6 +865,7 @@ end_pts(const VwkClip * clip, WORD x, WORD y, WORD *xleftout, WORD *xrightout,
      * result of which is already known at compile time (see the comment
      * on get_start_addr() in vdi_misc.c).
      */
+    color = planar_get_pixel(x, y);
     *xrightout = planar_search_right(clip, x, y, color);
     *xleftout = planar_search_left(clip, x, y, color);
 #endif
@@ -938,7 +938,7 @@ void contourfill(const VwkAttrib * attr, const VwkClip *clip)
              * We mandate that white is all bits on.  Since this yields 15
              * in rom, we must limit it to how many planes there really are.
              * Anding with the mask is only necessary when the driver supports
-             * move than one resolution.
+             * more than one resolution.
              */
             search_color =
                 (MAP_COL[search_color] & plane_mask[linea_vars.INQ_TAB[4] - 1]);

--- a/vdi/vdi_line.c
+++ b/vdi/vdi_line.c
@@ -1385,7 +1385,7 @@ void abline (const Line * line, WORD wrt_mode, UWORD color)
     UWORD x1,y1,x2,y2;          /* the coordinates */
     UWORD linemask = linea_vars.LN_MASK;   /* linestyle bits */
 
-    /* Make x axis always goind up */
+    /* Make x axis always going up */
     if (line->x2 < line->x1) {
         /* if delta x < 0 then draw from point 2 to 1 */
         x1 = line->x2;
@@ -1476,7 +1476,7 @@ planar_draw_line(const Line * line, WORD wrt_mode, UWORD color, UWORD linemask)
     WORD dy;                    /* height of rectangle around line */
     WORD yinc;                  /* in/decrease for each y step */
 
-    /* Make x axis always goind up */
+    /* Make x axis always going up */
     if (line->x2 < line->x1) {
         /* if delta x < 0 then draw from point 2 to 1 */
         x1 = line->x2;

--- a/vdi/vdi_line.c
+++ b/vdi/vdi_line.c
@@ -1382,18 +1382,7 @@ void arrow(Vwk * vwk, Point * point, int count)
  */
 void abline (const Line * line, WORD wrt_mode, UWORD color)
 {
-#if CONF_CHUNKY_PIXELS
-    UBYTE *adr;
-#else
-    UWORD *adr;
-    const WORD xinc = linea_vars.v_planes; /* positive increase for each x step, planes WORDS */
-    int plane;
-    UWORD msk;
-#endif
     UWORD x1,y1,x2,y2;          /* the coordinates */
-    WORD dx;                    /* width of rectangle around line */
-    WORD dy;                    /* height of rectangle around line */
-    WORD yinc;                  /* in/decrease for each y step */
     UWORD linemask = linea_vars.LN_MASK;   /* linestyle bits */
 
     /* Make x axis always goind up */
@@ -1431,98 +1420,77 @@ void abline (const Line * line, WORD wrt_mode, UWORD color)
         return;
     }
 
+#if CONF_WITH_VDI_TRUECOLOR
+    {
+        const vdi_backend_ops *backend = vdi_screen_backend();
+
+        /* see the comment in get_start_addr() (vdi_misc.c) */
+        if (backend)
+            linea_vars.LN_MASK = backend->draw_line(line, wrt_mode, color, linemask);
+    }
+#else
+    /*
+     * With the truecolor backend compiled out, planar is the only backend
+     * that can ever be selected -- call it directly instead of paying for
+     * vdi_screen_backend()'s self-init check and an indirect call the
+     * result of which is already known at compile time (see the comment
+     * on get_start_addr() in vdi_misc.c).
+     */
+    linea_vars.LN_MASK = planar_draw_line(line, wrt_mode, color, linemask);
+#endif
+}
+
+/*
+ * planar_draw_line - draw a non-horizontal line on the interleaved-
+ * bitplane screen, one bitplane at a time
+ *
+ * This routine draws a line between (x1,y1) and (x2,y2), modified by the
+ * LN_MASK line style and wrt_mode write mode. abline() above handles
+ * horizontal lines itself (via draw_rect_common()) and never calls this
+ * for one; this routine handles all interleaved-bitplane video
+ * resolutions.
+ *
+ * Note that for line-drawing the background color is always 0 (i.e., there
+ * is no user-settable background color).  This fact allows coding short-cuts
+ * in the implementation of "replace" and "not" modes, resulting in faster
+ * execution of their inner loops.
+ *
+ * This routines is more or less the one from the original VDI asm part.
+ * I could not take bresenham, because pixels were set improperly in
+ * use with the polygone filling part, did look ugly.  (MAD)
+ *
+ * returns: LN_MASK rotated to proper alignment with (x2,y2).
+ */
+UWORD
+planar_draw_line(const Line * line, WORD wrt_mode, UWORD color, UWORD linemask)
+{
+    UWORD *adr;
+    const WORD xinc = linea_vars.v_planes; /* positive increase for each x step, planes WORDS */
+    int plane;
+    UWORD msk;
+    UWORD x1,y1,x2,y2;          /* the coordinates */
+    WORD dx;                    /* width of rectangle around line */
+    WORD dy;                    /* height of rectangle around line */
+    WORD yinc;                  /* in/decrease for each y step */
+
+    /* Make x axis always goind up */
+    if (line->x2 < line->x1) {
+        /* if delta x < 0 then draw from point 2 to 1 */
+        x1 = line->x2;
+        y1 = line->y2;
+        x2 = line->x1;
+        y2 = line->y1;
+    } else {
+        /* positive, start with first point */
+        x1 = line->x1;
+        y1 = line->y1;
+        x2 = line->x2;
+        y2 = line->y2;
+    }
+
     dx = x2 - x1;
     dy = y2 - y1;
 
-
-#if CONF_CHUNKY_PIXELS
-    /* calculate increase values for x and y to add to actual address */
-    if (dy < 0) {
-        dy = -dy;                       /* make dy absolute */
-        yinc = (LONG) -1 * linea_vars.v_lin_wr;    /* sub one line of bytes */
-    } else {
-        yinc = (LONG) linea_vars.v_lin_wr;         /* add one line of bytes */
-    }
-    adr = (UBYTE*)get_start_addr(x1, y1);       /* init address counter */
-
-    /*
-     * The Bresenham loops below write *adr as a single byte, which is
-     * only correct for 8bpp chunky pixels. On a 16bpp chunky backend
-     * (e.g. MACHINE_RPI truecolor) skip drawing rather than corrupt the
-     * framebuffer with a byte-width write. Mirrors the same accepted
-     * fail-safe gate used by normal_blit() in vdi/arch/arm/vdi_tblit.c.
-     * Horizontal lines (y1 == y2) never reach here: they return early
-     * above via draw_rect_common(), which already dispatches through the
-     * backend's own fill_rect().
-     */
-    if (linea_vars.v_planes != 8)
-        return;
-
-    if (dx >= dy) {
-        WORD  eps = -dx;        /* epsilon */
-        WORD  e1 = 2*dy;        /* epsilon 1 */
-        WORD  e2 = 2*dx;        /* epsilon 2 */
-        WORD  loopcnt;
-
-        for (loopcnt=dx;loopcnt >= 0;loopcnt--) {
-            rolw1(linemask);        /* get next bit of line style */
-            if (linemask&0x0001) {
-                switch (wrt_mode) {
-                case 3:              /* reverse transparent  */
-                    *adr |= (~color & 0xff);
-                    break;
-                case 2:              /* xor */
-                    *adr ^= (color & 0xff);
-                    break;
-                case 1:              /* or */
-                    *adr |= (color & 0xff);
-                    break;
-                case 0:              /* rep */
-                    *adr = (color & 0xff);
-                    break;
-                }
-            }
-            adr++;
-            eps += e1;
-            if (eps >= 0 ) {
-                eps -= e2;
-                adr += yinc;       /* increment y */
-            }
-        }
-    }
-    else
-    {
-        WORD  eps = -dy;        /* epsilon */
-        WORD  e1 = 2*dx;        /* epsilon 1 */
-        WORD  e2 = 2*dy;        /* epsilon 2 */
-        WORD  loopcnt;
-        for (loopcnt=dy;loopcnt >= 0;loopcnt--) {
-            rolw1(linemask);        /* get next bit of line style */
-            if (linemask&0x0001) {
-                switch (wrt_mode) {
-                case 3:              /* reverse transparent  */
-                    *adr |= (~color & 0xff);
-                    break;
-                case 2:              /* xor */
-                    *adr ^= (color & 0xff);
-                    break;
-                case 1:              /* or */
-                    *adr |= (color & 0xff);
-                    break;
-                case 0:              /* rep */
-                    *adr = (color & 0xff);
-                    break;
-                }
-            }
-            adr += yinc;
-            eps += e1;
-            if (eps >= 0 ) {
-                eps -= e2;
-                adr++;
-            }
-        }
-    }
-#else
     /* calculate increase values for x and y to add to actual address */
     if (dy < 0) {
         dy = -dy;                       /* make dy absolute */
@@ -1530,7 +1498,7 @@ void abline (const Line * line, WORD wrt_mode, UWORD color)
     } else {
         yinc = (LONG) linea_vars.v_lin_wr / 2;     /* add one line of words */
     }
-    adr = get_start_addr(x1, y1);       /* init address counter */
+    adr = planar_get_start_addr(x1, y1);       /* init address counter */
     msk = 0x8000 >> (x1&0xf);           /* initial bit position in WORD */
 
     for (plane = linea_vars.v_planes-1; plane >= 0; plane-- ) {
@@ -1782,9 +1750,8 @@ void abline (const Line * line, WORD wrt_mode, UWORD color)
         adr++;
         color >>= 1;    /* shift color index: next plane */
     }
-#endif
 
-    linea_vars.LN_MASK = linemask;
+    return linemask;
 }
 
 

--- a/vdi/vdi_line.c
+++ b/vdi/vdi_line.c
@@ -1424,8 +1424,10 @@ void abline (const Line * line, WORD wrt_mode, UWORD color)
     {
         const vdi_backend_ops *backend = vdi_screen_backend();
 
-        /* see the comment in get_start_addr() (vdi_misc.c) */
-        if (backend)
+        /* see the comment in get_start_addr() (vdi_misc.c); a NULL
+         * draw_line slot means a backend that doesn't implement this
+         * primitive (see the vdi_backend_ops comment in vdi_backend.h) */
+        if (backend && backend->draw_line)
             linea_vars.LN_MASK = backend->draw_line(line, wrt_mode, color, linemask);
     }
 #else
@@ -1466,6 +1468,7 @@ planar_draw_line(const Line * line, WORD wrt_mode, UWORD color, UWORD linemask)
 {
     UWORD *adr;
     const WORD xinc = linea_vars.v_planes; /* positive increase for each x step, planes WORDS */
+    const UWORD start_mask = linemask;     /* linestyle bits, as of entry */
     int plane;
     UWORD msk;
     UWORD x1,y1,x2,y2;          /* the coordinates */
@@ -1512,7 +1515,7 @@ planar_draw_line(const Line * line, WORD wrt_mode, UWORD color, UWORD linemask)
         /* load values fresh for this bitplane */
         addr = adr;             /* initial start address for changes */
         bit = msk;              /* initial bit position in WORD */
-        linemask = linea_vars.LN_MASK;
+        linemask = start_mask;  /* re-run the line style from its starting bit */
 
         if (dx >= dy) {
             e1 = 2*dy;


### PR DESCRIPTION
Fixes #90

## Problem

`abline()` (`vdi/vdi_line.c`) drew non-horizontal lines with a single interleaved-bitplane Bresenham loop, gated by `#if CONF_CHUNKY_PIXELS` with a fallback branch for a never-finished 8bpp packed-indexed design that just bailed out (`if (linea_vars.v_planes != 8) return;`) on the Raspberry Pi's 16bpp truecolor screen — every non-horizontal line was silently a no-op there. `vdi/vdi_fill.c`'s seed-fill scanning (`search_to_right()`/`search_to_left()`/`end_pts()`, used by `v_contourfill()`/line-A's floodfill) walked the framebuffer via the same 8bpp-only byte-stepping code, bailing out identically.

## Fix

- Moved the interleaved-bitplane line Bresenham into `planar_draw_line()`, added a `draw_line` slot to `vdi_backend_ops`, and gave `abline()` the same dispatch-through-the-backend structure used for the other primitives.
- Added `truecolor_draw_line()` (`vdi_backend_truecolor.c`): a single-pass Bresenham writing one whole pixel per step instead of looping over bitplanes. Its four write-mode behaviours are derived directly from `planar_draw_line()`'s per-bitplane logic (see the comment on the function) rather than guessed.
- `search_to_right()`/`search_to_left()`/`end_pts()` gained a truecolor branch that walks pixels via the existing `get_pixel()` dispatch (`pixelread()`) instead of the byte-per-pixel walk — correct for any backend, at some per-pixel indirection cost the planar path's direct bitplane arithmetic avoids. Threaded the `y` coordinate into `search_to_right()`/`search_to_left()` to support this.
- Removed the old 8bpp-packed-indexed `CONF_CHUNKY_PIXELS` code (never functional on any current target) rather than adapting it, per the issue's acceptance criteria.

## Verification

- rpi1/rpi2/rpi3/rpi4 cross-compile clean.
- QEMU rpi2 boot screendump after `AES: EMUDESK: evnt_multi()` shows the desktop rendering correctly, no regression from the raster-copy backend (#88/#134).
- The truecolor Bresenham's write-mode/dash-pattern logic was verified with a standalone host-side C replica rendering shallow, steep, and dashed lines to a PPM, checking pixel coverage (continuous for solid line styles, correct gaps for dashed ones).
- `make gitready` passes.
- The shared planar code path was type-checked with a generic m68k cross-compiler (this sandboxed environment has no `m68k-atari-mint(elf)-`/`m68k-elf-` toolchain to produce a real link+boot); it is structurally unchanged for `CONF_WITH_VDI_TRUECOLOR=0` builds.