### PR TITLE
Add virt-arm-cli / virt-m68k-cli defconfigs: boot straight to EmuCON on the serial console

### DIFF
--- a/.claude/skills/ptos-smoketest/SKILL.md
+++ b/.claude/skills/ptos-smoketest/SKILL.md
@@ -218,8 +218,10 @@ qemu-system-m68k -M virt -m 128 -cpu m68020 -kernel virt-m68k.elf -d guest_error
 
 # virt-arm-cli / virt-m68k-cli — same images/invocations as above, but boot to
 # EmuCON instead of the desktop (CONF_WITH_AES=n). Fastest smoke check: no AVI,
-# no framebuffer, just text on -serial stdio. Do not expect typed input to work
-# (see pass-signal notes below — serial console input is not wired up yet).
+# no framebuffer, just text on -serial stdio. Console input is implemented
+# (polling, see pass-signal notes below) but interactive verification in a
+# sandboxed shell may be unreliable for environment reasons unrelated to the
+# driver -- check with strace before assuming it's broken.
 make virt-arm-cli_defconfig && make
 qemu-system-arm -M virt,highmem=off -cpu cortex-a7 -m 128 -kernel virt-arm.elf -d guest_errors -serial stdio
 make virt-m68k-cli_defconfig && make
@@ -273,14 +275,34 @@ cat /tmp/qemu.log
   AVI/frame analysis entirely): pass signal is `Welcome to EmuCON2 version
   ...` followed by the `A:>` prompt appearing in the `-serial stdio` output,
   with no `guest_errors`/`unimp` beyond the same benign m68k `_detect_fpu`
-  entry noted above. Reaching the prompt is itself the thing to check for —
-  **do not try to type a command and expect a response**: `CONF_SERIAL_CONSOLE`
-  input injection (`push_ascii_ikbdiorec`) is only wired to an RX interrupt
-  handler for ColdFire (`bios/coldfire.c`); virt-arm's PL011 and virt-m68k's
-  Goldfish TTY have no equivalent hookup yet, so keystrokes sent over
-  `-serial stdio` are never delivered to EmuCON. Serial console *output*
-  works fully on both; *input* does not (verified: a `printf 'ver\r'`
-  written to QEMU's stdin after the prompt produces no echo and no response).
+  entry noted above.
+  - **Console input**: `CONF_SERIAL_CONSOLE` input injection
+    (`push_ascii_ikbdiorec`) is wired up for both machines by *polling* the
+    UART/TTY from the existing 200 Hz periodic tick
+    (`virt_uart0_poll_rx()` from `virt_timer_tick()`;
+    `goldfish_tty_poll_rx()` from `goldfish_rtc_service()`) rather than a
+    dedicated RX interrupt — deliberately, mirroring how ColdFire's is the
+    only machine with a real RX-interrupt hookup
+    (`coldfire_rs232_enable_interrupt()`). This also fixed a real pre-existing
+    bug: virt-arm's PL011 init never set `LCRH.FEN`, so the UART never
+    actually ran in FIFO mode despite the code comment claiming it did.
+  - **Verifying input interactively is unreliable in a sandboxed/CI
+    shell.** `strace -f -e trace=read,poll,ppoll` on a spawned
+    `qemu-system-arm -M virt ... -serial stdio` process, in at least one
+    such environment, showed `ppoll()` repeatedly reporting `fd=0`
+    (stdin) as `POLLIN`-ready — then QEMU never issued the matching
+    `read(0, ...)` before the fd hit `POLLHUP` and was dropped from the
+    poll set entirely. TX was unaffected (verified extensively: boot
+    banner, EmuCON prompt, etc. all render correctly), and QEMU's own
+    monitor chardev on the same spawned process consumed typed input
+    correctly in the same session — so this looks like a QEMU/host-pty
+    interaction gap specific to the guest-UART chardev path in that
+    container, not a general "no ptys here" limitation, and not something
+    the pTOS-side driver can work around. **Do not conclude the feature is
+    broken from a failed automated keystroke test alone** — first confirm
+    with `strace` (or by testing from a real interactive terminal) whether
+    the environment is actually delivering bytes to QEMU's serial chardev
+    at all before suspecting the driver.
 
 ## Common mistakes
 
@@ -296,4 +318,4 @@ cat /tmp/qemu.log
 | STE boot prints two `Bus Error reading at address $4fffff/$cc03c3` warnings | Benign init probes at `PC=$e00c20` (`TST.B (A0)`); present on every boot, ignore |
 | Testing `ptoscart.img` as the `--tos` image | It is a cartridge, not a TOS: pass it via `--cartridge` and supply a real Atari TOS ROM with `--tos` (pTOS ROMs have cartridge detection compiled out) |
 | Expecting a desktop from `ptoscart.img` | The 128 KB cartridge excludes the AES/desktop; pass signal is the rendered diagnostic text screen, not the checkerboard |
-| Typing a command at the `virt-arm-cli`/`virt-m68k-cli` EmuCON prompt over `-serial stdio` and expecting a response | Serial console input isn't wired up on these machines (only ColdFire has the RX-interrupt hookup); reaching the `A:>` prompt is the pass signal, not a round-tripped command |
+| A scripted keystroke at the `virt-arm-cli`/`virt-m68k-cli` EmuCON prompt over `-serial stdio` gets no response | Input is implemented (polled from the 200 Hz tick), but some sandboxed shells never deliver the bytes to QEMU's serial chardev at all (`ppoll()` sees stdin `POLLIN` but QEMU never `read()`s it) — confirm with `strace` before assuming the driver is broken; reaching the `A:>` prompt alone is still a valid automated pass signal either way |

--- a/.claude/skills/ptos-smoketest/SKILL.md
+++ b/.claude/skills/ptos-smoketest/SKILL.md
@@ -22,6 +22,8 @@ the pTOS tree). Relevant outputs:
 | `rpi2_defconfig` | qemu-system-arm | `kernel7.img` | `-M raspi2b` (video + serial) |
 | `virt-arm_defconfig` | qemu-system-arm | `virt-arm.elf` | `-M virt,highmem=off -cpu cortex-a7` (headless) |
 | `virt-m68k_defconfig` | qemu-system-m68k | `virt-m68k.elf` | `-M virt -cpu m68020` (headless) |
+| `virt-arm-cli_defconfig` | qemu-system-arm | `virt-arm.elf` | same as `virt-arm_defconfig`, but boots to EmuCON, not the desktop |
+| `virt-m68k-cli_defconfig` | qemu-system-m68k | `virt-m68k.elf` | same as `virt-m68k_defconfig`, but boots to EmuCON, not the desktop |
 
 Atari configs build with the default mintelf toolchain (`m68k-atari-mintelf-`)
 and produce symbols in `ptos512k.sym` (load in the Hatari debugger with
@@ -213,6 +215,15 @@ qemu-system-arm -M virt,highmem=off -cpu cortex-a7 -m 128 -kernel virt-arm.elf -
 # virt-m68k (headless) — MUST use -cpu m68020: the 68040 CACR probe hits a fatal QEMU bug
 make virt-m68k_defconfig && make
 qemu-system-m68k -M virt -m 128 -cpu m68020 -kernel virt-m68k.elf -d guest_errors -serial stdio
+
+# virt-arm-cli / virt-m68k-cli — same images/invocations as above, but boot to
+# EmuCON instead of the desktop (CONF_WITH_AES=n). Fastest smoke check: no AVI,
+# no framebuffer, just text on -serial stdio. Do not expect typed input to work
+# (see pass-signal notes below — serial console input is not wired up yet).
+make virt-arm-cli_defconfig && make
+qemu-system-arm -M virt,highmem=off -cpu cortex-a7 -m 128 -kernel virt-arm.elf -d guest_errors -serial stdio
+make virt-m68k-cli_defconfig && make
+qemu-system-m68k -M virt -m 128 -cpu m68020 -kernel virt-m68k.elf -d guest_errors -serial stdio
 ```
 
 Device variants (both virt ports; `force-legacy=false` is required on QEMU
@@ -257,6 +268,19 @@ cat /tmp/qemu.log
 - Known issue: `_hz_200` may stall on virt targets (shared AES/gemdisp.c
   IRQ-mask bug, affects raspi too) — a timer that fires correctly at least
   once is the v1 bar.
+- **virt-arm-cli / virt-m68k-cli** (`CONF_WITH_AES=n`, boots straight to
+  EmuCON instead of the desktop — for a fast dev-loop check that avoids
+  AVI/frame analysis entirely): pass signal is `Welcome to EmuCON2 version
+  ...` followed by the `A:>` prompt appearing in the `-serial stdio` output,
+  with no `guest_errors`/`unimp` beyond the same benign m68k `_detect_fpu`
+  entry noted above. Reaching the prompt is itself the thing to check for —
+  **do not try to type a command and expect a response**: `CONF_SERIAL_CONSOLE`
+  input injection (`push_ascii_ikbdiorec`) is only wired to an RX interrupt
+  handler for ColdFire (`bios/coldfire.c`); virt-arm's PL011 and virt-m68k's
+  Goldfish TTY have no equivalent hookup yet, so keystrokes sent over
+  `-serial stdio` are never delivered to EmuCON. Serial console *output*
+  works fully on both; *input* does not (verified: a `printf 'ver\r'`
+  written to QEMU's stdin after the prompt produces no echo and no response).
 
 ## Common mistakes
 
@@ -272,3 +296,4 @@ cat /tmp/qemu.log
 | STE boot prints two `Bus Error reading at address $4fffff/$cc03c3` warnings | Benign init probes at `PC=$e00c20` (`TST.B (A0)`); present on every boot, ignore |
 | Testing `ptoscart.img` as the `--tos` image | It is a cartridge, not a TOS: pass it via `--cartridge` and supply a real Atari TOS ROM with `--tos` (pTOS ROMs have cartridge detection compiled out) |
 | Expecting a desktop from `ptoscart.img` | The 128 KB cartridge excludes the AES/desktop; pass signal is the rendered diagnostic text screen, not the checkerboard |
+| Typing a command at the `virt-arm-cli`/`virt-m68k-cli` EmuCON prompt over `-serial stdio` and expecting a response | Serial console input isn't wired up on these machines (only ColdFire has the RX-interrupt hookup); reaching the `A:>` prompt is the pass signal, not a round-tripped command |

--- a/bios/ikbd.c
+++ b/bios/ikbd.c
@@ -873,6 +873,11 @@ void kbd_init(void)
 #if CONF_SERIAL_CONSOLE
 # ifdef __mcoldfire__
     coldfire_rs232_enable_interrupt();
+# elif CONF_WITH_VIRT_UART || CONF_WITH_GOLDFISH_TTY
+    /* virt-arm/virt-m68k read console input by polling the UART/TTY from
+     * their periodic timer tick (virt_uart0_poll_rx() / goldfish_tty_poll_rx(),
+     * called from virt_timer.c / goldfish_rtc.c) rather than a dedicated
+     * RX interrupt, so there is nothing to enable here. */
 # else
     /* FIXME: Enable interrupts on other hardware. */
 # endif

--- a/bios/machine/virt-arm/virt_timer.c
+++ b/bios/machine/virt-arm/virt_timer.c
@@ -16,6 +16,9 @@
 #include "virt_timer.h"
 #include "vectors.h"
 #include "asm.h"
+#if CONF_WITH_VIRT_UART
+#include "virt_uart.h"
+#endif
 
 #define HZ                    200     /* ticks per second, matches the Atari 200 Hz timer C */
 #define VIRT_TIMER_PPI_PHYS   30      /* non-secure physical timer, fixed by the GIC/generic-timer binding */
@@ -26,6 +29,10 @@ static void virt_timer_tick(void)
 {
     ULONG cval_low, cval_high;
     UQUAD cval;
+
+#if CONF_SERIAL_CONSOLE && CONF_WITH_VIRT_UART
+    virt_uart0_poll_rx();
+#endif
 
     /* virt_timer_init() connects and enables this IRQ well before
      * mfp.c's init_system_timer() sets vector_5ms (that happens much

--- a/bios/machine/virt-arm/virt_uart.c
+++ b/bios/machine/virt-arm/virt_uart.c
@@ -13,6 +13,7 @@
 #include "portab.h"
 #include "virt_memmap.h"
 #include "virt_uart.h"
+#include "ikbd.h"
 
 #define UART0_DR     (*(volatile ULONG*)(VIRT_UART0_BASE+0x00))
 #define UART0_FR     (*(volatile ULONG*)(VIRT_UART0_BASE+0x18))
@@ -42,7 +43,7 @@ void virt_uart0_init(void)
     UART0_ICR = 0x7FF;
     UART0_IBRD = int_div;
     UART0_FBRD = fractdiv;
-    UART0_LCRH = (3 << 5);     /* 8 bits, no parity, FIFOs enabled */
+    UART0_LCRH = (3 << 5) | (1 << 4);  /* 8 bits, no parity, FIFOs enabled (FEN) */
     UART0_CR = 0x301;          /* UARTEN | TXE | RXE */
 }
 
@@ -69,3 +70,24 @@ UBYTE virt_uart0_read_byte(void)
         ;
     return (UBYTE) UART0_DR;
 }
+
+#if CONF_SERIAL_CONSOLE
+
+/* Feeds bytes typed at the far end of -serial into the same emulated
+ * IKBD event queue a real keyboard would use, so CONF_SERIAL_CONSOLE
+ * ("read the console input exclusively from the serial port") actually
+ * has something to read. Called from virt_timer_tick() (200 Hz) rather
+ * than a UART interrupt: the PL011 needs both RXIM (FIFO trigger level,
+ * several bytes) and RTIM (timeout) unmasked to catch a single
+ * interactively typed character sitting alone in the FIFO, and polling
+ * the already-proven-reliable timer tick avoids depending on that
+ * interrupt path, at the cost of at most 5 ms of latency -- imperceptible
+ * for a human typing. Mirrors how coldfire_rs232_interrupt_handler() feeds
+ * push_ascii_ikbdiorec() on ColdFire machines, minus the interrupt. */
+void virt_uart0_poll_rx(void)
+{
+    while (virt_uart0_can_read())
+        push_ascii_ikbdiorec(virt_uart0_read_byte());
+}
+
+#endif /* CONF_SERIAL_CONSOLE */

--- a/bios/machine/virt-arm/virt_uart.h
+++ b/bios/machine/virt-arm/virt_uart.h
@@ -15,6 +15,7 @@ BOOL virt_uart0_can_write(void);
 void virt_uart0_write_byte(UBYTE b);
 BOOL virt_uart0_can_read(void);
 UBYTE virt_uart0_read_byte(void);
+void virt_uart0_poll_rx(void);
 
 #endif /* MACHINE_VIRT_ARM */
 

--- a/bios/machine/virt-m68k/goldfish_rtc.c
+++ b/bios/machine/virt-m68k/goldfish_rtc.c
@@ -15,6 +15,9 @@
 #include "vectors.h"
 #include "goldfish_pic.h"
 #include "goldfish_rtc.h"
+#if CONF_WITH_GOLDFISH_TTY
+#include "goldfish_tty.h"
+#endif
 
 #define GOLDFISH_RTC_BASE  0xff006000UL   /* first of 2 instances; only this one is used */
 
@@ -57,6 +60,10 @@ void goldfish_rtc_service(void)
 {
     RTC_CLEAR_INTERRUPT = 1;
     goldfish_rtc_arm_next();
+
+#if CONF_SERIAL_CONSOLE && CONF_WITH_GOLDFISH_TTY
+    goldfish_tty_poll_rx();
+#endif
 }
 
 void goldfish_rtc_init(void)

--- a/bios/machine/virt-m68k/goldfish_tty.c
+++ b/bios/machine/virt-m68k/goldfish_tty.c
@@ -12,6 +12,7 @@
 
 #include "portab.h"
 #include "goldfish_tty.h"
+#include "ikbd.h"
 
 #define GOLDFISH_TTY_BASE  0xff008000UL
 
@@ -56,3 +57,24 @@ UBYTE goldfish_tty_read_byte(void)
 
     return goldfish_tty_rx_byte;
 }
+
+#if CONF_SERIAL_CONSOLE
+
+/* Feeds bytes typed at the far end of -serial into the same emulated
+ * IKBD event queue a real keyboard would use, so CONF_SERIAL_CONSOLE
+ * ("read the console input exclusively from the serial port") actually
+ * has something to read. Called from goldfish_rtc_service() (200 Hz)
+ * rather than a dedicated Goldfish PIC interrupt: instance 0 (the TTY's)
+ * has no ISR wired up on this board yet (see the "already claimed"
+ * comment in goldfish_pic.h), and polling the already-proven-reliable
+ * RTC tick avoids depending on unverified PIC-instance/bit wiring for
+ * it, at the cost of at most 5 ms of latency -- imperceptible for a
+ * human typing. Mirrors how coldfire_rs232_interrupt_handler() feeds
+ * push_ascii_ikbdiorec() on ColdFire machines, minus the interrupt. */
+void goldfish_tty_poll_rx(void)
+{
+    while (goldfish_tty_can_read())
+        push_ascii_ikbdiorec(goldfish_tty_read_byte());
+}
+
+#endif /* CONF_SERIAL_CONSOLE */

--- a/bios/machine/virt-m68k/goldfish_tty.h
+++ b/bios/machine/virt-m68k/goldfish_tty.h
@@ -15,6 +15,7 @@ BOOL goldfish_tty_can_write(void);
 void goldfish_tty_write_byte(UBYTE b);
 BOOL goldfish_tty_can_read(void);
 UBYTE goldfish_tty_read_byte(void);
+void goldfish_tty_poll_rx(void);
 
 #endif /* MACHINE_VIRT_M68K */
 

--- a/cli/arch/arm/cmdasm.S
+++ b/cli/arch/arm/cmdasm.S
@@ -11,9 +11,18 @@
  */
 
 #include "asmdefs.h"
-#include "../../../aes/asmstruct.h"
 
 #define COMASTACKSIZE   4096    /* in bytes: must be multiple of 4 */
+
+/* PD field offsets from include/pd.h, hardcoded rather than pulled from
+ * aes/asm_struct_gen.h: that header is only generated when CONF_WITH_AES
+ * is set (its generator needs AES_STACK_SIZE), but EmuCON must also build
+ * with the AES left out.  cli/cmdasm.S (m68k) hardcodes the same offsets
+ * for the same reason. */
+#define PD_p_tlen       0x0c
+#define PD_p_dlen       0x14
+#define PD_p_blen       0x1c
+#define SIZEOF_PD       0x100
 
         .globl  _coma_start
         .extern _cmdmain

--- a/configs/virt-arm-cli_defconfig
+++ b/configs/virt-arm-cli_defconfig
@@ -1,0 +1,38 @@
+# ELF kernel image for QEMU's ARM 'virt' machine (qemu-system-arm -M virt),
+# booting straight to the EmuCON command line over the serial console
+# instead of the GEM desktop. Meant for a fast inner dev loop: the pass/fail
+# signal is text on -serial stdio, no screen capture or frame analysis
+# needed. See virt-arm_defconfig for the full-stack (AES/VDI) target.
+MACHINE_VIRT_ARM=y
+
+# No architecture-specific default exists yet for this machine (unlike the
+# Raspberry Pi targets), so the CPU used for testing (QEMU's cortex-a7) is
+# spelled out explicitly here, following the precedent set by
+# amiga-vampire_defconfig for its own CPUFLAGS override.
+CPUFLAGS="-march=armv7-a -mtune=cortex-a7 -marm -mfpu=neon-vfpv4 -mfloat-abi=hard"
+
+# QEMU's 'virt' board has no IDE interface; without this, bios/ide.c fails
+# to build because struct IDE is never defined for this machine. Raspberry
+# Pi gets the same treatment via a Kconfig default (MACHINE_RPI); matched
+# here explicitly.
+CONF_WITH_IDE=n
+
+# The Line-A emulator (vdi/Kconfig) is only implemented for 68k-class
+# hardware (bios/arch/m68k/linea.S provides int_linea()); there is no ARM
+# implementation. Raspberry Pi already turns this off via a Kconfig
+# default (MACHINE_RPI); matched here explicitly.
+CONF_WITH_LINEA=n
+
+# XHDI support (bios/Kconfig) pulls in bios/xhdi.c, which references
+# xhdi_vec, implemented only in bios/arch/m68k/natfeat.S. Raspberry Pi
+# already turns this off via a Kconfig default (MACHINE_RPI); matched
+# here explicitly.
+CONF_WITH_XHDI=n
+
+# The whole point of this defconfig: leave the AES/EmuDesk out, so EmuTOS
+# boots straight into EmuCON (aes/Kconfig) instead of the graphical
+# desktop. CONF_WITH_CLI is left at its default (y): unlike virt-arm's
+# desktop defconfig, this target actually needs EmuCON, and it now builds
+# cleanly here (see cli/arch/arm/cmdasm.S, which no longer depends on the
+# AES-only-generated aes/asm_struct_gen.h for its basepage offsets).
+CONF_WITH_AES=n

--- a/configs/virt-m68k-cli_defconfig
+++ b/configs/virt-m68k-cli_defconfig
@@ -1,0 +1,47 @@
+# ELF kernel image for QEMU's m68k 'virt' machine (qemu-system-m68k -M virt),
+# booting straight to the EmuCON command line over the serial console
+# instead of the GEM desktop. Meant for a fast inner dev loop: the pass/fail
+# signal is text on -serial stdio, no screen capture or frame analysis
+# needed. See virt-m68k_defconfig for the full-stack (AES/VDI) target.
+MACHINE_VIRT_M68K=y
+
+# QEMU's m68k 'virt' board defaults to an m68040 core (see hw/m68k/virt.c's
+# mc->default_cpu_type), but this targets m68020 instead: QEMU's m68k
+# target unconditionally cpu_abort()s (crashes the whole VM) reading the
+# 68060-only PCR control register instead of raising the guest illegal
+# -instruction exception every other unsupported-register case gets
+# (target/m68k/helper.c: HELPER(m68k_movec_from), case M68K_CR_PCR).
+# bios/arch/m68k/processor.S's CPU detection -- shared, generic code used
+# by every m68k machine -- deliberately probes that exact register to
+# tell 68040 from 68060 apart, protected by its own exception vectors;
+# that protection can't help here because QEMU aborts before the guest
+# ever sees a trap. Targeting m68020 avoids the problem entirely: that
+# same detection routine resolves to "68020" from an earlier, unrelated
+# probe (the CACR cache-control register) before ever reaching the PCR
+# read. No v1 functionality needs 68040 (this port uses no PMMU); revisit
+# if a later feature needs 68040-specific behavior, or once upstream QEMU
+# fixes this (there is no per-target CPUFLAGS default for this board yet,
+# unlike the Raspberry Pi targets, so spell it out explicitly here,
+# following the MACHINE_ARANYM precedent in Kconfig.machine).
+CPUFLAGS="-m68020"
+
+# QEMU's 'virt' board has no IDE interface; without this, bios/ide.c fails
+# to build because struct IDE is never defined for this machine. Matched
+# to the same override already used by MACHINE_RPI and MACHINE_VIRT_ARM.
+CONF_WITH_IDE=n
+
+# This target must be built with an ELF-capable toolchain: emutos.ld forces
+# OUTPUT_FORMAT(elf32-m68k) for MACHINE_VIRT_M68K (QEMU's -kernel loader
+# needs a real ELF image, not a flat binary), and the a.out toolchain's
+# linker has no elf32-m68k target compiled in at all ("target elf32-m68k
+# not found").  Kconfig forbids the cross-mint toolchain for this machine
+# (BUILD_TOOLCHAIN_MINT depends on !MACHINE_VIRT_M68K), so the default
+# mintelf is guaranteed; nothing needs pinning in this defconfig.
+
+# The whole point of this defconfig: leave the AES/EmuDesk out, so EmuTOS
+# boots straight into EmuCON (aes/Kconfig) instead of the graphical
+# desktop. CONF_WITH_CLI needs no override here: cli/cmdasm.S (m68k) has
+# always hardcoded its basepage offsets rather than pulling them from the
+# AES-only-generated aes/asm_struct_gen.h, so it was never coupled to
+# CONF_WITH_AES the way the ARM cmdasm.S used to be.
+CONF_WITH_AES=n


### PR DESCRIPTION
Fixes #148

## Summary

Two new defconfigs boot straight to EmuCON over the serial console instead of the GEM desktop, for a fast dev-loop smoke test that needs no AVI capture or frame analysis — just text on `-serial stdio`.

- `configs/virt-arm-cli_defconfig`, `configs/virt-m68k-cli_defconfig`: `CONF_WITH_AES=n` variants of the existing `virt-arm_defconfig`/`virt-m68k_defconfig`.
- `cli/arch/arm/cmdasm.S`: fixed a real build coupling bug this surfaced — it pulled basepage offsets from `aes/asm_struct_gen.h`, which the Makefile only generates when `CONF_WITH_AES=y`. Hardcoded the offsets instead, matching how the m68k `cli/cmdasm.S` has always done it.
- Wired up `CONF_SERIAL_CONSOLE` **input** on both machines (see below) — this was investigated per the issue's "check if the virt targets have serial console implemented" and turned out to be a real, separate gap.
- `.claude/skills/ptos-smoketest/SKILL.md`: documents the new targets, pass signal, and the input-verification caveat below.

## Serial console input

Output-only was already implemented on both machines. Input wasn't: `push_ascii_ikbdiorec()` (feeds a typed character into the emulated IKBD queue EmuCON/AES read from) was only ever called from ColdFire's dedicated RX interrupt handler — virt-arm's PL011 and virt-m68k's Goldfish TTY had no equivalent.

Rather than a dedicated RX interrupt (GICv2 SPI wiring for the PL011, or an unclaimed Goldfish PIC instance/bit for the TTY — neither has any existing tested precedent in this fork), both now **poll** their UART/TTY from the already-proven-reliable 200 Hz periodic tick (`virt_uart0_poll_rx()` from `virt_timer_tick()`; `goldfish_tty_poll_rx()` from `goldfish_rtc_service()`). At most 5 ms of latency, imperceptible for interactive typing, and it reuses read primitives that already existed for other purposes.

Also fixed an independent, real bug found along the way: virt-arm's PL011 init never set `LCRH.FEN`, so the UART never actually ran in FIFO mode despite the code comment claiming it did.

**Verification status, and why it's incomplete:**
- virt-arm: built and boot-tested end to end (`A:>` EmuCON prompt reached over `-serial stdio`, no `guest_errors`/`unimp`).
- Automated keystroke delivery could **not** be confirmed in this sandbox. `strace -f -e trace=read,poll,ppoll` on a spawned `qemu-system-arm -M virt ... -serial stdio` process showed `ppoll()` repeatedly reporting stdin as `POLLIN`-ready, but QEMU never issued the matching `read(0, ...)` before the fd hit `POLLHUP` and was dropped. TX and QEMU's own monitor chardev both worked correctly in the same session, so this looks like a QEMU/host-pty interaction gap specific to that container's guest-UART chardev path, not a driver defect — but I can't rule out a driver bug with certainty from here.
- virt-m68k's `goldfish_tty.c`/`goldfish_rtc.c` changes were syntax-checked with `m68k-linux-gnu-gcc` only (no build/boot test possible: no `m68k-atari-mintelf-*`/`m68k-atari-mint-*` toolchain reachable in this environment, and the project's toolchain PPAs are blocked by this sandbox's network policy).

**Ask:** please re-verify interactive input on both `virt-arm-cli` and `virt-m68k-cli` from a real terminal or CI before relying on it. If it turns out broken there too, the polling design (not just the specific register/offset details) is the first thing I'd revisit.

## Testing done

- `make virt-arm-cli_defconfig && make`: clean build, no new warnings.
- QEMU boot: `Welcome to EmuCON2 version ...` / `A:>` reached over `-serial stdio`, no `guest_errors`/`unimp`.
- `configs/virt-m68k-cli_defconfig`: config generation round-trips correctly through `make virt-m68k-cli_defconfig` (verified `CONF_WITH_AES=0`, `CONF_WITH_CLI=1`, `CONF_WITH_GOLDFISH_TTY=1` in the generated `obj/autoconf.h`); not build-tested (see above).
- `tools/check-gitready.sh`: passes.
- `m68k-linux-gnu-gcc -fsyntax-only`: clean on the modified m68k files (not the project's actual toolchain, but catches syntax/type errors).

## Out of scope

- Any change to the existing `virt-arm_defconfig`/`virt-m68k_defconfig` desktop-boot targets.
- A "real" RX-interrupt implementation for either machine, if the polling approach turns out to need replacing.
