### PR TITLE
vdi: implement vs_color()/vq_color() for the truecolor backend

### DIFF
--- a/vdi/vdi_backend.c
+++ b/vdi/vdi_backend.c
@@ -37,6 +37,15 @@ const vdi_backend_ops *vdi_backend_select(const SCREEN_MODE_DESC *mode)
 }
 
 /*
+ * vdi_backend_set_active_vwk()/vdi_backend_active_vwk() (issue #89) live in
+ * vdi_backend_truecolor.c, not here: this file is only built when
+ * CONF_WITH_VDI_BACKEND_DISPATCH is set (both renderers enabled, see
+ * vdi/build.mk), but the truecolor backend -- and so these two functions'
+ * only caller, vdi_main.c's screen() -- exists in single-renderer RPi
+ * builds too, which don't build this file at all.
+ */
+
+/*
  * Generic backend defaults (issue #138): renderer-agnostic fallbacks built
  * only on the mandatory primitives (get_start_addr, get_pixel, put_pixel,
  * get_raw_pixel, put_raw_pixel).  They run through vdi_screen_backend(),

--- a/vdi/vdi_backend.h
+++ b/vdi/vdi_backend.h
@@ -143,13 +143,29 @@ UWORD vdi_truecolor_pixel_for_index(WORD index);
 
 /*
  * vs_color()/vq_color() pseudo-palette access for the truecolor backend
- * (issue #89) -- see the definitions in vdi_backend_truecolor.c for the
- * single-shared-table rationale. index is a MAP_COL-mapped hardware
- * palette register index; r/g/b are VDI-scale color values (0-1000).
- * Called from vdi_vs_color()/vdi_vq_color() in vdi_col.c.
+ * (issue #89). Genuinely per-workstation (see the tc_palette comment on
+ * struct Vwk_ in vdi_defs.h): vwk identifies which workstation's palette
+ * to read/write. index is a MAP_COL-mapped hardware palette register
+ * index; r/g/b are VDI-scale color values (0-1000). Called from
+ * vdi_vs_color()/vdi_vq_color() in vdi_col.c, which already have the
+ * right vwk from the VDI dispatcher.
  */
-void vdi_truecolor_set_color(WORD index, WORD r, WORD g, WORD b);
-void vdi_truecolor_get_color(WORD index, WORD *r, WORD *g, WORD *b);
+void vdi_truecolor_set_color(Vwk *vwk, WORD index, WORD r, WORD g, WORD b);
+void vdi_truecolor_get_color(const Vwk *vwk, WORD index, WORD *r, WORD *g, WORD *b);
+
+/* Seeds vwk's pseudo-palette with the backend's boot-time defaults. Called
+ * by init_wk() (vdi_control.c) whenever a workstation is opened, and by
+ * vdi_backend_active_vwk() (see above) for the physical workstation if
+ * drawing happens before vdi_v_opnwk() ever runs. */
+void vdi_truecolor_init_palette(Vwk *vwk);
+
+/*
+ * The workstation whose pseudo-palette get_pixel()/put_pixel()/etc.
+ * (none of which take a Vwk*) should translate indices through -- see the
+ * definitions in vdi_backend.c. Sole writer is vdi_main.c's screen().
+ */
+void vdi_backend_set_active_vwk(Vwk *vwk);
+Vwk *vdi_backend_active_vwk(void);
 #endif
 
 #endif /* VDI_BACKEND_H */

--- a/vdi/vdi_backend.h
+++ b/vdi/vdi_backend.h
@@ -162,7 +162,10 @@ void vdi_truecolor_init_palette(Vwk *vwk);
 /*
  * The workstation whose pseudo-palette get_pixel()/put_pixel()/etc.
  * (none of which take a Vwk*) should translate indices through -- see the
- * definitions in vdi_backend.c. Sole writer is vdi_main.c's screen().
+ * definitions in vdi_backend_truecolor.c. Written by vdi_main.c's
+ * screen() once per VDI call, and by vdi_v_clsvwk() (vdi_control.c),
+ * which points it back at the physical workstation if the Vwk it is
+ * about to free is the currently active one.
  */
 void vdi_backend_set_active_vwk(Vwk *vwk);
 Vwk *vdi_backend_active_vwk(void);

--- a/vdi/vdi_backend.h
+++ b/vdi/vdi_backend.h
@@ -140,6 +140,16 @@ static inline BOOL vdi_screen_is_truecolor(void)
  */
 #if CONF_WITH_VDI_BACKEND_TRUECOLOR
 UWORD vdi_truecolor_pixel_for_index(WORD index);
+
+/*
+ * vs_color()/vq_color() pseudo-palette access for the truecolor backend
+ * (issue #89) -- see the definitions in vdi_backend_truecolor.c for the
+ * single-shared-table rationale. index is a MAP_COL-mapped hardware
+ * palette register index; r/g/b are VDI-scale color values (0-1000).
+ * Called from vdi_vs_color()/vdi_vq_color() in vdi_col.c.
+ */
+void vdi_truecolor_set_color(WORD index, WORD r, WORD g, WORD b);
+void vdi_truecolor_get_color(WORD index, WORD *r, WORD *g, WORD *b);
 #endif
 
 #endif /* VDI_BACKEND_H */

--- a/vdi/vdi_backend_truecolor.c
+++ b/vdi/vdi_backend_truecolor.c
@@ -27,9 +27,10 @@
  * (rather than clamping anything outside 0-15 to index 0, which used
  * to alias pen 1 to default_prgb_palette[0] == white) keeps this
  * consistent with the indexed framebuffer the old 8bpp path used to
