### PR TITLE
Cherry-pick upstream VDI/AES bugfixes

### DIFF
--- a/aes/gemctrl.c
+++ b/aes/gemctrl.c
@@ -87,14 +87,52 @@ static void ct_msgup(WORD message, AESPD *owner, WORD wh, WORD m1, WORD m2, WORD
     ap_sendmsg(appl_msg, message, owner, wh, m1, m2, m3, m4);
 
     /*
-     * wait for button to come up if not an arrowed message
+     * wait for button to come up, unless this is a close on a
+     * hotclose window: otherwise a slow click will cause us to
+     * stay in ctlmgr(), eating keys
      */
-    if ( message != WM_ARROWED &&
-       ( message != WM_CLOSED && !(D.w_win[wh].w_kind & HOTCLOSE) ) )
+    if (!((message == WM_CLOSED) && (D.w_win[wh].w_kind & HOTCLOSE)))
     {
         while( (button & 0x0001) != 0x0 )
             dsptch();
     }
+}
+
+
+/*
+ * handle WM_ARROWED message
+ *
+ * this function sends WM_ARROWED messages continuously whilst the left
+ * button is held down.
+ */
+static void handle_arrow_msg(WORD w_handle, WORD gadget)
+{
+    WINDOW *pwin = &D.w_win[w_handle];
+    AESPD *p = pwin->w_owner;
+    WORD action;
+
+    wm_update(END_UPDATE);      /* give up the screen */
+
+    action = gl_wa[gadget - W_UPARROW];
+
+    do
+    {
+        if (p->p_stat & WAITIN)  /* send message now if he's waiting */
+        {
+            ap_sendmsg(appl_msg, WM_ARROWED, p, w_handle, action, 0, 0, 0);
+        }
+        else                     /* else make it the next to be processed */
+        {
+            if (p->p_msg.action < 0)    /* (if no pending message) */
+            {
+                p->p_msg.action = action;
+                p->p_msg.wh = w_handle;
+            }
+        }
+        dsptch();
+    } while(button & 0x0001);
+
+    wm_update(BEG_UPDATE);      /* take back the screen */
 }
 
 
@@ -206,9 +244,8 @@ static void hctl_window(WORD w_handle, WORD mx, WORD my)
         case W_DNARROW:
         case W_LFARROW:
         case W_RTARROW:
-            message = WM_ARROWED;
-            x = gl_wa[cpt - W_UPARROW];
-            break;
+            handle_arrow_msg(w_handle, cpt);
+            return;
         case W_HELEV:
         case W_VELEV:
 doelev:     message = (cpt == W_HELEV) ? WM_HSLID : WM_VSLID;
