### PR TITLE
Port generic desktop alert refactor (#118)

### DIFF
--- a/desk/deskfun.c
+++ b/desk/deskfun.c
@@ -97,9 +97,9 @@ WORD fun_alert(WORD defbut, WORD stnum)
  *  string used with this function therefore has exactly one conversion
  *  specifier (STDISKFU/STDELDIS "%c", STRMVLOC "%s", STFMTINF "%ld"),
  *  and passing a string with more specifiers than values would make
- *  sprintf() read past the end of its argument list.  Do not extend
- *  this function to merge several values; write a dedicated helper
- *  instead.
+ *  sprintf() read past the end of its argument list.  Do not use this
+ *  function to merge several values without rewriting it first (e.g. by
+ *  forwarding the whole va_list to sprintf()).
  */
 WORD fun_alert_merge(WORD defbut, WORD stnum, ...)
 {

--- a/desk/deskfun.c
+++ b/desk/deskfun.c
@@ -83,9 +83,9 @@ WORD fun_alert(WORD defbut, WORD stnum)
  *  practice because every value a caller can supply is at most
  *  pointer-sized: a char promoted to int for "%c", a char * for "%s",
  *  and a long for "%ld", the last guaranteed to fit by the
- *  _Static_assert() above.  sprintf() re-reads the value from its own
- *  varargs list with the type its format specifier demands (see
- *  doprintf() in util/doprintf.c), so a slot that is only re-interpreted
+ *  _Static_assert() in the function body below.  sprintf() re-reads the
+ *  value from its own varargs list with the type its format specifier
+ *  demands (see doprintf() in util/doprintf.c), so a slot that is only re-interpreted
  *  as a smaller or equal-sized type never reads past the value; "%c"
  *  takes an int, which on m68k is 16 bits and on ARM 32, both no wider
  *  than the slot we forwarded.  The same pattern has shipped in upstream
@@ -99,7 +99,7 @@ WORD fun_alert(WORD defbut, WORD stnum)
  *  and passing a string with more specifiers than values would make
  *  sprintf() read past the end of its argument list.  Do not use this
  *  function to merge several values without rewriting it first (e.g. by
- *  forwarding the whole va_list to sprintf()).
+ *  going through a vsprintf()-style helper that takes a va_list).
  */
 WORD fun_alert_merge(WORD defbut, WORD stnum, ...)
 {

--- a/desk/deskfun.c
+++ b/desk/deskfun.c
@@ -91,6 +91,15 @@ WORD fun_alert(WORD defbut, WORD stnum)
  *  than the slot we forwarded.  The same pattern has shipped in upstream
  *  EmuTOS since 2019 and runs on real m68k hardware, so treat it as
  *  intentional rather than something to "fix".
+ *
+ *  The varargs list is contracted to hold exactly one merge value: only
+ *  the first argument is read and forwarded to sprintf().  Every alert
+ *  string used with this function therefore has exactly one conversion
+ *  specifier (STDISKFU/STDELDIS "%c", STRMVLOC "%s", STFMTINF "%ld"),
+ *  and passing a string with more specifiers than values would make
+ *  sprintf() read past the end of its argument list.  Do not extend
+ *  this function to merge several values; write a dedicated helper
+ *  instead.
  */
 WORD fun_alert_merge(WORD defbut, WORD stnum, ...)
 {

--- a/desk/deskfun.c
+++ b/desk/deskfun.c
@@ -77,6 +77,20 @@ WORD fun_alert(WORD defbut, WORD stnum)
  *  The following way of handling multiple types for the variable to be
  *  merged is a bit of a kludge, but at least we make an attempt to
  *  avoid obvious problems ...
+ *
+ *  The merge value is read as a pointer-sized slot (32 bits on both
+ *  m68k and ARM) and forwarded verbatim to sprintf().  This works in
+ *  practice because every value a caller can supply is at most
+ *  pointer-sized: a char promoted to int for "%c", a char * for "%s",
+ *  and a long for "%ld", the last guaranteed to fit by the
+ *  _Static_assert() above.  sprintf() re-reads the value from its own
+ *  varargs list with the type its format specifier demands (see
+ *  doprintf() in util/doprintf.c), so a slot that is only re-interpreted
+ *  as a smaller or equal-sized type never reads past the value; "%c"
+ *  takes an int, which on m68k is 16 bits and on ARM 32, both no wider
+ *  than the slot we forwarded.  The same pattern has shipped in upstream
+ *  EmuTOS since 2019 and runs on real m68k hardware, so treat it as
+ *  intentional rather than something to "fix".
  */
 WORD fun_alert_merge(WORD defbut, WORD stnum, ...)
 {

--- a/desk/deskfun.c
+++ b/desk/deskfun.c
@@ -21,6 +21,7 @@
 
 /* #define ENABLE_KDEBUG */
 
+#include <stdarg.h>
 #include "config.h"
 #include "portab.h"
 #include "obdefs.h"
@@ -71,43 +72,24 @@ WORD fun_alert(WORD defbut, WORD stnum)
 
 
 /*
- *  Issue an alert after merging in an optional character variable
+ *  Issue an alert after merging in a variable
+ *
+ *  The following way of handling multiple types for the variable to be
+ *  merged is a bit of a kludge, but at least we make an attempt to
+ *  avoid obvious problems ...
  */
-WORD fun_alert_merge(WORD defbut, WORD stnum, BYTE merge)
+WORD fun_alert_merge(WORD defbut, WORD stnum, ...)
 {
+    va_list ap;
+    _Static_assert(sizeof(void *) >= sizeof(long), "incompatible type sizes");
+
+    va_start(ap, stnum);
     rsrc_gaddr_rom(R_STRING, stnum, (void **)&G.a_alert);
-    sprintf(G.g_1text, G.a_alert, merge);
+    sprintf(G.g_1text, G.a_alert, va_arg(ap, void *));
+    va_end(ap);
 
     return form_alert(defbut, G.g_1text);
 }
-
-
-#if CONF_WITH_FORMAT
-/*
- *  Issue an alert after merging in a long variable
- */
-WORD fun_alert_long(WORD defbut, WORD stnum, LONG merge)
-{
-    rsrc_gaddr_rom(R_STRING, stnum, (void **)&G.a_alert);
-    sprintf(G.g_1text, G.a_alert, merge);
-
-    return form_alert(defbut, G.g_1text);
-}
-#endif
-
-
-#if CONF_WITH_DESKTOP_SHORTCUTS
-/*
- *  Issue an alert after merging in a string
- */
-WORD fun_alert_string(WORD defbut, WORD stnum, BYTE *merge)
-{
-    rsrc_gaddr_rom(R_STRING, stnum, (void **)&G.a_alert);
-    sprintf(G.g_1text, G.a_alert, merge);
-
-    return form_alert(defbut, G.g_1text);
-}
-#endif
 
 
 void fun_msg(WORD type, WORD w3, WORD w4, WORD w5, WORD w6, WORD w7)

--- a/desk/deskfun.h
+++ b/desk/deskfun.h
@@ -18,15 +18,7 @@
 #define CLOSE_TO_ROOT   2       /* display root folder in window */
 
 WORD fun_alert(WORD defbut, WORD stnum);
-WORD fun_alert_merge(WORD defbut, WORD stnum, BYTE merge);
-
-#if CONF_WITH_FORMAT
-WORD fun_alert_long(WORD defbut, WORD stnum, LONG merge);
-#endif
-
-#if CONF_WITH_DESKTOP_SHORTCUTS
-WORD fun_alert_string(WORD defbut, WORD stnum, BYTE *merge);
-#endif
+WORD fun_alert_merge(WORD defbut, WORD stnum, ...);
 
 #if CONF_WITH_FILEMASK
 void fun_mask(WNODE *pw);

--- a/desk/desksupp.c
+++ b/desk/desksupp.c
@@ -341,7 +341,7 @@ static void remove_locate_shortcut(WORD curr)
     if (!pa)        /* can't happen */
         return;
 
-    rc = fun_alert_string(1, STRMVLOC, filename_start(pa->a_pdata));
+    rc = fun_alert_merge(1, STRMVLOC, filename_start(pa->a_pdata));
     switch(rc)
     {
     case 1:             /* Remove */
@@ -1407,7 +1407,7 @@ void do_format(void)
             drive = (tree[FMT_DRVA].ob_state & SELECTED) ? 0 : 1;
             refresh_drive('A'+drive);           /* update relevant windows */
             dos_space(drive + 1, &total, &avail);
-            if (fun_alert_long(2, STFMTINF, avail) == 2)
+            if (fun_alert_merge(2, STFMTINF, avail) == 2)
                 rc = -1;
         }
         tree[FMT_BAR].ob_width = max_width;     /* reset to starting values */

--- a/docs/superpowers/plans/2026-08-08-port-generic-desktop-alert.md
+++ b/docs/superpowers/plans/2026-08-08-port-generic-desktop-alert.md
@@ -1,0 +1,208 @@
+# Generic Desktop Alert Port Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port upstream EmuTOS commit `47f05896` into this fork: replace the three desktop alert helpers (`fun_alert_merge`, `fun_alert_long`, `fun_alert_string`) with a single variadic `fun_alert_merge(WORD defbut, WORD stnum, ...)` and rename the two remaining call sites, keeping the fork's `rsrc_gaddr_rom` string fetch and `G.g_1text` buffer (issue #118).
+
+**Architecture:** The fork already lacks the upstream `deskapp.c`/`deskdir.c` retry loops, so only the `deskfun.c`/`deskfun.h` consolidation plus two `desksupp.c` renames apply. The merged function reads the RSC string with `rsrc_gaddr_rom` (as the fork's `fun_alert` does) and `sprintf`s the `va_arg(ap, void *)` merge value into `G.g_1text`. Both `#if CONF_WITH_FORMAT` / `#if CONF_WITH_DESKTOP_SHORTCUTS` guards on the deleted helpers disappear; the variadic function is unconditional, matching upstream. See `docs/superpowers/specs/2026-08-08-port-generic-desktop-alert-design.md`.
+
+**Tech Stack:** GCC C90 (`-std=gnu90`), `-Wundef`, `portab.h` types (`WORD`, `BYTE`, `LONG`, `void *`), `<stdarg.h>` (already used in `bios/kprint.c:16`, `desk/gembind.c:30`). Verification via `make` + `make gitready` and the `.claude/skills/ptos-smoketest/SKILL.md` invocations.
+
+## Global Constraints
+
+- C90 with GNU extensions: declarations at the top of a block; `/* */` comments. 4 spaces, never a hard tab. Run `make gitready` before committing.
+- **`int` is 16 bits on m68k** (`-mshort`), 32 bits on ARM. `void *` is 32-bit on both targets.
+- `-Wundef` is on: every `#if` symbol must be defined. Feature symbols are always defined `0`/`1`. Never edit `obj/autoconf.h` / `obj/auto.conf`.
+- The fork has **no `desktop_str_addr`** — always fetch strings with `rsrc_gaddr_rom(R_STRING, stnum, (void **)&G.a_alert)`, exactly as `fun_alert()` at `desk/deskfun.c:68` does.
+- The fork buffers merged alerts into `G.g_1text` (there is no `G.g_work` in this fork).
+- `_Static_assert` is already used in this fork (`aes/gemaplib.c:203`) and is accepted by the toolchains.
+- `deskdir.c:437` (`STDISKFU`) and `deskdir.c:878` (`STDELDIS`) already call `fun_alert_merge` — do not touch them.
+- Verification before completion: build the affected configs and run the smoke tests listed in each task; report real output, not assumptions.
+- The two renamed callers stay inside their existing `#if` blocks (`CONF_WITH_DESKTOP_SHORTCUTS` at `desksupp.c:306`, `CONF_WITH_FORMAT` at `desksupp.c:1147`). No Kconfig change.
+
+---
+
+### Task 1: Collapse the three alert helpers into variadic `fun_alert_merge`
+
+Delivers the whole port: `deskfun.c`/`deskfun.h` consolidation and the two `desksupp.c` renames, verified by a clean build and a stale-reference grep.
+
+**Files:**
+- Modify: `desk/deskfun.c:22-29` (add `#include <stdarg.h>`), `desk/deskfun.c:73-110` (replace three functions)
+- Modify: `desk/deskfun.h:20-29` (replace three prototypes + two `#if` guards)
+- Modify: `desk/desksupp.c:344` (rename `fun_alert_string` → `fun_alert_merge`)
+- Modify: `desk/desksupp.c:1410` (rename `fun_alert_long` → `fun_alert_merge`)
+- Test: `configs/atari512_defconfig`, `configs/rpi2_defconfig`, `configs/virt-arm_defconfig`, `configs/atari512-dispatch_defconfig`, `configs/rpi2-sparse_defconfig`
+
+**Interfaces:**
+- Consumes: existing `rsrc_gaddr_rom` (from `aesbind.h`/`deskbind.h`, already used at `deskfun.c:68`), `form_alert()`, `G.a_alert`, `G.g_1text`, `filename_start()`, `sprintf`.
+- Produces: single prototype `WORD fun_alert_merge(WORD defbut, WORD stnum, ...);` in `desk/deskfun.h`; variadic definition in `desk/deskfun.c`. Removes `fun_alert_long` and `fun_alert_string` entirely (no other references remain after the `desksupp.c` renames).
+
+- [ ] **Step 1: Add `#include <stdarg.h>` to deskfun.c**
+
+In `desk/deskfun.c`, add `#include <stdarg.h>` immediately after the `/* #define ENABLE_KDEBUG */` block, before `#include "config.h"` (line 24):
+
+```c
+#include <stdarg.h>
+#include "config.h"
+```
+
+The `#include <stdarg.h>` line is placed directly above the existing `#include "config.h"`.
+
+- [ ] **Step 2: Replace the three alert helpers in deskfun.c**
+
+Replace the whole block from `desk/deskfun.c:73` (the comment `/*\n *  Issue an alert after merging in an optional character variable\n */`) through line 110 (`#endif` closing `CONF_WITH_DESKTOP_SHORTCUTS`) with:
+
+```c
+
+/*
+ *  Issue an alert after merging in a variable
+ *
+ *  The following way of handling multiple types for the variable to be
+ *  merged is a bit of a kludge, but at least we make an attempt to
+ *  avoid obvious problems ...
+ */
+WORD fun_alert_merge(WORD defbut, WORD stnum, ...)
+{
+    va_list ap;
+    _Static_assert(sizeof(void *) >= sizeof(long), "incompatible type sizes");
+
+    va_start(ap, stnum);
+    rsrc_gaddr_rom(R_STRING, stnum, (void **)&G.a_alert);
+    sprintf(G.g_1text, G.a_alert, va_arg(ap, void *));
+    va_end(ap);
+
+    return form_alert(defbut, G.g_1text);
+}
+```
+
+The result must look exactly like the upstream commit's `deskfun.c` hunk, except `rsrc_gaddr_rom(...)` replaces upstream's `desktop_str_addr(stnum)` and `G.g_1text` replaces upstream's `G.g_work`.
+
+- [ ] **Step 3: Replace the three prototypes in deskfun.h**
+
+In `desk/deskfun.h`, replace lines 20-29 (the three prototypes plus both `#if` guard blocks) with a single prototype:
+
+```c
+WORD fun_alert(WORD defbut, WORD stnum);
+WORD fun_alert_merge(WORD defbut, WORD stnum, ...);
+```
+
+The `fun_alert` line stays; `fun_alert_merge` becomes variadic; the `#if CONF_WITH_FORMAT` / `#if CONF_WITH_DESKTOP_SHORTCUTS` blocks around `fun_alert_long` / `fun_alert_string` are deleted.
+
+- [ ] **Step 4: Rename the two desksupp.c call sites**
+
+In `desk/desksupp.c`:
+
+- Line 344: `rc = fun_alert_string(1, STRMVLOC, filename_start(pa->a_pdata));` → `rc = fun_alert_merge(1, STRMVLOC, filename_start(pa->a_pdata));`
+- Line 1410: `if (fun_alert_long(2, STFMTINF, avail) == 2)` → `if (fun_alert_merge(2, STFMTINF, avail) == 2)`
+
+Do not change anything else on those lines or around them.
+
+- [ ] **Step 5: Grep for stale references**
+
+Run:
+
+```sh
+grep -rn "fun_alert_string\|fun_alert_long" --include="*.c" --include="*.h" . | grep -v "\.git\|obj/"
+```
+
+Expected: no output (exit status 1). If any hits remain outside `obj/`, the renames were missed.
+
+- [ ] **Step 6: Build atari512 and rpi2**
+
+```sh
+make atari512_defconfig && make clean && make
+make rpi2_defconfig && make clean && make
+```
+
+Expected: both build successfully with no warnings related to `deskfun` / `stdarg` / `fun_alert`. `rpi2` exercises the ARM toolchain; `atari512` exercises m68k with the guarded `CONF_WITH_FORMAT` caller (`STFMTINF`) compiled in.
+
+- [ ] **Step 7: Build with the guards toggled (atari512)**
+
+Prove the merged function is unconditional — build with `CONF_WITH_DESKTOP_SHORTCUTS` and `CONF_WITH_FORMAT` both off:
+
+```sh
+make atari512_defconfig
+sed -i 's/^CONF_WITH_DESKTOP_SHORTCUTS=y/# CONF_WITH_DESKTOP_SHORTCUTS is not set/; s/^CONF_WITH_FORMAT=y/# CONF_WITH_FORMAT is not set/' .config
+make clean && make
+```
+
+Expected: builds clean. The guards now only gate the *callers* (the `STRMVLOC` block at `desksupp.c:306-…` and the format dialog at `desksupp.c:1147-…`), while the variadic `fun_alert_merge` itself always compiles. `.config` uses Kconfiglib format; commenting out the `=y` lines with the `# CONF_WITH_... is not set` form is the correct way to disable a symbol (there is no `scripts/config` tool in this fork).
+
+- [ ] **Step 8: Restore the config and run gitready**
+
+```sh
+make atari512_defconfig
+make gitready
+```
+
+Expected: `make gitready` reports no whitespace/format problems.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add desk/deskfun.c desk/deskfun.h desk/desksupp.c
+git commit -m "feat(desk): port generic desktop alert refactor (#118)"
+```
+
+---
+
+### Task 2: Full configuration matrix and smoke tests
+
+Delivers the spec's verification section: all five configs build with the expected object sets, and the GEM desktop is reachable under Hatari (atari512, atari512-dispatch) and QEMU (rpi2-sparse, virt-arm), with no new `guest_errors`.
+
+**Files:**
+- Test: `configs/atari512_defconfig`, `configs/rpi2_defconfig`, `configs/virt-arm_defconfig`, `configs/atari512-dispatch_defconfig`, `configs/rpi2-sparse_defconfig`
+- Reference: `.claude/skills/ptos-smoketest/SKILL.md` (pass signals and QEMU/Hatari invocations)
+
+**Interfaces:**
+- Consumes: the variadic `fun_alert_merge` from Task 1 and the renamed callers.
+- Produces: verified evidence for the PR that the port builds and boots on planar (m68k + ARM) and truecolor (m68k dispatch + ARM) configurations.
+
+- [ ] **Step 1: Build the full matrix from a clean tree**
+
+```sh
+make distclean
+make atari512_defconfig && make
+make rpi2_defconfig && make clean && make
+make virt-arm_defconfig && make clean && make
+make atari512-dispatch_defconfig && make clean && make
+make rpi2-sparse_defconfig && make clean && make
+```
+
+Expected: all five build cleanly. `atari512` / `virt-arm` build the planar backend only (no `obj/vdi_backend*.o`); `rpi2` builds truecolor only (`obj/vdi_backend_truecolor.o`); `atari512-dispatch` / `rpi2-sparse` build both plus `obj/vdi_backend.o`.
+
+- [ ] **Step 2: Hatari boot atari512**
+
+Follow `.claude/skills/ptos-smoketest/SKILL.md` for the atari512 Hatari invocation (after rebuilding `ptos512k.img` — the matrix leaves `rpi2-sparse`'s image as the last built, so run `make atari512_defconfig && make clean && make` first if `ptos512k.img` is absent).
+
+Expected: GEM desktop reachable; all-pixel checkerboard counts `green > 40000 && white > 50000`. The known pre-existing `WARN : Bus Error reading at $4fffff/$cc03c3, PC=$e00c20` may appear — it is noise, identical on stock builds.
+
+- [ ] **Step 3: Hatari boot atari512-dispatch**
+
+Run the atari512-dispatch Hatari invocation from the smoketest skill. Expected: desktop reachable (same checkerboard pass signal).
+
+- [ ] **Step 4: QEMU boot rpi2-sparse and virt-arm**
+
+Rebuild each config (`make rpi2-sparse_defconfig && make clean && make`, then `make virt-arm_defconfig && make clean && make`) and boot under QEMU per the smoketest skill.
+
+Expected: both reach the GEM desktop (`rc=124` after the timeout is the expected way to stop a healthy boot); `guest_errors` log empty or containing only pre-existing, unrelated messages.
+
+- [ ] **Step 5: Confirm no stale references in the final tree**
+
+```sh
+grep -rn "fun_alert_string\|fun_alert_long" --include="*.c" --include="*.h" . | grep -v "\.git\|obj/"
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Final gitready and commit**
+
+```sh
+make atari512_defconfig
+make gitready
+git add -A
+git commit -m "chore(desk): verify generic desktop alert port across all configs (#118)"
+git push
+```
+
+Expected: `make gitready` clean; commit pushed; PR #141 left in draft for the maintainer to review and mark ready.

--- a/docs/superpowers/plans/2026-08-08-port-generic-desktop-alert.md
+++ b/docs/superpowers/plans/2026-08-08-port-generic-desktop-alert.md
@@ -14,7 +14,7 @@
 - **`int` is 16 bits on m68k** (`-mshort`), 32 bits on ARM. `void *` is 32-bit on both targets.
 - `-Wundef` is on: every `#if` symbol must be defined. Feature symbols are always defined `0`/`1`. Never edit `obj/autoconf.h` / `obj/auto.conf`.
 - The fork has **no `desktop_str_addr`** — always fetch strings with `rsrc_gaddr_rom(R_STRING, stnum, (void **)&G.a_alert)`, exactly as `fun_alert()` at `desk/deskfun.c:68` does.
-- The fork buffers merged alerts into `G.g_1text` (there is no `G.g_work` in this fork).
+- Upstream commit `47f05896` and the fork both buffer merged alerts into `G.g_1text` — no buffer change needed.
 - `_Static_assert` is already used in this fork (`aes/gemaplib.c:203`) and is accepted by the toolchains.
 - `deskdir.c:437` (`STDISKFU`) and `deskdir.c:878` (`STDELDIS`) already call `fun_alert_merge` — do not touch them.
 - Verification before completion: build the affected configs and run the smoke tests listed in each task; report real output, not assumptions.
@@ -75,7 +75,7 @@ WORD fun_alert_merge(WORD defbut, WORD stnum, ...)
 }
 ```
 
-The result must look exactly like the upstream commit's `deskfun.c` hunk, except `rsrc_gaddr_rom(...)` replaces upstream's `desktop_str_addr(stnum)` and `G.g_1text` replaces upstream's `G.g_work`.
+The result must look exactly like the upstream commit's `deskfun.c` hunk, except `rsrc_gaddr_rom(...)` replaces upstream's `desktop_str_addr(stnum)` (the `G.g_1text` buffer is identical upstream and in the fork).
 
 - [x] **Step 3: Replace the three prototypes in deskfun.h**
 

--- a/docs/superpowers/plans/2026-08-08-port-generic-desktop-alert.md
+++ b/docs/superpowers/plans/2026-08-08-port-generic-desktop-alert.md
@@ -37,7 +37,7 @@ Delivers the whole port: `deskfun.c`/`deskfun.h` consolidation and the two `desk
 - Consumes: existing `rsrc_gaddr_rom` (from `aesbind.h`/`deskbind.h`, already used at `deskfun.c:68`), `form_alert()`, `G.a_alert`, `G.g_1text`, `filename_start()`, `sprintf`.
 - Produces: single prototype `WORD fun_alert_merge(WORD defbut, WORD stnum, ...);` in `desk/deskfun.h`; variadic definition in `desk/deskfun.c`. Removes `fun_alert_long` and `fun_alert_string` entirely (no other references remain after the `desksupp.c` renames).
 
-- [ ] **Step 1: Add `#include <stdarg.h>` to deskfun.c**
+- [x] **Step 1: Add `#include <stdarg.h>` to deskfun.c**
 
 In `desk/deskfun.c`, add `#include <stdarg.h>` immediately after the `/* #define ENABLE_KDEBUG */` block, before `#include "config.h"` (line 24):
 
@@ -48,7 +48,7 @@ In `desk/deskfun.c`, add `#include <stdarg.h>` immediately after the `/* #define
 
 The `#include <stdarg.h>` line is placed directly above the existing `#include "config.h"`.
 
-- [ ] **Step 2: Replace the three alert helpers in deskfun.c**
+- [x] **Step 2: Replace the three alert helpers in deskfun.c**
 
 Replace the whole block from `desk/deskfun.c:73` (the comment `/*\n *  Issue an alert after merging in an optional character variable\n */`) through line 110 (`#endif` closing `CONF_WITH_DESKTOP_SHORTCUTS`) with:
 
@@ -77,7 +77,7 @@ WORD fun_alert_merge(WORD defbut, WORD stnum, ...)
 
 The result must look exactly like the upstream commit's `deskfun.c` hunk, except `rsrc_gaddr_rom(...)` replaces upstream's `desktop_str_addr(stnum)` and `G.g_1text` replaces upstream's `G.g_work`.
 
-- [ ] **Step 3: Replace the three prototypes in deskfun.h**
+- [x] **Step 3: Replace the three prototypes in deskfun.h**
 
 In `desk/deskfun.h`, replace lines 20-29 (the three prototypes plus both `#if` guard blocks) with a single prototype:
 
@@ -88,7 +88,7 @@ WORD fun_alert_merge(WORD defbut, WORD stnum, ...);
 
 The `fun_alert` line stays; `fun_alert_merge` becomes variadic; the `#if CONF_WITH_FORMAT` / `#if CONF_WITH_DESKTOP_SHORTCUTS` blocks around `fun_alert_long` / `fun_alert_string` are deleted.
 
-- [ ] **Step 4: Rename the two desksupp.c call sites**
+- [x] **Step 4: Rename the two desksupp.c call sites**
 
 In `desk/desksupp.c`:
 
@@ -97,7 +97,7 @@ In `desk/desksupp.c`:
 
 Do not change anything else on those lines or around them.
 
-- [ ] **Step 5: Grep for stale references**
+- [x] **Step 5: Grep for stale references**
 
 Run:
 
@@ -107,7 +107,7 @@ grep -rn "fun_alert_string\|fun_alert_long" --include="*.c" --include="*.h" . | 
 
 Expected: no output (exit status 1). If any hits remain outside `obj/`, the renames were missed.
 
-- [ ] **Step 6: Build atari512 and rpi2**
+- [x] **Step 6: Build atari512 and rpi2**
 
 ```sh
 make atari512_defconfig && make clean && make
@@ -116,7 +116,7 @@ make rpi2_defconfig && make clean && make
 
 Expected: both build successfully with no warnings related to `deskfun` / `stdarg` / `fun_alert`. `rpi2` exercises the ARM toolchain; `atari512` exercises m68k with the guarded `CONF_WITH_FORMAT` caller (`STFMTINF`) compiled in.
 
-- [ ] **Step 7: Build with the guards toggled (atari512)**
+- [x] **Step 7: Build with the guards toggled (atari512)**
 
 Prove the merged function is unconditional — build with `CONF_WITH_DESKTOP_SHORTCUTS` and `CONF_WITH_FORMAT` both off:
 
@@ -128,7 +128,7 @@ make clean && make
 
 Expected: builds clean. The guards now only gate the *callers* (the `STRMVLOC` block at `desksupp.c:306-…` and the format dialog at `desksupp.c:1147-…`), while the variadic `fun_alert_merge` itself always compiles. `.config` uses Kconfiglib format; commenting out the `=y` lines with the `# CONF_WITH_... is not set` form is the correct way to disable a symbol (there is no `scripts/config` tool in this fork).
 
-- [ ] **Step 8: Restore the config and run gitready**
+- [x] **Step 8: Restore the config and run gitready**
 
 ```sh
 make atari512_defconfig
@@ -137,7 +137,7 @@ make gitready
 
 Expected: `make gitready` reports no whitespace/format problems.
 
-- [ ] **Step 9: Commit**
+- [x] **Step 9: Commit**
 
 ```bash
 git add desk/deskfun.c desk/deskfun.h desk/desksupp.c
@@ -158,7 +158,7 @@ Delivers the spec's verification section: all five configs build with the expect
 - Consumes: the variadic `fun_alert_merge` from Task 1 and the renamed callers.
 - Produces: verified evidence for the PR that the port builds and boots on planar (m68k + ARM) and truecolor (m68k dispatch + ARM) configurations.
 
-- [ ] **Step 1: Build the full matrix from a clean tree**
+- [x] **Step 1: Build the full matrix from a clean tree**
 
 ```sh
 make distclean
@@ -171,23 +171,23 @@ make rpi2-sparse_defconfig && make clean && make
 
 Expected: all five build cleanly. `atari512` / `virt-arm` build the planar backend only (no `obj/vdi_backend*.o`); `rpi2` builds truecolor only (`obj/vdi_backend_truecolor.o`); `atari512-dispatch` / `rpi2-sparse` build both plus `obj/vdi_backend.o`.
 
-- [ ] **Step 2: Hatari boot atari512**
+- [x] **Step 2: Hatari boot atari512**
 
 Follow `.claude/skills/ptos-smoketest/SKILL.md` for the atari512 Hatari invocation (after rebuilding `ptos512k.img` — the matrix leaves `rpi2-sparse`'s image as the last built, so run `make atari512_defconfig && make clean && make` first if `ptos512k.img` is absent).
 
 Expected: GEM desktop reachable; all-pixel checkerboard counts `green > 40000 && white > 50000`. The known pre-existing `WARN : Bus Error reading at $4fffff/$cc03c3, PC=$e00c20` may appear — it is noise, identical on stock builds.
 
-- [ ] **Step 3: Hatari boot atari512-dispatch**
+- [x] **Step 3: Hatari boot atari512-dispatch**
 
 Run the atari512-dispatch Hatari invocation from the smoketest skill. Expected: desktop reachable (same checkerboard pass signal).
 
-- [ ] **Step 4: QEMU boot rpi2-sparse and virt-arm**
+- [x] **Step 4: QEMU boot rpi2-sparse and virt-arm**
 
 Rebuild each config (`make rpi2-sparse_defconfig && make clean && make`, then `make virt-arm_defconfig && make clean && make`) and boot under QEMU per the smoketest skill.
 
 Expected: both reach the GEM desktop (`rc=124` after the timeout is the expected way to stop a healthy boot); `guest_errors` log empty or containing only pre-existing, unrelated messages.
 
-- [ ] **Step 5: Confirm no stale references in the final tree**
+- [x] **Step 5: Confirm no stale references in the final tree**
 
 ```sh
 grep -rn "fun_alert_string\|fun_alert_long" --include="*.c" --include="*.h" . | grep -v "\.git\|obj/"
@@ -195,7 +195,7 @@ grep -rn "fun_alert_string\|fun_alert_long" --include="*.c" --include="*.h" . | 
 
 Expected: no output.
 
-- [ ] **Step 6: Final gitready and commit**
+- [x] **Step 6: Final gitready and commit**
 
 ```sh
 make atari512_defconfig

--- a/docs/superpowers/specs/2026-08-08-port-generic-desktop-alert-design.md
+++ b/docs/superpowers/specs/2026-08-08-port-generic-desktop-alert-design.md
@@ -1,0 +1,117 @@
+# Design: Port generic desktop alert refactor (#118)
+
+Part of #111 (cherry-pick upstream EmuTOS desktop/AES features).
+
+## Goal
+
+Port upstream EmuTOS commit `47f05896` "Implement generic desktop alert
+function" (Roger Burrows, 2019-07-23) into this fork, adapted to the fork's
+divergences.
+
+The commit replaces three desktop alert helpers with a single variadic one,
+simplifying the code and saving ROM.
+
+## Note on the issue text
+
+Issue #118 says the change is "Self-contained in `aes/gemfmalt.c`". That is
+wrong: the commit touches only `desk/` files and `aes/gemfmalt.c` is
+untouched. Per the maintainer's decision, we port the actual commit in
+`desk/`.
+
+## Upstream change (before fork adaptation)
+
+The three functions
+
+- `fun_alert_merge(WORD defbut, WORD stnum, BYTE merge)`  (always built)
+- `fun_alert_long(WORD defbut, WORD stnum, LONG merge)`   (#if CONF_WITH_FORMAT)
+- `fun_alert_string(WORD defbut, WORD stnum, BYTE *merge)` (#if CONF_WITH_DESKTOP_SHORTCUTS in fork)
+
+collapse into
+
+```c
+WORD fun_alert_merge(WORD defbut, WORD stnum, ...)
+{
+    va_list ap;
+    _Static_assert(sizeof(void *) >= sizeof(long), "incompatible type sizes");
+
+    va_start(ap, stnum);
+    sprintf(G.g_work, desktop_str_addr(stnum), va_arg(ap, void *));
+    va_end(ap);
+
+    return form_alert(defbut, G.g_work);
+}
+```
+
+plus `#include <stdarg.h>` and the header prototype
+
+```c
+WORD fun_alert_merge(WORD defbut, WORD stnum, ...);
+```
+
+Upstream call sites renamed `fun_alert_string`/`fun_alert_long` to
+`fun_alert_merge` in `deskapp.c`, `deskdir.c` and `desksupp.c`.
+
+Current upstream master still carries the variadic form, so this port tracks
+upstream's final state.
+
+## Fork divergences and how the port adapts
+
+| Upstream | Fork | Port action |
+| --- | --- | --- |
+| `desktop_str_addr(stnum)` | `rsrc_gaddr_rom(R_STRING, stnum, (void **)&G.a_alert)` (no `desktop_str_addr` in fork) | keep fork's fetch inside the variadic body |
+| `G.g_work` buffer | `G.g_1text` buffer | keep `G.g_1text` |
+| `deskapp.c` retry loop calls `fun_alert_string(1, STCRTFIL, ...)` | fork `save_to_disk()` (deskapp.c:906) has no retry loop; uses `fun_alert(1, STSVINF)`/`fun_alert(1, STNOINF)` | no change |
+| `deskdir.c` STDELFIL/STDELDIR/STOPFAIL/STCRTFIL `fun_alert_string` calls | fork has no such retry loops | no change |
+| `desksupp.c` STFILENF/STTRINFO/STPRINFO `fun_alert_string` calls | fork lacks these call sites | no change |
+| — | fork callers: deskdir.c:437 `fun_alert_merge(1, STDISKFU, pdst_file[0])`, deskdir.c:878 `fun_alert_merge(2, STDELDIS, psrc_path[0])`, desksupp.c:344 `fun_alert_string(1, STRMVLOC, ...)`, desksupp.c:1410 `fun_alert_long(2, STFMTINF, avail)` | deskdir.c callers unchanged (already call `fun_alert_merge`); desksupp.c:344/1410 renamed to `fun_alert_merge` |
+
+## Configuration
+
+The fork guards `fun_alert_string` under `CONF_WITH_DESKTOP_SHORTCUTS` and
+`fun_alert_long` under `CONF_WITH_FORMAT`. Per the maintainer's decision we
+port faithfully: both functions are deleted entirely and the variadic
+`fun_alert_merge` is unconditional, matching upstream. The guards in
+`deskfun.h`/`deskfun.c` disappear; the remaining `CONF_WITH_DESKTOP_SHORTCUTS`
+and `CONF_WITH_FORMAT` options stay (they gate other code) and the renamed
+callers remain inside their existing `#if` blocks. No Kconfig change.
+
+## Files changed
+
+- `desk/deskfun.c` — add `#include <stdarg.h>`; replace the three functions
+  (deskfun.c:76-110) with the variadic `fun_alert_merge`, using
+  `rsrc_gaddr_rom` + `G.g_1text`; drop the two `#if` guards.
+- `desk/deskfun.h` — replace the three prototypes and both `#if` guards
+  (deskfun.h:21-29) with the single variadic prototype.
+- `desk/desksupp.c` — rename `fun_alert_string(1, STRMVLOC, ...)` at :344 to
+  `fun_alert_merge(...)`; rename `fun_alert_long(2, STFMTINF, avail)` at :1410
+  to `fun_alert_merge(...)`.
+
+## Portability notes
+
+- The `va_arg(ap, void *)` read is a deliberate upstream "kludge": on m68k
+  `int` is 16 bits but `void *` is 32 bits, so a `%c` merge passes a promoted
+  char while the callee reads a pointer-sized slot. This ships in upstream
+  EmuTOS on real m68k hardware since 2019; on ARM both are 32-bit and clean.
+  `_Static_assert(sizeof(void *) >= sizeof(long))` guards the `%ld` case.
+- `_Static_assert` is already used in the fork (`aes/gemaplib.c:203`).
+- Format strings (`desk/desk_rsc.c`): STDISKFU `%c`, STDELDIS `%c`, STRMVLOC
+  `%s`, STFMTINF `%ld`; each passes the matching argument.
+
+## Verification
+
+- Build all five configs used for issue #138: atari512, rpi2, virt-arm,
+  atari512-dispatch, rpi2-sparse. Check `obj/` object sets unchanged except
+  expected.
+- Hatari boot atari512 and atari512-dispatch; QEMU boot rpi2-sparse and
+  virt-arm; confirm GEM desktop reachable (checkerboard counts), no new
+  `guest_errors`.
+- Confirm `fun_alert_string`/`fun_alert_long` no longer referenced anywhere.
+- Build with `CONF_WITH_DESKTOP_SHORTCUTS` off and `CONF_WITH_FORMAT` on and
+  vice versa to prove the merged function is unconditionally available.
+
+## Out of scope
+
+- Upstream's `deskapp.c`/`deskdir.c` retry-loop call sites (do not exist in
+  the fork).
+- Any change to `aes/gemfmalt.c` (unrelated to this commit).
+- Behavior of `form_alert()` itself.

--- a/docs/superpowers/specs/2026-08-08-port-generic-desktop-alert-design.md
+++ b/docs/superpowers/specs/2026-08-08-port-generic-desktop-alert-design.md
@@ -35,10 +35,10 @@ WORD fun_alert_merge(WORD defbut, WORD stnum, ...)
     _Static_assert(sizeof(void *) >= sizeof(long), "incompatible type sizes");
 
     va_start(ap, stnum);
-    sprintf(G.g_work, desktop_str_addr(stnum), va_arg(ap, void *));
+    sprintf(G.g_1text, desktop_str_addr(stnum), va_arg(ap, void *));
     va_end(ap);
 
-    return form_alert(defbut, G.g_work);
+    return form_alert(defbut, G.g_1text);
 }
 ```
 
@@ -59,7 +59,6 @@ upstream's final state.
 | Upstream | Fork | Port action |
 | --- | --- | --- |
 | `desktop_str_addr(stnum)` | `rsrc_gaddr_rom(R_STRING, stnum, (void **)&G.a_alert)` (no `desktop_str_addr` in fork) | keep fork's fetch inside the variadic body |
-| `G.g_work` buffer | `G.g_1text` buffer | keep `G.g_1text` |
 | `deskapp.c` retry loop calls `fun_alert_string(1, STCRTFIL, ...)` | fork `save_to_disk()` (deskapp.c:906) has no retry loop; uses `fun_alert(1, STSVINF)`/`fun_alert(1, STNOINF)` | no change |
 | `deskdir.c` STDELFIL/STDELDIR/STOPFAIL/STCRTFIL `fun_alert_string` calls | fork has no such retry loops | no change |
 | `desksupp.c` STFILENF/STTRINFO/STPRINFO `fun_alert_string` calls | fork lacks these call sites | no change |


### PR DESCRIPTION
Fixes #118

Ports upstream EmuTOS commit 47f05896 "Implement generic desktop alert function" (Roger Burrows, 2019-07-23): replaces fun_alert_merge/fun_alert_long/fun_alert_string with a single variadic fun_alert_merge, adapted to the fork's rsrc_gaddr_rom string fetch.