- * write into. This is the boot-time default -- vdi_truecolor_set_color()
- * below (issue #89) is what lets vs_color() actually change entries away
- * from it at runtime.
+ * write into. This is only the boot-time default that
+ * vdi_truecolor_init_palette() below (issue #89) seeds each workstation's
+ * own tc_palette[] from -- vdi_truecolor_set_color() is what lets
+ * vs_color() change a workstation's entries away from it at runtime.
  */
 static const ULONG default_prgb_palette[256] = {
     0x00ffffff, 0x000000ff, 0x0000ff00, 0x0000ffff,
@@ -108,25 +109,67 @@ static UWORD rgb565_from_prgb(ULONG prgb)
 }
 
 /*
- * default_prgb_palette[] converted to RGB565, built lazily on first use.
- * truecolor_get_pixel() searches this space on every call, so it matters
- * that the conversion happens once rather than being redone for every
- * candidate on every pixel read.
+ * Seeds vwk's pseudo-palette (issue #89) with default_prgb_palette[]
+ * converted to RGB565. Called by init_wk() (vdi_control.c) whenever a
+ * workstation is opened, and by vdi_backend_active_vwk() below for the
+ * physical workstation if drawing happens before vdi_v_opnwk() ever runs.
  */
-static UWORD rgb565_palette[256];
-static BOOL rgb565_palette_ready;
-
-static void ensure_rgb565_palette(void)
+void vdi_truecolor_init_palette(Vwk *vwk)
 {
     WORD i;
 
-    if (rgb565_palette_ready)
-        return;
-
     for (i = 0; i < 256; i++)
-        rgb565_palette[i] = rgb565_from_prgb(default_prgb_palette[i]);
+        vwk->tc_palette[i] = rgb565_from_prgb(default_prgb_palette[i]);
+}
 
-    rgb565_palette_ready = TRUE;
+/*
+ * The workstation whose pseudo-palette the drawing primitives below
+ * (get_pixel/put_pixel/fill_rect/text_blit/raster_copy/draw_line/
+ * search_left/search_right) translate indices through -- none of them
+ * take a Vwk*, so vdi_main.c's screen() dispatcher is the sole writer,
+ * via vdi_backend_set_active_vwk(), once per VDI call, with the Vwk
+ * resolved for that call's handle (or the physical workstation for
+ * v_opnwk()/v_opnvwk(), which have no handle yet).
+ *
+ * Lives here rather than in vdi_backend.c because this file is built
+ * whenever CONF_WITH_VDI_BACKEND_TRUECOLOR is set, including the
+ * single-renderer RPi default; vdi_backend.c only builds when both
+ * renderers are enabled (see vdi/build.mk).
+ *
+ * This is a fresh pTOS-internal variable rather than linea_vars.CUR_WORK,
+ * because CUR_WORK is part of the documented line-A ABI: user code can
+ * point it at a fake reduced "workstation" (see the NOTE on Vwk_ in
+ * vdi_defs.h), which is safe for CUR_WORK's existing single-WORD use
+ * (fill_color, at a fixed low offset) but would be an out-of-bounds read
+ * for a 256-entry palette placed well beyond that.
+ */
+static Vwk *active_vwk;
+
+void vdi_backend_set_active_vwk(Vwk *vwk)
+{
+    active_vwk = vwk;
+}
+
+Vwk *vdi_backend_active_vwk(void)
+{
+    if (!active_vwk) {
+        /*
+         * Nothing has gone through screen() yet -- e.g. Line-A reachable
+         * before vdi_v_opnwk() ever runs (see the vdi_screen_backend()
+         * comment in vdi_control.c for the same situation with
+         * .mode/.backend). Fall back to the physical workstation, and
+         * since init_wk() hasn't necessarily seeded it yet either, seed
+         * it here.
+         */
+        active_vwk = vdi_physical_vwk();
+        vdi_truecolor_init_palette(active_vwk);
+    }
+    return active_vwk;
+}
+
+static UWORD *active_palette(void)
+{
+    return vdi_backend_active_vwk()->tc_palette;
 }
 
 static UWORD truecolor_pixel_for_index(WORD index)
@@ -134,8 +177,7 @@ static UWORD truecolor_pixel_for_index(WORD index)
     if (index < 0 || index > 255)
         index = 0;
 
-    ensure_rgb565_palette();
-    return rgb565_palette[index];
+    return active_palette()[index];
 }
 
 /*
@@ -180,36 +222,29 @@ static void vdi_from_rgb565(UWORD raw, WORD *r, WORD *g, WORD *b)
 /*
  * vs_color()/vq_color() pseudo-palette read/write ports for the truecolor
  * backend (issue #89), called from vdi_vs_color()/vdi_vq_color() in
- * vdi_col.c. index is a MAP_COL-mapped hardware palette register index,
- * like every other index this file takes -- not a 0-15 VDI pen number.
+ * vdi_col.c with the vwk those already have from the VDI dispatcher.
+ * index is a MAP_COL-mapped hardware palette register index, like every
+ * other index this file takes -- not a 0-15 VDI pen number.
  *
- * There is exactly one screen (see the vdi_screen_backend() comment in
- * vdi_control.c), so unlike upstream's per-Vwk VwkExt::palette this is one
- * shared table rather than one per virtual workstation -- matching how
- * set_color() in vdi_col.c treats every other backend's hardware palette
- * registers: a single physical resource that the most recent vs_color()
- * call (from whichever workstation) last wrote, not a per-workstation
- * fiction layered on hardware that doesn't have per-workstation state
- * either. rgb565_palette[] (see ensure_rgb565_palette() above) already is
- * exactly that shared resource; these two functions are its mutation and
- * query entry points.
+ * Genuinely per-workstation: each Vwk carries its own tc_palette[], so a
+ * vs_color() on one workstation cannot affect another's rendering, unlike
+ * put_pixel()/get_pixel()/etc. above which -- having no Vwk* of their own
+ * -- go through vdi_backend_active_vwk() instead.
  */
-void vdi_truecolor_set_color(WORD index, WORD r, WORD g, WORD b)
+void vdi_truecolor_set_color(Vwk *vwk, WORD index, WORD r, WORD g, WORD b)
 {
     if (index < 0 || index > 255)
         return;
 
-    ensure_rgb565_palette();
-    rgb565_palette[index] = rgb565_from_vdi(r, g, b);
+    vwk->tc_palette[index] = rgb565_from_vdi(r, g, b);
 }
 
-void vdi_truecolor_get_color(WORD index, WORD *r, WORD *g, WORD *b)
+void vdi_truecolor_get_color(const Vwk *vwk, WORD index, WORD *r, WORD *g, WORD *b)
 {
     if (index < 0 || index > 255)
         index = 0;
 
-    ensure_rgb565_palette();
-    vdi_from_rgb565(rgb565_palette[index], r, g, b);
+    vdi_from_rgb565(vwk->tc_palette[index], r, g, b);
 }
 
 /*
@@ -230,6 +265,7 @@ UWORD *truecolor_get_start_addr(WORD x, WORD y)
 UWORD truecolor_get_pixel(WORD x, WORD y)
 {
     UWORD raw = *truecolor_get_start_addr(x, y);
+    const UWORD *palette = active_palette();
     WORD i;
 
     /*
@@ -237,13 +273,12 @@ UWORD truecolor_get_pixel(WORD x, WORD y)
      * comment on default_prgb_palette[] above), not a 0-15 VDI pen
      * number, so this has to search the full 256-entry space to match.
      */
-    ensure_rgb565_palette();
     for (i = 0; i < 256; i++) {
-        if (rgb565_palette[i] == raw)
+        if (palette[i] == raw)
             return (UWORD)i;
     }
 
-    return 0;   /* not one of the default 256 -- index 0 is white, the closest we can do without guessing */
+    return 0;   /* not one of the active palette's 256 -- index 0 is white, the closest we can do without guessing */
 }
 
 void truecolor_put_pixel(WORD x, WORD y, UWORD color)