@@ -314,7 +351,7 @@ void ctlmgr(void)
 {
     WORD    ev_which;
     WORD    rets[6];
-    WORD    i, wh;
+    WORD    wh;
 
     /*
      * set defaults for multi wait
@@ -327,26 +364,13 @@ void ctlmgr(void)
         w_setactive();
         /*
          * wait for something to happen, keys need to be eaten
-         * inc. fake key sent by ... or if button already down,
-         * then let other guys run then do it
+         * including fake key sent by mn_bar() [the menu bar handler]
          */
-        if (button)
-        {
-            for (i = 0; i < (totpds*2); i++)
-                dsptch();
-
-            ev_which = MU_BUTTON;
-            rets[0] = xrat;
-            rets[1] = yrat;
-        }
-        else
-        {
-            ev_which = MU_KEYBD | MU_BUTTON;
-            if ( gl_mntree )            /* only wait on bar when there  */
-                ev_which |= MU_M1;      /* is a menu                    */
-            ev_which = ev_multi(ev_which, &gl_ctwait, &gl_ctwait,
-                                0x0L, 0x0001ff01L, NULL, rets);
-        }
+        ev_which = MU_KEYBD | MU_BUTTON;
+        if ( gl_mntree )            /* only wait on bar when there  */
+            ev_which |= MU_M1;      /* is a menu                    */
+        ev_which = ev_multi(ev_which, &gl_ctwait, &gl_ctwait,
+                            0x0L, 0x0001ff01L, NULL, rets);
 
         ct_mouse(TRUE);                 /* grab screen sink     */
         /*

--- a/aes/gemdisp.c
+++ b/aes/gemdisp.c
@@ -157,12 +157,12 @@ void chkkbd(void)
         return;
 
     kstat = gsx_kstate();
-    achar = gsx_char();
-    if (achar && (gl_mowner->p_cda->c_q.c_cnt >= KBD_SIZE))
-    {
-        achar = 0x0;                        /* buffer overrun       */
-        sound(TRUE, 880, 2);
-    }
+    achar = 0;
+
+    /* only get a key if there's room in the buffer */
+    if (gl_mowner->p_cda->c_q.c_cnt < KBD_SIZE)
+        achar = gsx_char();     /* returns 0 if no key available */
+
     if (achar || (kstat != kstate))
     {
         disable_interrupts();

--- a/aes/gemevlib.c
+++ b/aes/gemevlib.c
@@ -97,6 +97,31 @@ UWORD ev_button(WORD bflgclks, UWORD bmask, UWORD bstate, WORD rets[])
 
 
 /*
+ *  Retrieve a pending message: either a real one from the process's
+ *  message queue, or a synthetic WM_ARROWED sent by ctlmgr() while
+ *  a window arrow gadget is held down (see handle_arrow_msg()).
+ */
+void ev_mesag(WORD *mebuff)
+{
+    if ((rlr->p_qindex == 0) && (rlr->p_msg.action >= 0))
+    {
+        *mebuff++ = WM_ARROWED;
+        *mebuff++ = rlr->p_pid;
+        *mebuff++ = 0;
+        *mebuff++ = rlr->p_msg.wh;
+        *mebuff++ = rlr->p_msg.action;
+        *mebuff++ = 0;
+        *mebuff++ = 0;
+        *mebuff = 0;
+        rlr->p_msg.action = -1;
+        return;
+    }
+
+    ap_rdwr(MU_MESAG, rlr, 16, mebuff);
+}
+
+
+/*
  *  Wait for the mouse to leave or enter a specified rectangle
  */
 UWORD ev_mouse(MOBLK *pmo, WORD rets[])
@@ -186,9 +211,9 @@ WORD ev_multi(WORD flags, MOBLK *pmo1, MOBLK *pmo2, LONG tmcount,
     /* quick check message */
     if (flags & MU_MESAG)
     {
-        if (rlr->p_qindex > 0)
+        if ((rlr->p_qindex > 0) || (rlr->p_msg.action >= 0))
         {
-            ap_rdwr(MU_MESAG, rlr, 16, mebuff);
+            ev_mesag(mebuff);
             what |= MU_MESAG;
         }
     }

--- a/aes/gemevlib.h
+++ b/aes/gemevlib.h
@@ -17,6 +17,7 @@ extern WORD     gl_ticktime;
 WORD ev_block(WORD code, LONG lvalue);
 UWORD ev_button(WORD bflgclks, UWORD bmask, UWORD bstate, WORD rets[]);
 UWORD ev_mouse(MOBLK *pmo, WORD rets[]);
+void ev_mesag(WORD *mebuff);
 void ev_timer(LONG count);
 WORD ev_multi(WORD flags, MOBLK *pmo1, MOBLK *pmo2, LONG tmcount,
               LONG buparm, WORD *mebuff, WORD prets[]);

--- a/aes/gemfmalt.c
+++ b/aes/gemfmalt.c
@@ -32,6 +32,7 @@
 #include "gemoblib.h"
 #include "gemobed.h"
 #include "geminit.h"
+#include "geminput.h"
 #include "gemrslib.h"
 #include "gemgraf.h"
 #include "gemfmlib.h"
@@ -334,8 +335,18 @@ WORD fm_alert(WORD defbut, BYTE *palstr)
     gsx_sclip(&d);
     ob_draw(tree, ROOT, MAX_DEPTH);
 
-    /* turn on the mouse    */
+    /*
+     * turn on the mouse and set the mouse owner.  the latter is required
+     * for DAs to be able to issue form_alert()s.
+     *
+     * if we don't update mouse ownership, the desktop will remain the
+     * mouse owner, and the system will queue any mouse clicks to the
+     * desktop's evnt_multi(), rather than the evnt_multi() issued by
+     * the fm_do() below.  this will result in the DA (and then the whole
+     * system) hanging.
+     */
     ct_mouse(TRUE);
+    gl_mowner = rlr;
 
     /* let user pick button */
     i = fm_do(tree, 0);

--- a/aes/gemfmalt.c
+++ b/aes/gemfmalt.c
@@ -32,7 +32,6 @@
 #include "gemoblib.h"
 #include "gemobed.h"
 #include "geminit.h"
-#include "geminput.h"
 #include "gemrslib.h"
 #include "gemgraf.h"
 #include "gemfmlib.h"
@@ -336,17 +335,15 @@ WORD fm_alert(WORD defbut, BYTE *palstr)
     ob_draw(tree, ROOT, MAX_DEPTH);
 
     /*
-     * turn on the mouse and set the mouse owner.  the latter is required
-     * for DAs to be able to issue form_alert()s.
-     *
-     * if we don't update mouse ownership, the desktop will remain the
-     * mouse owner, and the system will queue any mouse clicks to the
-     * desktop's evnt_multi(), rather than the evnt_multi() issued by
-     * the fm_do() below.  this will result in the DA (and then the whole
-     * system) hanging.
+     * turn on the mouse.  ct_mouse(TRUE) also sets gl_mowner to rlr,
+     * which is required for DAs to be able to issue form_alert()s: if
+     * mouse ownership isn't updated, the desktop remains the mouse
+     * owner, and the system queues any mouse clicks to the desktop's
+     * evnt_multi() rather than the evnt_multi() issued by fm_do()
+     * below.  this would result in the DA (and then the whole system)
+     * hanging.
      */
     ct_mouse(TRUE);
-    gl_mowner = rlr;
 
     /* let user pick button */
     i = fm_do(tree, 0);

--- a/aes/gemfslib.c
+++ b/aes/gemfslib.c
@@ -528,7 +528,11 @@ WORD fs_input(BYTE *pipath, BYTE *pisel, WORD *pbutton, BYTE *pilabel)
     BYTE *pstr;
     GRECT pt;
     BYTE locstr[LEN_ZPATH+4], locold[LEN_ZPATH+4];  /* at least 3 bytes longer than 'mask' */
-    BYTE mask[LEN_ZPATH+1], selname[LEN_FSNAME];
+    /* static: the FTITLE object's te_ptext is pointed directly at mask
+     * (see below) and that pointer can outlive this call, e.g. if the
+     * resource tree is redrawn without another fs_input() call first */
+    static BYTE mask[LEN_ZPATH+1];
+    BYTE selname[LEN_FSNAME];
     OBJECT *obj;
     TEDINFO *tedinfo;
 

--- a/aes/gemfslib.c
+++ b/aes/gemfslib.c
@@ -522,7 +522,7 @@ WORD fs_input(BYTE *pipath, BYTE *pisel, WORD *pbutton, BYTE *pilabel)
     WORD mx, my;
     OBJECT *tree;
     ULONG bitmask;
-    BYTE *ad_fpath, *ad_fname, *ad_ftitle;
+    BYTE *ad_fpath, *ad_fname;
     WORD drive;
     WORD dclkret, cont, newlist, newsel, newdrive;
     BYTE *pstr;
@@ -567,9 +567,8 @@ WORD fs_input(BYTE *pipath, BYTE *pisel, WORD *pbutton, BYTE *pilabel)
     tree = rs_trees[FSELECTR];
     obj = tree + FTITLE;
     tedinfo = obj->ob_spec.tedinfo;
-    ad_ftitle = tedinfo->te_ptext;
     set_mask(mask, locstr);             /* save caller's mask */
-    strcpy(ad_ftitle, mask);            /*  & copy to title line */
+    tedinfo->te_ptext = mask;           /*  & point title line at it */
 
     obj = tree + FSDIRECT;
     tedinfo = obj->ob_spec.tedinfo;

--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -778,6 +778,7 @@ void gem_main(void)
             rlr->p_uda->u_spsuper = &rlr->p_uda->u_supstk;
         rlr->p_pid = i;
         rlr->p_stat = 0;
+        rlr->p_msg.action = -1;
     }
     curpid = 0;
     rlr->p_pid = curpid++;

--- a/aes/gemsuper.c
+++ b/aes/gemsuper.c
@@ -140,7 +140,7 @@ static UWORD crysbind(WORD opcode, AESGLOBAL *pglobal, WORD control[], WORD int_
     case EVNT_MESAG:
         aestrace("evnt_mesag()");
         rlr->p_flags |= AP_MESAG;
-        ap_rdwr(MU_MESAG, rlr, 16, (WORD *)ME_PBUFF);
+        ev_mesag((WORD *)ME_PBUFF);
         if (*(WORD *)ME_PBUFF == AC_CLOSE)
             rlr->p_flags |= AP_ACCLOSE;
         break;

--- a/aes/struct.h
+++ b/aes/struct.h
@@ -119,9 +119,15 @@ struct aespd                /* process descriptor */
         EVB     *p_evlist;      /* 28 */
         EVB     *p_qdq;         /* 2C */
         EVB     *p_qnq;         /* 30 */
-        BYTE    *p_qaddr;       /* 34 */
-        WORD    p_qindex;       /* 38 */
-        BYTE    p_queue[QUEUE_SIZE];   /* 3A */
+
+        struct {            /* used by ctlmgr() to pass WM_ARROWED msg to event handlers */
+            WORD action;        /* action to perform (WA_UPLINE etc) [-ve means no msg] */
+            WORD wh;            /* window handle of applicable window */
+        }       p_msg;
+
+        BYTE    *p_qaddr;       /* */
+        WORD    p_qindex;       /* */
+        BYTE    p_queue[QUEUE_SIZE];   /* */
         BYTE    p_appdir[LEN_ZPATH+2];  /* directory containing the executable */
                                         /* (includes trailing path separator)  */
 };

--- a/bios/arch/m68k/vectors.S
+++ b/bios/arch/m68k/vectors.S
@@ -20,6 +20,7 @@
         .globl  _biostrap       // call BIOS from C
         .globl  _xbiostrap      // call XBIOS from C
         .globl  _xbios_unimpl
+        .globl  _supexec
 
         .globl  _check_read_byte
         .globl  _int_vbl
@@ -1135,6 +1136,13 @@ _xbios_unimpl:
        addq.l   #2,sp
        rts
 
+/*
+ * Supexec() function handler
+ * See xbios.c for more information.
+ */
+_supexec:
+        movea.l 4(a7),a0
+        jmp     (a0)
 
 #if CONF_WITH_BUS_ERROR
 

--- a/bios/blkdev.c
+++ b/bios/blkdev.c
@@ -689,11 +689,15 @@ LONG blkdev_getbpb(WORD dev)
 
 static LONG blkdev_mediach(WORD dev)
 {
-    BLKDEV *b = &blkdev[dev];
+    BLKDEV *b;
     UWORD unit;
     LONG ret;
 
-    if ((dev < 0 ) || (dev >= BLKDEVNUM) || !(b->flags&DEVICE_VALID))
+    if ((dev < 0 ) || (dev >= BLKDEVNUM))
+        return EUNDEV;  /* unknown device */
+
+    b = &blkdev[dev];
+    if (!(b->flags&DEVICE_VALID))
         return EUNDEV;  /* unknown device */
 
     unit = b->unit;

--- a/bios/blkdev.c
+++ b/bios/blkdev.c
@@ -690,11 +690,13 @@ LONG blkdev_getbpb(WORD dev)
 static LONG blkdev_mediach(WORD dev)
 {
     BLKDEV *b = &blkdev[dev];
-    UWORD unit = b->unit;
+    UWORD unit;
     LONG ret;
 
     if ((dev < 0 ) || (dev >= BLKDEVNUM) || !(b->flags&DEVICE_VALID))
         return EUNDEV;  /* unknown device */
+
+    unit = b->unit;
 
     /* if we've already marked the drive as MEDIACHANGE, don't change it */
     if (b->mediachange == MEDIACHANGE)

--- a/bios/xbios.c
+++ b/bios/xbios.c
@@ -732,16 +732,31 @@ static void xbios_25(void)
  * BIOS or GEMDOS calls. This function is meant to allow programs
  * to hack hardware and protected locations without having to fiddle
  * with GEMDOS get/set supervisor mode call.
- * There is no rule regarding to which registers might be clobbered by the user
- * function. For safety, we assume it can clobber all of them.
+ *
+ * On m68k, the normal version of supexec() is a tiny assembler
+ * trampoline (see vectors.S) that jumps to the user's code instead
+ * of calling it, so it adds no stack frame of its own. This matters
+ * because there is no rule about how much stack the user's function
+ * needs, and some callers (e.g. certain game loaders) run with very
+ * little stack to spare.
+ *
+ * The debug version lives here and is much uglier since it has to
+ * protect itself against GCC possibly generating code to use registers
+ * which might have been clobbered by the called user function. There
+ * are no rules about this, so for safety, we assume it can clobber all
+ * of them.
  */
-
-static LONG supexec(PFLONG codeptr)
+#if DBG_XBIOS
+static LONG xbios_26(PFLONG codeptr)
 {
 #if defined(__m68k__)
     register LONG retval __asm__("d0");
     register PFLONG func __asm__("a0") = codeptr;
+#endif
 
+    kprintf("XBIOS: Supexec(%p)\n", codeptr);
+
+#if defined(__m68k__)
     /* a6 is saved/restored around the call instead of being listed as a
      * clobber: some m68k-atari-mintelf-gcc 13.3.0 builds ICE in
      * print_operand_address (RTL "final" pass) when a6 is clobbered by
@@ -765,13 +780,6 @@ static LONG supexec(PFLONG codeptr)
     /* On arm we assume the function follows the eabi and dont save any additional registers */
     return codeptr();
 #endif
-}
-
-#if DBG_XBIOS
-static LONG xbios_26(PFLONG codeptr)
-{
-    kprintf("XBIOS: Supexec(%p)\n", codeptr);
-    return supexec(codeptr);
 }
 #endif
 
@@ -1052,6 +1060,16 @@ LONG xbios_do_unimpl(WORD number)
 }
 
 extern LONG xbios_unimpl(void);
+
+#if defined(__m68k__)
+extern LONG supexec(PFLONG);   /* implemented in vectors.S */
+#else
+/* On arm we assume the function follows the eabi and dont save any additional registers */
+static LONG supexec(PFLONG codeptr)
+{
+    return codeptr();
+}
+#endif
 
 
 /*

--- a/bios/xbios.c
+++ b/bios/xbios.c
@@ -777,7 +777,7 @@ static LONG xbios_26(PFLONG codeptr)
 
     return retval;
 #else
-    /* On arm we assume the function follows the eabi and dont save any additional registers */
+    /* On arm we assume the function follows the eabi and don't save any additional registers */
     return codeptr();
 #endif
 }
@@ -1064,7 +1064,7 @@ extern LONG xbios_unimpl(void);
 #if defined(__m68k__)
 extern LONG supexec(PFLONG);   /* implemented in vectors.S */
 #else
-/* On arm we assume the function follows the eabi and dont save any additional registers */
+/* On arm we assume the function follows the eabi and don't save any additional registers */
 static LONG supexec(PFLONG codeptr)
 {
     return codeptr();

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -1122,7 +1122,11 @@ void app_save(WORD todisk)
         *pcurr++ = '\n';
         if (pcurr-gl_afile >= SIZE_AFILE)   /* overflow check */
         {
-            for (pcurr -= 2; *pcurr != '\n'; pcurr--)
+            /* the '#R' revision line written at the very start of this
+             * function always ends in '\n', so this is guaranteed to
+             * find one; the lower bound just keeps that guarantee from
+             * being a silent buffer underrun if it's ever violated */
+            for (pcurr -= 2; (pcurr > gl_afile) && (*pcurr != '\n'); pcurr--)
                 ;
             pcurr++;        /* point after previous line */
             break;

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -1247,6 +1247,9 @@ ANODE *app_afind_by_id(WORD obid)
 {
     ANODE *pa;
 
+    if (obid < WOBS_START)      /* validate obid */
+        return NULL;
+
     for (pa = G.g_ahead; pa; pa = pa->a_next)
     {
         if (pa->a_obid == obid)

--- a/desk/deskapp.c
+++ b/desk/deskapp.c
@@ -127,9 +127,20 @@
 
 #define INF_REV_LEVEL   0x01    /* revision level when creating EMUDESK.INF */
 
+/*
+ * the maximum size of an EMUDESK.INF line (see app_save())
+ */
+#define MAX_SIZE_INF_LINE   (MAXPATHLEN+100)    /* conservative */
+
 static WORD     inf_rev_level;  /* revision level of current EMUDESK.INF */
 
-static BYTE     gl_afile[SIZE_AFILE];
+/*
+ * gl_afile is sized larger than SIZE_AFILE by the length of one line,
+ * so that app_save() only needs to check for buffer overflow at the
+ * end of each line, rather than before every write within it.  the
+ * data actually saved/loaded is always bounded to SIZE_AFILE bytes.
+ */
+static BYTE     gl_afile[SIZE_AFILE+MAX_SIZE_INF_LINE];
 static BYTE     *gl_buffer;
 
 
@@ -1109,6 +1120,13 @@ void app_save(WORD todisk)
         }
         *pcurr++ = '\r';
         *pcurr++ = '\n';
+        if (pcurr-gl_afile >= SIZE_AFILE)   /* overflow check */
+        {
+            for (pcurr -= 2; *pcurr != '\n'; pcurr--)
+                ;
+            pcurr++;        /* point after previous line */
+            break;
+        }
     }
     *pcurr++ = 0x0;
 

--- a/doc/bugs.txt
+++ b/doc/bugs.txt
@@ -4,13 +4,8 @@ AES/VDI/Line-A bugs:
   http://sourceforge.net/mailarchive/message.php?msg_id=29276993
   This is due to a bug somewhere in the ugly text_blt() assembler
   function in vdi_tblit.S.
-- Thick arcs going partly outside of screen have incorrectly
-  drawn pixels at top of screen in vdiline tester.
 - In "MathMaze" and "The Ultimate Minesweeper", game win and score
   dialogs leave left/bottom outline on screen when they close.
-- Line-A polygons are one pixel short at both sides.  This is
-  because clc_flit() function does it for VDI (where perimeter
-  is drawn separately).  It is visible e.g. in "Japlish" game.
 
 Desktop bugs:
 - Sometimes, if ^C is pressed during a "Show file" operation, the menu

--- a/vdi/vdi_fill.c
+++ b/vdi/vdi_fill.c
@@ -563,8 +563,6 @@ polygon(Vwk * vwk, Point * ptsin, int count)
             if (fill_maxy >= clipper->ymn_clip) {
                 /* polygon starts before clip */
                 fill_miny = clipper->ymn_clip - 1;       /* polygon partial overlap */
-                if (fill_miny < 1)
-                    fill_miny = 1;
             } else
                 return;         /* polygon entirely before clip */
         }

--- a/vdi/vdi_fill.c
+++ b/vdi/vdi_fill.c
@@ -11,10 +11,13 @@
 
 
 
+/* #define ENABLE_KDEBUG */
+
 #include "config.h"
 #include "portab.h"
 #include "vdi_defs.h"
 #include "vdi_backend.h"
+#include "kprint.h"
 #include "../bios/tosvars.h"
 #include "../bios/lineavars.h"
 
@@ -22,7 +25,6 @@
 #define NOT_FOUND -1
 #define DOWN_FLAG 0x8000
 #define QSIZE 200
-#define QMAX QSIZE-1
 
 
 
@@ -904,7 +906,9 @@ void contourfill(const VwkAttrib * attr, const VwkClip *clip)
     WORD xright;                /* */
     WORD direction;             /* is next scan line up or down */
     BOOL notdone;               /* does seedpoint==search_color */
-    BOOL gotseed;               /* a seed was put in the Q      */
+    WORD gotseed;               /* 1 => seed was put in the Q */
+                                 /* 0 => no seed was put in the Q */
+                                 /* -1 => queue overflowed */
     BOOL seed_type;             /* indicates the type of fill */
 
     xleft = PTSIN[0];
@@ -973,26 +977,32 @@ void contourfill(const VwkAttrib * attr, const VwkClip *clip)
             direction = (oldy & DOWN_FLAG) ? 1 : -1;
             gotseed = get_seed(attr, clip, oldxleft, (oldy + direction),
                                &newxleft, &newxright, seed_type);
+            if (gotseed < 0)
+                return;         /* error, quit */
 
             if ((newxleft < (oldxleft - 1)) && gotseed) {
                 xleft = oldxleft;
                 while (xleft > newxleft) {
                     --xleft;
-                    get_seed(attr, clip, xleft, oldy ^ DOWN_FLAG,
-                             &xleft, &xright, seed_type);
+                    if (get_seed(attr, clip, xleft, oldy ^ DOWN_FLAG,
+                             &xleft, &xright, seed_type) < 0)
+                        return; /* error, quit */
                 }
             }
             while (newxright < oldxright) {
                 ++newxright;
                 gotseed = get_seed(attr, clip, newxright, oldy + direction,
                                    &xleft, &newxright, seed_type);
+                if (gotseed < 0)
+                    return;     /* error, quit */
             }
             if ((newxright > (oldxright + 1)) && gotseed) {
                 xright = oldxright;
                 while (xright < newxright) {
                     ++xright;
-                    get_seed(attr, clip, xright, oldy ^ DOWN_FLAG,
-                             &xleft, &xright, seed_type);
+                    if (get_seed(attr, clip, xright, oldy ^ DOWN_FLAG,
+                             &xleft, &xright, seed_type) < 0)
+                        return; /* error, quit */
                 }
             }
 
@@ -1073,9 +1083,9 @@ get_seed(const VwkAttrib * attr, const VwkClip * clip,
         }
 
         if (qhole == NOT_FOUND) {
-            if ((qtop += 3) > QMAX) {
-                qtmp = qbottom;
-                qtop -= 3;
+            if ((qtop += 3) > QSIZE) {  /* can't raise qtop ... */
+                KDEBUG(("contourfill(): queue overflow\n"));
+                return -1;      /* error */
             }
         } else
             qtmp = qhole;

--- a/vdi/vdi_fill.c
+++ b/vdi/vdi_fill.c
@@ -463,13 +463,18 @@ clc_flit (const VwkAttrib * attr, const VwkClip * clipper, const Point * point, 
     if ( intersections > 1 )
         bub_sort(fill_buffer, intersections);
 
-    if (attr->clip) {
-        /* Clipping is in force.  Once the endpoints of the line segment have */
-        /* been adjusted for the border, clip them to the left and right sides */
-        /* of the clipping rectangle. */
+    /*
+     * Testing under Atari TOS shows that the fill area always *includes*
+     * the left & right perimeter (for those functions that allow the
+     * perimeter to be drawn separately, it is drawn on top of the edge
+     * pixels).  We now conform to Atari TOS.
+     */
 
-        /* The x-coordinates of each line segment are adjusted so that the */
-        /* border of the figure will not be drawn with the fill pattern. */
+    if (attr->clip) {
+        /*
+         * Clipping is in force.  Clip the endpoints of the line segment
+         * to the left and right sides of the clipping rectangle.
+         */
 
         /* loop through buffered points */
         WORD * ptr = fill_buffer;
@@ -477,13 +482,9 @@ clc_flit (const VwkAttrib * attr, const VwkClip * clipper, const Point * point, 
             WORD x1, x2;
             Rect rect;
 
-            /* grab a pair of adjusted intersections */
-            x1 = *ptr++ + 1;
-            x2 = *ptr++ - 1;
-
-            /* do nothing, if starting point greater than ending point */
-            if ( x1 > x2 )
-                continue;
+            /* grab a pair of endpoints */
+            x1 = *ptr++;
+            x2 = *ptr++;
 
             if ( x1 < clipper->xmn_clip ) {
                 if ( x2 < clipper->xmn_clip )
@@ -508,33 +509,19 @@ clc_flit (const VwkAttrib * attr, const VwkClip * clipper, const Point * point, 
     else {
         /* Clipping is not in force.  Draw from point to point. */
 
-        /* This code has been modified from the version in the screen driver. */
-        /* The x-coordinates of each line segment are adjusted so that the */
-        /* border of the figure will not be drawn with the fill pattern.  If */
-        /* the starting point is greater than the ending point then nothing is */
-        /* done. */
-
         /* loop through buffered points */
         WORD * ptr = fill_buffer;
         for (i = intersections / 2 - 1; i >= 0; i--) {
-            WORD x1, x2;
             Rect rect;
 
-            /* grab a pair of adjusted endpoints */
-            x1 = *ptr++ + 1 ;   /* word */
-            x2 = *ptr++ - 1 ;   /* word */
+            /* grab a pair of endpoints */
+            rect.x1 = *ptr++;
+            rect.y1 = y;
+            rect.x2 = *ptr++;
+            rect.y2 = y;
 
-            /* If starting point greater than ending point, nothing is done. */
-            /* is start still to left of end? */
-            if ( x1 <= x2 ) {
-                rect.x1 = x1;
-                rect.y1 = y;
-                rect.x2 = x2;
-                rect.y2 = y;
-
-                /* rectangle fill routine draws horizontal line */
-                draw_rect_common(attr, &rect);
-            }
+            /* rectangle fill routine draws horizontal line */
+            draw_rect_common(attr, &rect);
         }
     }
 }

--- a/vdi/vdi_line.c
+++ b/vdi/vdi_line.c
@@ -712,7 +712,6 @@ void linea_polygon(void)
         clipper.xmn_clip = 0;
         clipper.xmx_clip = xres;
     }
-    /* compared to real line-A, clc_flit explicitly skips outline */
     clc_flit(&attr, &clipper, points, linea_vars.Y1, count);
 }
 

--- a/vdi/vdi_raster.c
+++ b/vdi/vdi_raster.c
@@ -628,7 +628,7 @@ bit_blt (void)
 #define mHOP_Halftone 0x01
     blt->hop = mHOP_Source;   /* word */    /* set HOP to source only */
 
-    for (plane = blit_info->plane_ct-1; plane >= 0; plane--) {
+    for (plane = 0; plane < blit_info->plane_ct; plane++) {
         int op_tabidx;
 
         blt->src_addr = s_addr;         /* load Source pointer to this plane */


### PR DESCRIPTION
## Summary

Ports low-risk, generic-code bugfixes from upstream EmuTOS (post fork-point) that pTOS never received, per #110.

**Ported (12 commits):**
- `252a871d` — fix file-selector heap overwrite in `fs_input()` (mask string overran `te_ptext`)
- `9712bcbe` — fix `bit_blt()` FG/BG colour plane order (wrong colours with blitter/ColdFire since 2004)
- `b2dacc1d` + `289c3dcc` — fix `contourfill()` queue off-by-one and overflow handling (could loop forever)
- `25182b82` — avoid overflow in AES's keyboard buffer (only request a key when there's room)
- `1079d817` — add buffer overflow check when saving EMUDESK.INF
- `ed49853c` — fix hang when a desk accessory issues `form_alert()` (mouse ownership)
- `cc24601b` — fix OOB access in `blkdev_mediach()` on an illegal device number
- `2fd6576f` — fix EmuDesk crash when double-clicking the desktop background
- `62138169` — fix window arrow-gadget handling so held-down button events don't leak to app event loops (adapted to pTOS's older AES event-queue code)
- `291dcce7` + `4e52a6a0` — fill polygons including their left/right perimeter (fixes lineA polygons and wideline/arrow/GDP output being one pixel short)
- `7926ccb5` — fix wideline drawn incorrectly when clipping is active near the screen top
- `288e0270` — avoid an extra m68k stack frame in `Supexec()` (ported as a real assembler trampoline in `vectors.S`, adapted to pTOS's existing arch-split ARM/m68k `supexec()`)

**Investigated and not ported, with reasoning:**
- The four `util/doprintf.c` fixes and `28c21ecc` (`sh_name()`) — pTOS's code in these areas predates the upstream implementations the bugs live in, so none of them reproduce.
- `bca12b52` (arc precision/speed) — a cosmetic accuracy polish against a trig-table implementation upstream had already rewritten; pTOS's `vdi_gdp.c` is a structurally different, older implementation, and porting it would mean re-deriving table-generation logic upstream never had against this code, with no way to visually verify the result.

## Test plan

- [x] `make gitready` passes
- [x] Full build succeeds on all 5 ARM configs: `rpi1`, `rpi2`, `rpi3`, `rpi4`, `virt-arm`
- [x] All touched files compile cleanly (object-level, `-O0`) on all 4 m68k configs: `atari512`, `amiga`, `m548x-bas`, `virt-m68k` (full m68k link not verifiable in this environment — no real `m68k-atari-mintelf-`/`m68k-elf-` toolchain available, only a substitute `m68k-linux-gnu-` toolchain with pre-existing, unrelated GCC-13 ICEs and type-identity mismatches at full-project scale)
- [x] rpi1 image smoke-tested under QEMU (`qemu-system-arm -M raspi1ap`): boots cleanly to `AES: EMUDESK: evnt_multi()` idle loop, zero `guest_errors`

Fixes #110

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUmMjginTVPvLpEncxNWnf)_