### PR TITLE
Port graf_mouse()/ctlmgr() mouse-ownership conflict fix

### DIFF
--- a/aes/gemctrl.c
+++ b/aes/gemctrl.c
@@ -323,7 +323,6 @@ void ct_mouse(WORD grabit)
     {
         wm_update(BEG_UPDATE);
         gl_ctmown = TRUE;
-        gl_mowner = rlr;
         set_mouse_to_arrow();
         gl_tmpmoff = gl_moff;
         if (gl_tmpmoff)

--- a/aes/gemfmalt.c
+++ b/aes/gemfmalt.c
@@ -32,6 +32,7 @@
 #include "gemoblib.h"
 #include "gemobed.h"
 #include "geminit.h"
+#include "geminput.h"
 #include "gemrslib.h"
 #include "gemgraf.h"
 #include "gemfmlib.h"
@@ -335,15 +336,22 @@ WORD fm_alert(WORD defbut, BYTE *palstr)
     ob_draw(tree, ROOT, MAX_DEPTH);
 
     /*
-     * turn on the mouse.  ct_mouse(TRUE) also sets gl_mowner to rlr,
-     * which is required for DAs to be able to issue form_alert()s: if
-     * mouse ownership isn't updated, the desktop remains the mouse
-     * owner, and the system queues any mouse clicks to the desktop's
-     * evnt_multi() rather than the evnt_multi() issued by fm_do()
-     * below.  this would result in the DA (and then the whole system)
-     * hanging.
+     * turn on the mouse and set the mouse owner.  the latter is required
+     * for DAs to be able to issue form_alert()s.
+     *
+     * if we don't update mouse ownership, the desktop will remain the
+     * mouse owner, and the system will queue any mouse clicks to the
+     * desktop's evnt_multi(), rather than the evnt_multi() issued by
+     * the fm_do() below.  this will result in the DA (and then the whole
+     * system) hanging.
+     *
+     * ct_mouse(TRUE) no longer does this itself as of #146/803fe7a8: it
+     * is also called from GRAF_MOUSE handling now, where reassigning
+     * ownership on every mouse-form toggle would steal it from whoever
+     * actually holds it.
      */
     ct_mouse(TRUE);
+    gl_mowner = rlr;
 
     /* let user pick button */
     i = fm_do(tree, 0);

--- a/aes/gemgrlib.c
+++ b/aes/gemgrlib.c
@@ -22,12 +22,14 @@
 #include "basepage.h"
 #include "obdefs.h"
 #include "gemlib.h"
+#include "crysbind.h"
 
 #include "gemevlib.h"
 #include "gemgraf.h"
 #include "gemwmlib.h"
 #include "gemoblib.h"
 #include "geminput.h"
+#include "geminit.h"
 #include "gemgsxif.h"
 #include "gemgrlib.h"
 #include "gemasm.h"
@@ -374,6 +376,31 @@ WORD gr_slidebox(OBJECT *tree, WORD parent, WORD obj, WORD isvert)
         return mul_div(divnd, 1000, divis);
     else
         return 0;
+}
+
+
+/*
+ * handle graf_mouse() processing
+ */
+void gr_mouse(WORD mode, MFORM *maddr)
+{
+    switch(mode)
+    {
+    default:
+        if ((mode < ARROW) || (mode > OUTLN_CROSS))
+            mode = ARROW;       /* fail safe */
+        maddr = mouse_cursor[mode];
+        FALLTHROUGH;
+    case USER_DEF:
+        gsx_mfset(maddr);
+        break;
+    case M_OFF:
+        gsx_moff();
+        break;
+    case M_ON:
+        gsx_mon();
+        break;
+    }
 }
 
 

--- a/aes/gemgrlib.c
+++ b/aes/gemgrlib.c
@@ -387,6 +387,8 @@ void gr_mouse(WORD mode, MFORM *maddr)
     switch(mode)
     {
     default:
+        if (mode > USER_DEF)    /* unknown mode beyond M_OFF/M_ON: ignore, as before */
+            break;
         if ((mode < ARROW) || (mode > OUTLN_CROSS))
             mode = ARROW;       /* fail safe */
         maddr = mouse_cursor[mode];

--- a/aes/gemgrlib.h
+++ b/aes/gemgrlib.h
@@ -9,7 +9,7 @@
 
 #ifndef GEMGRLIB_H
 #define GEMGRLIB_H
-
+#include "gsxdefs.h"
 
 void gr_stepcalc(WORD orgw, WORD orgh, GRECT *pt, WORD *pcx, WORD *pcy,
                  WORD *pcnt, WORD *pxstep, WORD *pystep);
@@ -25,6 +25,7 @@ void gr_growbox(GRECT *po, GRECT *pt);
 void gr_shrinkbox(GRECT *po, GRECT *pt);
 WORD gr_watchbox(OBJECT *tree, WORD obj, WORD instate, WORD outstate);
 WORD gr_slidebox(OBJECT *tree, WORD parent, WORD obj, WORD isvert);
+void gr_mouse(WORD mode, MFORM *maddr);
 void gr_mkstate(WORD *pmx, WORD *pmy, WORD *pmstat, WORD *pkstat);
 
 

--- a/aes/gemsuper.c
+++ b/aes/gemsuper.c
@@ -81,9 +81,8 @@ static void aestrace(const char* message)
 static UWORD crysbind(WORD opcode, AESGLOBAL *pglobal, WORD control[], WORD int_in[], WORD int_out[], LONG addr_in[])
 {
     LONG    count, buparm;
-    MFORM   *maddr;
     OBJECT  *tree;
-    WORD    mouse, ret;
+    WORD    ret;
     WORD    unsupported = FALSE;
 
     count = 0L;
@@ -294,25 +293,7 @@ static UWORD crysbind(WORD opcode, AESGLOBAL *pglobal, WORD control[], WORD int_
         ret = gl_handle;
         break;
     case GRAF_MOUSE:
-        if (GR_MNUMBER > USER_DEF)
-        {
-            if (GR_MNUMBER == M_OFF)
-                gsx_moff();
-            if (GR_MNUMBER == M_ON)
-                gsx_mon();
-            break;
-        }
-        if (GR_MNUMBER != USER_DEF)
-        {
-            if ((GR_MNUMBER < ARROW) || (GR_MNUMBER > OUTLN_CROSS))
-                mouse = ARROW;
-            else
-                mouse = GR_MNUMBER;
-            maddr = mouse_cursor[mouse];
-        }
-        else
-            maddr = (MFORM *)GR_MADDR;
-        gsx_mfset(maddr);
+        gr_mouse(GR_MNUMBER, (MFORM *)GR_MADDR);
         break;
     case GRAF_MKSTATE:
         gr_mkstate(&GR_MX, &GR_MY, &GR_MSTATE, &GR_KSTATE);

--- a/aes/gemsuper.c
+++ b/aes/gemsuper.c
@@ -44,8 +44,9 @@
 #include "gemrslib.h"
 #include "gemshlib.h"
 #include "gemfmalt.h"
-#include "gemdosif.h"
 #include "gemasm.h"
+#include "gemctrl.h"
+#include "gemdosif.h"
 
 #include "string.h"
 
@@ -293,7 +294,14 @@ static UWORD crysbind(WORD opcode, AESGLOBAL *pglobal, WORD control[], WORD int_
         ret = gl_handle;
         break;
     case GRAF_MOUSE:
-        gr_mouse(GR_MNUMBER, (MFORM *)GR_MADDR);
+        if (gl_ctmown)          /* if the ctlmgr owns the mouse, */
+        {                       /* give up control (temporarily) */
+            ct_mouse(FALSE);
+            gr_mouse(GR_MNUMBER, (MFORM *)GR_MADDR);
+            ct_mouse(TRUE);
+        }
+        else
+            gr_mouse(GR_MNUMBER, (MFORM *)GR_MADDR);
         break;
     case GRAF_MKSTATE:
         gr_mkstate(&GR_MX, &GR_MY, &GR_MSTATE, &GR_KSTATE);


### PR DESCRIPTION
Fixes #146

## Summary

Ports the two upstream commits behind the `gl_mowner`/`ct_mouse()` question raised during review of #145:

- **`73f05cd6`** — pure refactor extracting the inline `GRAF_MOUSE` opcode handling out of `gemsuper.c`'s `crysbind()` into a new `gr_mouse(WORD mode, MFORM *maddr)` in `aes/gemgrlib.c`. No behavior change; pTOS had never received this (its `GRAF_MOUSE` handling was still the original fork-point-era inline code).
- **`803fe7a8`** — the actual bugfix: an app that continually toggles `graf_mouse(M_OFF)`/`graf_mouse(M_ON)` while running (e.g. A.C.T.) could race with `ctlmgr()`'s own mouse grab/release, unbalancing the `gl_moff` counting semaphore and leaving mouse droppings over the menu bar. `GRAF_MOUSE` now yields control via `ct_mouse(FALSE)`/`ct_mouse(TRUE)` around `gr_mouse()` whenever `ctlmgr()` currently owns the mouse (`gl_ctmown`).

  As a consequence, `ct_mouse()` no longer sets `gl_mowner` itself — since `GRAF_MOUSE` now calls `ct_mouse(TRUE)` incidentally on every guarded toggle, leaving the assignment in would let a mouse-visibility toggle from any process silently steal ownership from whoever actually holds it. `fm_alert()` (`aes/gemfmalt.c`) is the one caller that relied on `ct_mouse()`'s side effect (`ed49853c`, already ported in #145) — its explicit `gl_mowner = rlr;` assignment, correctly removed as redundant in #145, is restored here in the same change, matching upstream's actual sequencing.

Two commits, matching the two upstream commits:
1. Pure `gr_mouse()` extraction (no behavior change)
2. The conflict fix + `ct_mouse()`/`fm_alert()` ownership changes together

## Test plan

- [x] `make gitready` passes
- [x] Full build succeeds on all 5 ARM configs: `rpi1`, `rpi2`, `rpi3`, `rpi4`, `virt-arm`
- [x] All touched files compile cleanly (object-level, `-O0`) on all 4 m68k configs: `atari512`, `amiga`, `m548x-bas`, `virt-m68k` (no real `m68k-atari-mintelf-`/`m68k-elf-` toolchain available in this environment)
- [x] rpi1 image smoke-tested under QEMU (`qemu-system-arm -M raspi1ap`): boots cleanly to `AES: EMUDESK: evnt_multi()` idle loop, zero `guest_errors`
- [x] Audited all `ct_mouse(TRUE)`/`gl_mowner` call sites in `aes/*.c`: only `ctlmgr()`'s own grab (safe — ownership reverts to `ctl_pd` via existing `geminput.c` logic) and `fm_alert()` (now handled explicitly) were affected