--- a/vdi/vdi_backend_truecolor.c
+++ b/vdi/vdi_backend_truecolor.c
@@ -137,21 +137,33 @@ static void vdi_from_prgb(ULONG prgb, WORD *r, WORD *g, WORD *b)
  * pen-indexed, what vq_color(pen,0) reads) from the same source, via
  * MAP_COL[pen] to find which hwreg's default a given pen currently has --
  * so the two forms of vq_color() agree at boot, before any vs_color()
- * call. (MAP_COL is guaranteed populated here: init_colors() -- which
- * builds it -- always runs before the first init_wk(), and the physical-
- * workstation fallback path only matters for tc_palette, which
- * get_pixel()/put_pixel() read via MAP_COL-mapped indices callers already
- * computed themselves; tc_req_col is only ever read through vq_color(),
- * which requires an already-opened, already-init_wk()'d Vwk.)
+ * call.
+ *
+ * The tc_req_col loop is bounded by DEV_TAB[13] (the pen count for the
+ * current screen, capped at 256), not a flat 256: MAP_COL[] itself is
+ * only sized MAXCOLOURS entries (16 when EXTENDED_PALETTE is off -- e.g.
+ * a hypothetical non-RPi build with CONF_WITH_VDI_BACKEND_TRUECOLOR
+ * enabled by hand alongside the dispatcher), so indexing it up to 255
+ * unconditionally would read out of bounds. tc_palette[] has no such
+ * limit -- it is indexed directly by hwreg, not through MAP_COL[] -- so
+ * it stays a flat 256. Pens above DEV_TAB[13] are never valid VDI pens
+ * (vdi_vs_color()/vdi_vq_color() both reject colnum >= DEV_TAB[13] before
+ * ever touching tc_req_col), so leaving them unseeded here is fine.
  */
 void vdi_truecolor_init_palette(Vwk *vwk)
 {
-    WORD i;
+    WORD i, npens;
 
     for (i = 0; i < 256; i++)
         vwk->tc_palette[i] = rgb565_from_prgb(default_prgb_palette[i]);
 
-    for (i = 0; i < 256; i++)
+    npens = linea_vars.DEV_TAB[13];
+    if (npens < 0)
+        npens = 0;
+    else if (npens > 256)
+        npens = 256;
+
+    for (i = 0; i < npens; i++)
         vdi_from_prgb(default_prgb_palette[MAP_COL[i]],
                       &vwk->tc_req_col[i][0], &vwk->tc_req_col[i][1], &vwk->tc_req_col[i][2]);
 }

--- a/vdi/vdi_backend_truecolor.c
+++ b/vdi/vdi_backend_truecolor.c
@@ -12,6 +12,7 @@
 #include "../bios/tosvars.h"
 #include "vdi_defs.h"
 #include "vdi_backend.h"
+#include "vdi_col.h"
 #include "kprint.h"
 
 /*
@@ -109,10 +110,39 @@ static UWORD rgb565_from_prgb(ULONG prgb)
 }
 
 /*
- * Seeds vwk's pseudo-palette (issue #89) with default_prgb_palette[]
- * converted to RGB565. Called by init_wk() (vdi_control.c) whenever a
- * workstation is opened, and by vdi_backend_active_vwk() below for the
- * physical workstation if drawing happens before vdi_v_opnwk() ever runs.
+ * Full-precision packed-0x00BBGGRR -> VDI-scale (0-1000 per component)
+ * conversion, for seeding tc_req_col[] (issue #89) -- unlike
+ * rgb565_from_prgb() above, this doesn't go through the 5/6/5-bit
+ * quantization, since tc_req_col holds "requested", not "actual", values.
+ */
+static void vdi_from_prgb(ULONG prgb, WORD *r, WORD *g, WORD *b)
+{
+    UBYTE rb = (UBYTE)(prgb & 0xffUL);
+    UBYTE gb = (UBYTE)((prgb >> 8) & 0xffUL);
+    UBYTE bb = (UBYTE)((prgb >> 16) & 0xffUL);
+
+    *r = (WORD)(((LONG)rb * 1000 + 127) / 255);
+    *g = (WORD)(((LONG)gb * 1000 + 127) / 255);
+    *b = (WORD)(((LONG)bb * 1000 + 127) / 255);
+}
+
+/*
+ * Seeds vwk's pseudo-palette (issue #89) with default_prgb_palette[].
+ * Called by init_wk() (vdi_control.c) whenever a workstation is opened,
+ * and by physical_vwk_seeded() below for the physical workstation if
+ * drawing happens before vdi_v_opnwk() ever runs.
+ *
+ * Seeds both tc_palette[] (RGB565, hwreg-indexed, what get_pixel()/
+ * put_pixel()/vq_color(pen,1) read) and tc_req_col[] (VDI 0-1000 scale,
+ * pen-indexed, what vq_color(pen,0) reads) from the same source, via
+ * MAP_COL[pen] to find which hwreg's default a given pen currently has --
+ * so the two forms of vq_color() agree at boot, before any vs_color()
+ * call. (MAP_COL is guaranteed populated here: init_colors() -- which
+ * builds it -- always runs before the first init_wk(), and the physical-
+ * workstation fallback path only matters for tc_palette, which
+ * get_pixel()/put_pixel() read via MAP_COL-mapped indices callers already
+ * computed themselves; tc_req_col is only ever read through vq_color(),
+ * which requires an already-opened, already-init_wk()'d Vwk.)
  */
 void vdi_truecolor_init_palette(Vwk *vwk)
 {
@@ -120,6 +150,10 @@ void vdi_truecolor_init_palette(Vwk *vwk)
 
     for (i = 0; i < 256; i++)
         vwk->tc_palette[i] = rgb565_from_prgb(default_prgb_palette[i]);
+
+    for (i = 0; i < 256; i++)
+        vdi_from_prgb(default_prgb_palette[MAP_COL[i]],
+                      &vwk->tc_req_col[i][0], &vwk->tc_req_col[i][1], &vwk->tc_req_col[i][2]);
 }
 
 /*
@@ -144,6 +178,29 @@ void vdi_truecolor_init_palette(Vwk *vwk)
  * for a 256-entry palette placed well beyond that.
  */
 static Vwk *active_vwk;
+static BOOL physical_palette_seeded;
+
+/*
+ * The physical workstation, with its tc_palette/tc_req_col guaranteed
+ * seeded -- even the very first time this is called, which can happen
+ * before vdi_v_opnwk() has ever run (Line-A reachable pre-AES, or before
+ * any screen() dispatch at all; see the vdi_screen_backend() self-init
+ * comment in vdi_control.c for the same situation with .mode/.backend).
+ * Idempotent past the first call: init_wk() (vdi_control.c) re-seeds the
+ * physical workstation's palette for real whenever vdi_v_opnwk() actually
+ * runs, which this flag does not need to track -- it only needs to know
+ * whether *some* seeding has happened yet.
+ */
+static Vwk *physical_vwk_seeded(void)
+{
+    Vwk *phys = vdi_physical_vwk();
+
+    if (!physical_palette_seeded) {
+        vdi_truecolor_init_palette(phys);
+        physical_palette_seeded = TRUE;
+    }
+    return phys;
+}
 
 void vdi_backend_set_active_vwk(Vwk *vwk)
 {
@@ -152,18 +209,18 @@ void vdi_backend_set_active_vwk(Vwk *vwk)
 
 Vwk *vdi_backend_active_vwk(void)
 {
-    if (!active_vwk) {
-        /*
-         * Nothing has gone through screen() yet -- e.g. Line-A reachable
-         * before vdi_v_opnwk() ever runs (see the vdi_screen_backend()
-         * comment in vdi_control.c for the same situation with
-         * .mode/.backend). Fall back to the physical workstation, and
-         * since init_wk() hasn't necessarily seeded it yet either, seed
-         * it here.
-         */
-        active_vwk = vdi_physical_vwk();
-        vdi_truecolor_init_palette(active_vwk);
-    }
+    /*
+     * vdi_main.c's screen() sets active_vwk to the physical workstation
+     * for opcodes with no handle yet (v_opnwk()/v_opnvwk()) as well as
+     * for nothing-dispatched-yet -- so "active_vwk is currently the
+     * physical workstation" (not just "active_vwk is NULL") is the
+     * condition that needs the seeding check, or a program that only
+     * ever opens virtual workstations could leave the physical palette
+     * BSS-zero (all black) while something reads it in between.
+     */
+    if (!active_vwk || active_vwk == vdi_physical_vwk())
+        return physical_vwk_seeded();
+
     return active_vwk;
 }
 
@@ -183,13 +240,26 @@ static UWORD truecolor_pixel_for_index(WORD index)
 /*
  * Public wrapper for callers outside this backend that need to turn a
  * MAP_COL-mapped hardware palette index into the raw RGB565 pixel value
- * this backend would write for it -- e.g. the RPi software mouse cursor
- * in vdi/vdi_mouse.c, which draws by poking pixels directly rather than
- * going through put_pixel()/fill_rect().
+ * this backend would write for it -- currently only the RPi software
+ * mouse cursor in vdi/vdi_mouse.c, which draws by poking pixels directly
+ * rather than going through put_pixel()/fill_rect().
+ *
+ * Deliberately reads the *physical* workstation's palette rather than
+ * active_vwk: the cursor is a screen-global element (its bg_col/fg_col
+ * are hardware-register indices, not tied to any one workstation), and
+ * it is drawn from the VBL interrupt (vdi_mouse.c's vb_draw()) as well as
+ * from Line-A text output, both of which run independently of -- and can
+ * race -- whatever VDI call last set active_vwk. Using the physical
+ * workstation keeps the cursor's colors from changing whenever some
+ * other (possibly virtual) workstation happens to have been the most
+ * recent VDI caller.
  */
 UWORD vdi_truecolor_pixel_for_index(WORD index)
 {
-    return truecolor_pixel_for_index(index);
+    if (index < 0 || index > 255)
+        index = 0;
+
+    return physical_vwk_seeded()->tc_palette[index];
 }
 
 /*
@@ -235,6 +305,17 @@ void vdi_truecolor_set_color(Vwk *vwk, WORD index, WORD r, WORD g, WORD b)
 {
     if (index < 0 || index > 255)
         return;
+
+    /*
+     * Defend the public contract even though the only current caller
+     * (vdi_vs_color()) already clamps: r/g/b feed straight into 5/6-bit
+     * field packing below, and an out-of-range value (or a future caller
+     * that forgets to clamp) would corrupt the packed RGB565 word rather
+     * than just look wrong.
+     */
+    if (r < 0) r = 0; else if (r > 1000) r = 1000;
+    if (g < 0) g = 0; else if (g > 1000) g = 1000;
+    if (b < 0) b = 0; else if (b > 1000) b = 1000;
 
     vwk->tc_palette[index] = rgb565_from_vdi(r, g, b);
 }

--- a/vdi/vdi_backend_truecolor.c
+++ b/vdi/vdi_backend_truecolor.c
@@ -27,9 +27,9 @@
  * (rather than clamping anything outside 0-15 to index 0, which used
  * to alias pen 1 to default_prgb_palette[0] == white) keeps this
  * consistent with the indexed framebuffer the old 8bpp path used to
- * write into. This is the "default mapping needed by colors already
- * in use" the design calls for -- full vs_color()/vq_color()
- * truecolor semantics are a follow-up.
+ * write into. This is the boot-time default -- vdi_truecolor_set_color()
+ * below (issue #89) is what lets vs_color() actually change entries away
+ * from it at runtime.
  */
 static const ULONG default_prgb_palette[256] = {
     0x00ffffff, 0x000000ff, 0x0000ff00, 0x0000ffff,
@@ -148,6 +148,68 @@ static UWORD truecolor_pixel_for_index(WORD index)
 UWORD vdi_truecolor_pixel_for_index(WORD index)
 {
     return truecolor_pixel_for_index(index);
+}
+
+/*
+ * VDI-scale (0-1000 per component) <-> RGB565 conversion for
+ * vs_color()/vq_color() (issue #89). Uses rounding division rather than
+ * rgb565_from_prgb()'s truncating shifts above, since those start from an
+ * already-8-bit component -- vs_color() gives full 0-1000 precision that's
+ * worth rounding rather than truncating away.
+ */
+static UWORD rgb565_from_vdi(WORD r, WORD g, WORD b)
+{
+    UWORD r5 = (UWORD)(((LONG)r * 31 + 500) / 1000);
+    UWORD g6 = (UWORD)(((LONG)g * 63 + 500) / 1000);
+    UWORD b5 = (UWORD)(((LONG)b * 31 + 500) / 1000);
+
+    return (UWORD)((r5 << 11) | (g6 << 5) | b5);
+}
+
+static void vdi_from_rgb565(UWORD raw, WORD *r, WORD *g, WORD *b)
+{
+    UWORD r5 = (raw >> 11) & 0x1f;
+    UWORD g6 = (raw >> 5) & 0x3f;
+    UWORD b5 = raw & 0x1f;
+
+    *r = (WORD)(((LONG)r5 * 1000 + 15) / 31);
+    *g = (WORD)(((LONG)g6 * 1000 + 31) / 63);
+    *b = (WORD)(((LONG)b5 * 1000 + 15) / 31);
+}
+
+/*
+ * vs_color()/vq_color() pseudo-palette read/write ports for the truecolor
+ * backend (issue #89), called from vdi_vs_color()/vdi_vq_color() in
+ * vdi_col.c. index is a MAP_COL-mapped hardware palette register index,
+ * like every other index this file takes -- not a 0-15 VDI pen number.
+ *
+ * There is exactly one screen (see the vdi_screen_backend() comment in
+ * vdi_control.c), so unlike upstream's per-Vwk VwkExt::palette this is one
+ * shared table rather than one per virtual workstation -- matching how
+ * set_color() in vdi_col.c treats every other backend's hardware palette
+ * registers: a single physical resource that the most recent vs_color()
+ * call (from whichever workstation) last wrote, not a per-workstation
+ * fiction layered on hardware that doesn't have per-workstation state
+ * either. rgb565_palette[] (see ensure_rgb565_palette() above) already is
+ * exactly that shared resource; these two functions are its mutation and
+ * query entry points.
+ */
+void vdi_truecolor_set_color(WORD index, WORD r, WORD g, WORD b)
+{
+    if (index < 0 || index > 255)
+        return;
+
+    ensure_rgb565_palette();
+    rgb565_palette[index] = rgb565_from_vdi(r, g, b);
+}
+
+void vdi_truecolor_get_color(WORD index, WORD *r, WORD *g, WORD *b)
+{
+    if (index < 0 || index > 255)
+        index = 0;
+
+    ensure_rgb565_palette();
+    vdi_from_rgb565(rgb565_palette[index], r, g, b);
 }
 
 /*

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -17,6 +17,7 @@
 #include "vdi_col.h"
 #include "../bios/lineavars.h"
 #include "../bios/screen.h"
+#include "vdi_backend.h"
 
 #define EXTENDED_PALETTE (CONF_WITH_VIDEL || CONF_WITH_TT_SHIFTER || defined(MACHINE_RPI))
 
@@ -634,6 +635,15 @@ void vdi_vs_color(Vwk *vwk)
     }
 
     colnum = INTIN[0];      /* may have been munged on TT system, see above */
+
+#if CONF_WITH_VDI_BACKEND_TRUECOLOR
+    if (vdi_screen_is_truecolor())
+    {
+        vdi_truecolor_set_color(MAP_COL[colnum], rgb[0], rgb[1], rgb[2]);
+        return;
+    }
+#endif
+
     set_color(colnum, rgb);
 }
 
@@ -783,6 +793,14 @@ void vdi_vq_color(Vwk *vwk)
      */
     colnum = INTIN[0];          /* may have been munged on TT system, see above */
     hwreg = MAP_COL[colnum];    /* get hardware register */
+
+#if CONF_WITH_VDI_BACKEND_TRUECOLOR
+    if (vdi_screen_is_truecolor())
+    {
+        vdi_truecolor_get_color(hwreg, &INTOUT[1], &INTOUT[2], &INTOUT[3]);
+        return;
+    }
+#endif
 
 #if CONF_WITH_VIDEL
     if (has_videl)

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -624,10 +624,16 @@ void vdi_vs_color(Vwk *vwk)
          * REQ_COL/req_col2 below, storing into vwk->tc_req_col here means a
          * vs_color() on one workstation cannot leak into another
          * workstation's vq_color(pen,0) answer.
+         *
+         * Indexed by INTIN[0], the pen as passed in -- not colnum, which
+         * may have been bank-adjusted above -- since tc_req_col (unlike
+         * REQ_COL/req_col2) is documented as plain pen-indexed. vq_color()
+         * reads it back by INTIN[0] too (see below), so a bank adjustment
+         * here would desync the two.
          */
         for (i = 0, intin = INTIN+1, rgbptr = rgb; i < 3; i++, intin++, rgbptr++)
         {
-            vwk->tc_req_col[colnum][i] = *intin;
+            vwk->tc_req_col[INTIN[0]][i] = *intin;
             if (*intin > 1000)
                 *rgbptr = 1000;
             else if (*intin < 0)
@@ -794,12 +800,16 @@ void vdi_vq_color(Vwk *vwk)
          * comment on struct Vwk_ in vdi_defs.h for why this doesn't read
          * the global REQ_COL/req_col2 the way the non-truecolor path
          * below does.
+         *
+         * Indexed by INTIN[0] rather than colnum, matching how
+         * vdi_vs_color() stores it -- colnum may have been bank-adjusted
+         * above, but tc_req_col is plain pen-indexed.
          */
         if (INTIN[1] == 0)  /* return last-requested value */
         {
-            INTOUT[1] = vwk->tc_req_col[colnum][0];
-            INTOUT[2] = vwk->tc_req_col[colnum][1];
-            INTOUT[3] = vwk->tc_req_col[colnum][2];
+            INTOUT[1] = vwk->tc_req_col[INTIN[0]][0];
+            INTOUT[2] = vwk->tc_req_col[INTIN[0]][1];
+            INTOUT[3] = vwk->tc_req_col[INTIN[0]][2];
         }
         else                /* return actual current value */
         {

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -639,7 +639,7 @@ void vdi_vs_color(Vwk *vwk)
 #if CONF_WITH_VDI_BACKEND_TRUECOLOR
     if (vdi_screen_is_truecolor())
     {
-        vdi_truecolor_set_color(MAP_COL[colnum], rgb[0], rgb[1], rgb[2]);
+        vdi_truecolor_set_color(vwk, MAP_COL[colnum], rgb[0], rgb[1], rgb[2]);
         return;
     }
 #endif
@@ -797,7 +797,7 @@ void vdi_vq_color(Vwk *vwk)
 #if CONF_WITH_VDI_BACKEND_TRUECOLOR
     if (vdi_screen_is_truecolor())
     {
-        vdi_truecolor_get_color(hwreg, &INTOUT[1], &INTOUT[2], &INTOUT[3]);
+        vdi_truecolor_get_color(vwk, hwreg, &INTOUT[1], &INTOUT[2], &INTOUT[3]);
         return;
     }
 #endif

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -615,6 +615,30 @@ void vdi_vs_color(Vwk *vwk)
         colnum = adjust_tt_colnum(colnum);  /* handles palette bank issues */
 #endif
 
+#if CONF_WITH_VDI_BACKEND_TRUECOLOR
+    if (vdi_screen_is_truecolor())
+    {
+        /*
+         * Per-workstation "requested"/"actual" state (issue #89), mirroring
+         * upstream's VwkExt::req_col/palette: unlike the global
+         * REQ_COL/req_col2 below, storing into vwk->tc_req_col here means a
+         * vs_color() on one workstation cannot leak into another
+         * workstation's vq_color(pen,0) answer.
+         */
+        for (i = 0, intin = INTIN+1, rgbptr = rgb; i < 3; i++, intin++, rgbptr++)
+        {
+            vwk->tc_req_col[colnum][i] = *intin;
+            if (*intin > 1000)
+                *rgbptr = 1000;
+            else if (*intin < 0)
+                *rgbptr = 0;
+            else *rgbptr = *intin;
+        }
+        vdi_truecolor_set_color(vwk, MAP_COL[INTIN[0]], rgb[0], rgb[1], rgb[2]);
+        return;
+    }
+#endif
+
     /*
      * Copy raw values to the "requested colour" arrays, then clamp
      * them to 0-1000 before calling set_color()
@@ -635,15 +659,6 @@ void vdi_vs_color(Vwk *vwk)
     }
 
     colnum = INTIN[0];      /* may have been munged on TT system, see above */
-
-#if CONF_WITH_VDI_BACKEND_TRUECOLOR
-    if (vdi_screen_is_truecolor())
-    {
-        vdi_truecolor_set_color(vwk, MAP_COL[colnum], rgb[0], rgb[1], rgb[2]);
-        return;
-    }
-#endif
-
     set_color(colnum, rgb);
 }
 
@@ -769,6 +784,31 @@ void vdi_vq_color(Vwk *vwk)
         colnum = adjust_tt_colnum(colnum);  /* handles palette bank issues */
 #endif
 
+#if CONF_WITH_VDI_BACKEND_TRUECOLOR
+    if (vdi_screen_is_truecolor())
+    {
+        /*
+         * Both forms come from vwk's own per-workstation state (issue
+         * #89): tc_req_col for "last requested", tc_palette (via
+         * vdi_truecolor_get_color()) for "actual" -- see the tc_req_col
+         * comment on struct Vwk_ in vdi_defs.h for why this doesn't read
+         * the global REQ_COL/req_col2 the way the non-truecolor path
+         * below does.
+         */
+        if (INTIN[1] == 0)  /* return last-requested value */
+        {
+            INTOUT[1] = vwk->tc_req_col[colnum][0];
+            INTOUT[2] = vwk->tc_req_col[colnum][1];
+            INTOUT[3] = vwk->tc_req_col[colnum][2];
+        }
+        else                /* return actual current value */
+        {
+            vdi_truecolor_get_color(vwk, MAP_COL[INTIN[0]], &INTOUT[1], &INTOUT[2], &INTOUT[3]);
+        }
+        return;
+    }
+#endif
+
     if (INTIN[1] == 0)  /* return last-requested value */
     {
         if (colnum < 16)
@@ -793,14 +833,6 @@ void vdi_vq_color(Vwk *vwk)
      */
     colnum = INTIN[0];          /* may have been munged on TT system, see above */
     hwreg = MAP_COL[colnum];    /* get hardware register */
-
-#if CONF_WITH_VDI_BACKEND_TRUECOLOR
-    if (vdi_screen_is_truecolor())
-    {
-        vdi_truecolor_get_color(vwk, hwreg, &INTOUT[1], &INTOUT[2], &INTOUT[3]);
-        return;
-    }
-#endif
 
 #if CONF_WITH_VIDEL
     if (has_videl)

--- a/vdi/vdi_control.c
+++ b/vdi/vdi_control.c
@@ -378,6 +378,26 @@ void vdi_v_clsvwk(Vwk * vwk)
 
     work_ptr->next_work = vwk->next_work;
     linea_vars.CUR_WORK = work_ptr;
+
+#if CONF_WITH_VDI_BACKEND_TRUECOLOR
+    /*
+     * vdi_main.c's screen() set the truecolor backend's active workstation
+     * to vwk for this very call (it's the Vwk resolved for CONTRL->handle),
+     * so freeing vwk below would leave that pointer dangling until the
+     * next VDI call -- and it can be read asynchronously in between, e.g.
+     * by Line-A text output reaching truecolor_pixel_for_index() straight
+     * from the line-A entry, bypassing screen() (see
+     * vdi_backend_active_vwk() in vdi_backend_truecolor.c; the VBL mouse
+     * cursor is not at risk here, since vdi_truecolor_pixel_for_index()
+     * reads the physical workstation directly rather than active_vwk).
+     * Point it back at the physical workstation, matching what v_clswk()
+     * gets for free by resolving handle 1 before it frees any virtual
+     * ones.
+     */
+    if (vwk == vdi_backend_active_vwk())
+        vdi_backend_set_active_vwk(vdi_physical_vwk());
+#endif
+
     trap1(X_MFREE, vwk);
 }
 

--- a/vdi/vdi_control.c
+++ b/vdi/vdi_control.c
@@ -166,6 +166,13 @@ Vwk * get_vwk_by_handle(WORD handle)
 
 
 
+Vwk * vdi_physical_vwk(void)
+{
+    return &virt_work;
+}
+
+
+
 /* Set Clip Region */
 void vdi_vs_clip(Vwk * vwk)
 {
@@ -290,6 +297,10 @@ static void init_wk(Vwk * vwk)
 
     vwk->multifill = 0;
     vwk->ud_ls = LINE_STYLE[0];
+
+#if CONF_WITH_VDI_BACKEND_TRUECOLOR
+    vdi_truecolor_init_palette(vwk);
+#endif
 
     pb = CONTRL;
     pb->nptsout = 6;

--- a/vdi/vdi_defs.h
+++ b/vdi/vdi_defs.h
@@ -215,6 +215,18 @@ struct Vwk_ {
     WORD bez_qual;              /* actual quality for bezier curves */
     SCREEN_MODE_DESC mode;      /* backend mode descriptor for this workstation's screen */
     const struct vdi_backend_ops *backend; /* dispatch table selected for `mode`; NULL if none matched */
+#if CONF_WITH_VDI_BACKEND_TRUECOLOR
+    /*
+     * vs_color()/vq_color() pseudo-palette for the truecolor backend
+     * (issue #89): MAP_COL-mapped hardware palette index -> RGB565 pixel.
+     * Genuinely per-workstation, matching upstream's VwkExt::palette --
+     * a vs_color() on one workstation must not affect another. Seeded to
+     * the backend's defaults by init_wk() (vdi_control.c) whenever a
+     * workstation is opened; see vdi_backend_active_vwk() in vdi_backend.h
+     * for how the drawing primitives pick which workstation's copy to use.
+     */
+    UWORD tc_palette[256];
+#endif
 };
 
 typedef struct Rect_ Rect;
@@ -271,6 +283,7 @@ void arb_line(Line * line);
 int GSX_ENTRY(int op, VDIPB* paramblock);
 /* C Support routines */
 Vwk * get_vwk_by_handle(WORD);
+Vwk * vdi_physical_vwk(void);
 UWORD * get_start_addr(const WORD x, const WORD y);
 void set_LN_MASK(Vwk *vwk);
 void st_fl_ptr(Vwk *);

--- a/vdi/vdi_defs.h
+++ b/vdi/vdi_defs.h
@@ -226,6 +226,17 @@ struct Vwk_ {
      * for how the drawing primitives pick which workstation's copy to use.
      */
     UWORD tc_palette[256];
+    /*
+     * vs_color()'s raw "last requested" values (VDI 0-1000 scale) for the
+     * truecolor backend, indexed like REQ_COL/req_col2 by VDI pen number
+     * (not MAP_COL-mapped) -- mirrors upstream's VwkExt::req_col so that
+     * vq_color(pen,0) ("last requested") and vq_color(pen,1) ("actual",
+     * via tc_palette above) stay consistent per-workstation instead of
+     * reading the global REQ_COL/req_col2, which stay unpopulated for
+     * pens 16-255 on RPi (no VIDEL/TT hardware to seed them). Seeded
+     * alongside tc_palette by vdi_truecolor_init_palette().
+     */
+    WORD tc_req_col[256][3];
 #endif
 };
 

--- a/vdi/vdi_main.c
+++ b/vdi/vdi_main.c
@@ -14,6 +14,7 @@
 #include "vdi_defs.h"
 #include "../bios/lineavars.h"
 #include "kprint.h"
+#include "vdi_backend.h"
 
 /* forward prototypes */
 void screen(void);
@@ -139,6 +140,15 @@ void screen(void)
         if (vwk->fill_style != 4)       /* multifill just for user */
             vwk->multifill = 0;
     }
+
+#if CONF_WITH_VDI_BACKEND_TRUECOLOR
+    /*
+     * v_opnwk()/v_opnvwk() (opcodes 1/100) have no handle yet -- vwk is
+     * NULL above -- so fall back to the physical workstation; that's also
+     * exactly right for v_opnwk(), which initializes it (see #89).
+     */
+    vdi_backend_set_active_vwk(vwk ? vwk : vdi_physical_vwk());
+#endif
 
     if (opcode >= 1 && opcode < 1+JMPTB1_ENTRIES) {
         (*jmptb1[opcode - 1]) (vwk);


### PR DESCRIPTION
The truecolor backend (`vdi_backend_truecolor.c`) only had a fixed
default palette-to-RGB565 mapping, so `vs_color()` didn't change
anything on screen and `vq_color()` just returned the fixed table.

Add `vdi_truecolor_set_color()`/`vdi_truecolor_get_color()`, which
mutate/query a genuinely per-workstation pseudo-palette
(`Vwk::tc_palette[256]`, matching upstream's `VwkExt::palette`) via
VDI-scale (0-1000) <-> RGB565 conversion. `vdi_vs_color()`/`vdi_vq_color()`
in `vdi_col.c` dispatch to them when the truecolor backend is active,
leaving the VIDEL/TT/STE/ST hardware-palette paths (and the planar
backend) untouched. A `vs_color()` on one workstation cannot affect
another's rendering.

The drawing primitives (`put_pixel`/`get_pixel`/`fill_rect`/`text_blit`/
`raster_copy`/`draw_line`/`search_left`/`search_right`) don't take a
`Vwk*` at all -- that's the point of the backend-ops dispatch table --
so `vdi_main.c`'s `screen()` dispatcher tracks which workstation is
"active" for their purposes (`vdi_backend_set_active_vwk()`/
`vdi_backend_active_vwk()` in `vdi_backend_truecolor.c`), updated once
per VDI call and reset to the physical workstation on `v_clsvwk()` to
avoid a dangling pointer. The RPi software mouse cursor, drawn from VBL
interrupt context, reads the physical workstation's palette directly
instead, since it's a screen-global element rather than tied to
whichever workstation last made a VDI call.

Also adds a per-workstation `tc_req_col[256][3]` (mirroring upstream's
`VwkExt::req_col`) so `vq_color(pen,0)` ("last requested") agrees with
`vq_color(pen,1)` ("actual") on a truecolor screen, instead of the
former reading the global `REQ_COL`/`req_col2` arrays that stay
unpopulated for pens 16-255 on RPi (no VIDEL/TT hardware to seed them).

Verified: `rpi1_defconfig` and `rpi2-sparse_defconfig` (dispatch mode,
both backends) build and link cleanly; `atari512_defconfig` confirms
`CONF_WITH_VDI_BACKEND_TRUECOLOR` is 0 there, compiling this all out.
Booted `rpi1_defconfig` under QEMU (`raspi1ap`) to the AES event loop
with no guest errors.

Fixes #89