### PR TITLE
Add pluggable filesystem layer for GEMDOS drives

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -28,6 +28,7 @@ menu "Kernel features"
 
 source "bios/Kconfig"
 source "bdos/Kconfig"
+source "fs/Kconfig"
 source "vdi/Kconfig"
 source "aes/Kconfig"
 source "desk/Kconfig"

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ optional-dirs-y = vdi
 optional-dirs-$(CONF_WITH_AES) += aes desk
 optional-dirs-$(CONF_WITH_CLI) += cli
 optional-dirs-$(CONF_WITH_USB) += usb
+optional-dirs-$(CONF_WITH_PLUGGABLE_FS) += fs
 
 core_dirs = $(core-dirs-y)
 optional_dirs = $(optional-dirs-y)
@@ -218,12 +219,23 @@ CPPFLAGS = $(CFLAGS)
 
 # Per-directory extra options; $(bios_copts) applies to bios/, and so on.
 # The USB code is conceptually part of the BIOS and needs access to the
-# BIOS private headers.
-usb_copts = $(addprefix -Ibios/,$(arch_subdirs)) -Ibios
+# BIOS private headers.  It also pulls in bdos/fs.h (via usb_global.h),
+# which needs -Ifs below when CONF_WITH_PLUGGABLE_FS is set.
+usb_copts = $(addprefix -Ibios/,$(arch_subdirs)) -Ibios -Ifs
 
 # virtio_blk.c (bios/) needs the shared virtio-mmio transport header from
 # util/.
 bios_copts = -Iutil
+
+# bdosmain.c's osif() dispatch hook needs the pluggable filesystem layer's
+# public API from fs/, when CONF_WITH_PLUGGABLE_FS is set - as does every
+# other bdos/ file that includes fs.h, since FTAB now embeds a PFSCOOKIE
+# by value when that option is on.
+bdos_copts = -Ifs
+
+# fatfs_pfs.c (fs/) wraps the built-in FAT filesystem, so it needs bdos/'s
+# private headers.
+fs_copts = -Ibdos
 
 CFILE_FLAGS = $(strip $(CFLAGS) $($(current_dir)_copts))
 SFILE_FLAGS = $(strip $(CFLAGS) $($(current_dir)_sopts))

--- a/bdos/bdosmain.c
+++ b/bdos/bdosmain.c
@@ -33,6 +33,9 @@
 #include "string.h"
 #include "kprint.h"
 #include "dos.h"
+#if CONF_WITH_PLUGGABLE_FS
+#include "pfs.h"
+#endif
 
 /*
 **  externals
@@ -487,6 +490,43 @@ restrt:
         return rc;
     }
 
+    /*
+     * for Fopen(), Fcreate() we check for special names.  This must run
+     * before any path/drive dispatch (pluggable or not, below) since
+     * these aren't real drive paths.
+     */
+    rc = 0;
+    if ((fn == GEMDOS_FOPEN) || (fn == GEMDOS_FCREATE)) /* open, create */
+    {
+        const SPECNAME *entry;
+        p = *((char **) &pw[1]);
+        for (i = 0, entry = specname_table; i < SN_ENTRIES; i++, entry++)
+        {
+            if (strcmp(p,entry->name) == 0)
+            {
+                rc = entry->handle;
+                break;
+            }
+        }
+    }
+
+#if CONF_WITH_PLUGGABLE_FS
+    /*
+     * route GEMDOS path-based filesystem calls through the pluggable
+     * filesystem layer instead of dispatching them via funcs[] below -
+     * this includes drives backed by the built-in FAT code, wrapped as
+     * fat_pfs_ops (fs/fatfs_pfs.c), so funcs[]'s entries for these
+     * calls are unreachable whenever this option is on.  Fread/
+     * Fwrite/Fclose are deliberately NOT routed here: they stay on the
+     * normal dispatch path below, and xread()/xwrite()/xclose()
+     * themselves are pluggable-aware instead (fsio.c/fsopnclo.c) - that
+     * covers every caller of those three, not just osif(), such as the
+     * process-termination handle cleanup in proc.c.
+     */
+    if (!rc && pfs_is_fs_call(fn))
+        return pfs_dispatch(fn, pw);
+#endif
+
     f = &funcs[fn];
     typ = f->stdio_typ;
 
@@ -570,12 +610,24 @@ restrt:
             h = pw[1];
 
         if (h >= NUMSTD)
+        {
             numl = (long) sft[h-NUMSTD].f_ofd;
+#if CONF_WITH_PLUGGABLE_FS
+            if (!numl)
+                numl = (long) sft[h-NUMSTD].f_pfs.fs;
+#endif
+        }
         else if (h >= 0)
         {
             h = run->p_uft[h];
             if (h > 0)
+            {
                 numl = (long) sft[h-NUMSTD].f_ofd;
+#if CONF_WITH_PLUGGABLE_FS
+                if (!numl)
+                    numl = (long) sft[h-NUMSTD].f_pfs.fs;
+#endif
+            }
             else
                 numl = h;
         }
@@ -637,24 +689,6 @@ restrt:
         }
     }
 
-
-    /*
-     * for Fopen(), Fcreate() we check for special names
-     */
-    rc = 0;
-    if ((fn == GEMDOS_FOPEN) || (fn == GEMDOS_FCREATE)) /* open, create */
-    {
-        const SPECNAME *entry;
-        p = *((char **) &pw[1]);
-        for (i = 0, entry = specname_table; i < SN_ENTRIES; i++, entry++)
-        {
-            if (strcmp(p,entry->name) == 0)
-            {
-                rc = entry->handle;
-                break;
-            }
-        }
-    }
 
     if (!rc)
     {

--- a/bdos/bdosmain.c
+++ b/bdos/bdosmain.c
@@ -490,43 +490,6 @@ restrt:
         return rc;
     }
 
-    /*
-     * for Fopen(), Fcreate() we check for special names.  This must run
-     * before any path/drive dispatch (pluggable or not, below) since
-     * these aren't real drive paths.
-     */
-    rc = 0;
-    if ((fn == GEMDOS_FOPEN) || (fn == GEMDOS_FCREATE)) /* open, create */
-    {
-        const SPECNAME *entry;
-        p = *((char **) &pw[1]);
-        for (i = 0, entry = specname_table; i < SN_ENTRIES; i++, entry++)
-        {
-            if (strcmp(p,entry->name) == 0)
-            {
-                rc = entry->handle;
-                break;
-            }
-        }
-    }
-
-#if CONF_WITH_PLUGGABLE_FS
-    /*
-     * route GEMDOS path-based filesystem calls through the pluggable
-     * filesystem layer instead of dispatching them via funcs[] below -
-     * this includes drives backed by the built-in FAT code, wrapped as
-     * fat_pfs_ops (fs/fatfs_pfs.c), so funcs[]'s entries for these
-     * calls are unreachable whenever this option is on.  Fread/
-     * Fwrite/Fclose are deliberately NOT routed here: they stay on the
-     * normal dispatch path below, and xread()/xwrite()/xclose()
-     * themselves are pluggable-aware instead (fsio.c/fsopnclo.c) - that
-     * covers every caller of those three, not just osif(), such as the
-     * process-termination handle cleanup in proc.c.
-     */
-    if (!rc && pfs_is_fs_call(fn))
-        return pfs_dispatch(fn, pw);
-#endif
-
     f = &funcs[fn];
     typ = f->stdio_typ;
 
@@ -689,6 +652,44 @@ restrt:
         }
     }
 
+
+    /*
+     * for Fopen(), Fcreate() we check for special names
+     */
+    rc = 0;
+    if ((fn == GEMDOS_FOPEN) || (fn == GEMDOS_FCREATE)) /* open, create */
+    {
+        const SPECNAME *entry;
+        p = *((char **) &pw[1]);
+        for (i = 0, entry = specname_table; i < SN_ENTRIES; i++, entry++)
+        {
+            if (strcmp(p,entry->name) == 0)
+            {
+                rc = entry->handle;
+                break;
+            }
+        }
+    }
+
+#if CONF_WITH_PLUGGABLE_FS
+    /*
+     * route GEMDOS path-based filesystem calls through the pluggable
+     * filesystem layer instead of dispatching them via funcs[] below -
+     * this includes drives backed by the built-in FAT code, wrapped as
+     * fat_pfs_ops (fs/fatfs_pfs.c), so funcs[]'s entries for these
+     * calls are unreachable whenever this option is on.  Fread/
+     * Fwrite/Fclose are deliberately NOT routed here: they stay on the
+     * normal dispatch path above (typ&0x80 doesn't apply to any of the
+     * calls pfs_is_fs_call() recognises, so this doesn't need to run
+     * any earlier than this, its original upstream position), and
+     * xread()/xwrite()/xclose() themselves are made pluggable-aware
+     * instead (fsio.c/fsopnclo.c) - that covers every caller of those
+     * three, not just osif(), such as the process-termination handle
+     * cleanup in proc.c.
+     */
+    if (!rc && pfs_is_fs_call(fn))
+        return pfs_dispatch(fn, pw);
+#endif
 
     if (!rc)
     {

--- a/bdos/fs.h
+++ b/bdos/fs.h
@@ -23,6 +23,10 @@
 
 #include "biosdefs.h"
 #include "pd.h"
+
+#if CONF_WITH_PLUGGABLE_FS
+#include "pfs.h"        /* PFSCOOKIE is embedded by value in FTAB below */
+#endif
 #ifdef MACHINE_RPI
 #   define OPT_PACKED  __attribute__((packed))
 #else
@@ -322,6 +326,13 @@ typedef struct
     OFD *f_ofd;
     PD  *f_own;         /* file owners */
     int f_use;          /* use count */
+#if CONF_WITH_PLUGGABLE_FS
+    PFSCOOKIE f_pfs;    /* f_pfs.fs != NULL marks a handle owned by a
+                         * pluggable filesystem driver with no legacy OFD
+                         * of its own; see fs/pfs.c.  Embedded by value,
+                         * not a pointer, so there is nothing to allocate
+                         * or free alongside the slot itself. */
+#endif
 } FTAB;
 
 
@@ -487,6 +498,9 @@ void xsetdta(DTAINFO *addr);
 long xsetdrv(int drv);
 long xgetdrv(void);
 OFD  *getofd(int h);
+#if CONF_WITH_PLUGGABLE_FS
+FTAB *getpfsslot(int h);
+#endif
 
 
 /*

--- a/bdos/fs_internal.h
+++ b/bdos/fs_internal.h
@@ -1,0 +1,44 @@
+/*
+ * fs_internal.h - FAT internals exposed for fs/fatfs_pfs.c
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ *
+ * Everything declared here was 'static' in bdos/fsdir.c until the
+ * pluggable filesystem layer (fs/fatfs_pfs.c) needed to call it directly.
+ * Not part of bdos/fs.h's regular public API - only fatfs_pfs.c should
+ * include this.
+ */
+
+#ifndef FS_INTERNAL_H
+#define FS_INTERNAL_H
+
+#include "fs.h"
+
+/* Build the path from the root down to (and including) 'p' into 'buf',
+ * as a sequence of "NAME\" components (no drive letter, no leading
+ * backslash of its own - the recursion for the root DND, which has no
+ * parent, emits exactly one separator).  '*len' is the remaining budget
+ * in 'buf' and is decremented as bytes are written.  Returns the
+ * position just past the last byte written; the caller is responsible
+ * for null-terminating (see xgetdir() for the pattern this follows).
+ */
+char *dopath(DND *p, char *buf, int *len);
+
+/* One directory-search step, given caller-owned search state 'dt'
+ * (as primed by the already-extern ixsfirst()).  Returns a pointer to
+ * the matching FCB still inside the live directory-buffer cache (not a
+ * copy - the same convention ixsfirst()/scan() use), or NULL at
+ * end-of-directory.  Updates *dt in place to resume from the next call.
+ */
+FCB *ixsnext(DTAINFO *dt);
+
+/* Copy the found entry's attribute/time/date/length/name from FCB 'f'
+ * into the public fields of DTA info area 'dt' - the same conversion
+ * xsnext() itself applies after a successful ixsnext(), needed here
+ * because fatfs_pfs.c's readdir() drives ixsfirst()/ixsnext() with its
+ * own private DTAINFO buffers rather than the caller's DTA.
+ */
+void makbuf(FCB *f, DTAINFO *dt);
+
+#endif /* FS_INTERNAL_H */

--- a/bdos/fsdir.c
+++ b/bdos/fsdir.c
@@ -141,16 +141,17 @@
 static int namlen(char *s11);
 static char *packit(char *s, char *d);
 static void unpackit(const char *src, char *dst);
-static char *dopath(DND *p, char *buf, int *len);
+char *dopath(DND *p, char *buf, int *len);     /* exposed via fs_internal.h for fs/fatfs_pfs.c */
 static DND *makdnd(DND *p, FCB *b);
 static DND *dcrack(const char **np);
 static int getpath(const char *p, char *d, int dirspec);
 static BOOL match(char *s1, char *s2);
-static void makbuf(FCB *f, DTAINFO *dt);
+void makbuf(FCB *f, DTAINFO *dt);      /* exposed via fs_internal.h for fs/fatfs_pfs.c */
 static DND *getdnd(char *n, DND *d);
 static void snipdnd(DND *dnd);
 static void freednd(DND *dn);
 static BOOL is_subdir(const char *s1,DND *dn1, DND *dn2);
+FCB *ixsnext(DTAINFO *dt);     /* exposed via fs_internal.h for fs/fatfs_pfs.c */
 
 /*
  *  local macros
@@ -532,7 +533,7 @@ long xsfirst(char *name, int att)
 /*
  * ixsnest
  */
-static FCB *ixsnext(DTAINFO *dt)
+FCB *ixsnext(DTAINFO *dt)
 {
     char name[12];
     char *buf, *bufend;
@@ -1353,7 +1354,7 @@ static void unpackit(const char *src, char *dst)
  *
  *      M01.01.1024.02
  */
-static char *dopath(DND *p, char *buf, int *len)
+char *dopath(DND *p, char *buf, int *len)
 {
     char temp[LEN_ZFNAME];
     char *tp;
@@ -1830,7 +1831,7 @@ static BOOL match(char *s1, char *s2)
 /*                              M01.01.0527.02
  *  makbuf - copy info from FCB into DTA info area
  */
-static void makbuf(FCB *f, DTAINFO *dt)
+void makbuf(FCB *f, DTAINFO *dt)
 {                                       /*  M01.01.03   */
     dt->dt_fattr = f->f_attrib;
     dt->dt_td.time = le2cpu16(f->f_td.time);

--- a/bdos/fshand.c
+++ b/bdos/fshand.c
@@ -114,7 +114,12 @@ long xdup(int h)
      * in the OFD pointer variable
      */
     if ((h = run->p_uft[h]) > 0)
+    {
         sft[i].f_ofd = sft[h-NUMSTD].f_ofd;
+#if CONF_WITH_PLUGGABLE_FS
+        sft[i].f_pfs = sft[h-NUMSTD].f_pfs;    /* carry a foreign driver's cookie too */
+#endif
+    }
     else
         sft[i].f_ofd = (OFD *)(long)h;
 

--- a/bdos/fshand.c
+++ b/bdos/fshand.c
@@ -94,9 +94,31 @@ long ixforce(int std, int h, PD *p)
 long xdup(int h)
 {
     int i;
+    long fh;
 
     if ((h < 0) || (h >= NUMSTD))
         return EIHNDL;          /* only dup standard */
+
+    fh = run->p_uft[h];
+
+#if CONF_WITH_PLUGGABLE_FS
+    /*
+     * A foreign driver's cookie has no shared/refcounted lifetime today
+     * - xclose() calls a driver's close()/release() once per sft[] slot,
+     * gated only on that slot's own f_use (bdos/fsopnclo.c).  Copying
+     * the cookie into a second, independently-tracked slot would let
+     * each slot's f_use reach zero on its own and double-release the
+     * same driver-side resource, as well as give the two handles
+     * independent PFSCOOKIE.pos values instead of a shared file
+     * position.  Refuse the dup rather than corrupt driver state; FAT
+     * handles are unaffected (they're never tagged f_pfs, see
+     * native_handles in fs/pfs.h), so this only blocks foreign drivers,
+     * none of which are in this tree yet - lift it once pluggable
+     * handles get a real shared/refcounted cookie.
+     */
+    if ((fh > 0) && sft[fh-NUMSTD].f_pfs.fs)
+        return EIHNDL;
+#endif
 
     for (i = 0; i < OPNFILES; i++)      /* find the first free handle */
         if (!sft[i].f_own)
@@ -113,31 +135,17 @@ long xdup(int h)
      * entry to the new entry; otherwise, store the BIOS handle
      * in the OFD pointer variable
      */
-    if ((h = run->p_uft[h]) > 0)
+    if (fh > 0)
     {
-        sft[i].f_ofd = sft[h-NUMSTD].f_ofd;
-#if CONF_WITH_PLUGGABLE_FS
-        /*
-         * carry a foreign driver's cookie too - a plain struct copy,
-         * which means the two handles get independent PFSCOOKIE.pos
-         * values instead of sharing a file position the way dup'd FAT
-         * handles do via their shared OFD.  No driver in this tree
-         * relies on shared-position dup semantics yet (FAT handles
-         * bypass this path entirely via native_handles, see fs/pfs.h),
-         * but a future driver that needs real Fdup() parity would need
-         * an indirection here (e.g. a shared, refcounted position)
-         * rather than this value copy.
-         */
-        sft[i].f_pfs = sft[h-NUMSTD].f_pfs;
-#endif
+        sft[i].f_ofd = sft[fh-NUMSTD].f_ofd;
     }
     else
     {
-        sft[i].f_ofd = (OFD *)(long)h;
-#if CONF_WITH_PLUGGABLE_FS
-        sft[i].f_pfs.fs = 0;   /* establish "not pluggable" for this fresh slot */
-#endif
+        sft[i].f_ofd = (OFD *)fh;
     }
+#if CONF_WITH_PLUGGABLE_FS
+    sft[i].f_pfs.fs = 0;   /* pluggable handles are rejected above */
+#endif
 
     sft[i].f_use = 1;
 

--- a/bdos/fshand.c
+++ b/bdos/fshand.c
@@ -117,11 +117,27 @@ long xdup(int h)
     {
         sft[i].f_ofd = sft[h-NUMSTD].f_ofd;
 #if CONF_WITH_PLUGGABLE_FS
-        sft[i].f_pfs = sft[h-NUMSTD].f_pfs;    /* carry a foreign driver's cookie too */
+        /*
+         * carry a foreign driver's cookie too - a plain struct copy,
+         * which means the two handles get independent PFSCOOKIE.pos
+         * values instead of sharing a file position the way dup'd FAT
+         * handles do via their shared OFD.  No driver in this tree
+         * relies on shared-position dup semantics yet (FAT handles
+         * bypass this path entirely via native_handles, see fs/pfs.h),
+         * but a future driver that needs real Fdup() parity would need
+         * an indirection here (e.g. a shared, refcounted position)
+         * rather than this value copy.
+         */
+        sft[i].f_pfs = sft[h-NUMSTD].f_pfs;
 #endif
     }
     else
+    {
         sft[i].f_ofd = (OFD *)(long)h;
+#if CONF_WITH_PLUGGABLE_FS
+        sft[i].f_pfs.fs = 0;   /* establish "not pluggable" for this fresh slot */
+#endif
+    }
 
     sft[i].f_use = 1;
 

--- a/bdos/fsio.c
+++ b/bdos/fsio.c
@@ -17,6 +17,9 @@
 #include "biosbind.h"
 #include "string.h"
 #include "kprint.h"
+#if CONF_WITH_PLUGGABLE_FS
+#include "pfs.h"
+#endif
 
 
 /*
@@ -185,6 +188,14 @@ long    xread(int h, long len, void *ubufr)
     OFD *p;
     long ret;
 
+#if CONF_WITH_PLUGGABLE_FS
+    {
+        FTAB *slot = getpfsslot(h);
+        if (slot)
+            return pfs_handle_read(&slot->f_pfs, len, ubufr);
+    }
+#endif
+
     p = getofd(h);
     if ( p )
         ret = ixread(p,len,ubufr);
@@ -234,6 +245,14 @@ long    xwrite(int h, long len, void *ubufr)
 {
     OFD *p;
     long ret;
+
+#if CONF_WITH_PLUGGABLE_FS
+    {
+        FTAB *slot = getpfsslot(h);
+        if (slot)
+            return pfs_handle_write(&slot->f_pfs, len, ubufr);
+    }
+#endif
 
     p = getofd(h);
 

--- a/bdos/fsmain.c
+++ b/bdos/fsmain.c
@@ -485,3 +485,32 @@ OFD *getofd(int h)
 
     return sft[n].f_ofd;
 }
+
+
+#if CONF_WITH_PLUGGABLE_FS
+/*
+ *  getpfsslot - returns ptr to the sft[] entry for a handle owned by a
+ *  pluggable filesystem driver (see fs/pfs.c), or NULL if 'h' is not a
+ *  valid handle or does not belong to one.
+ *
+ *  Mirrors getofd() (above), including std-handle indirection via the
+ *  same syshnd(), so every caller of xread()/xwrite()/xclose() - not
+ *  just osif() - reaches a pluggable handle correctly.
+ */
+FTAB *getpfsslot(int h)
+{
+    WORD n;
+
+    if ((h < 0) | (h >= NUMHANDLES))
+        return NULL;
+
+    n = syshnd(h);
+    if (n < 0)
+        return NULL;
+
+    if (!sft[n].f_pfs.fs)
+        return NULL;
+
+    return &sft[n];
+}
+#endif

--- a/bdos/fsmain.c
+++ b/bdos/fsmain.c
@@ -501,7 +501,7 @@ FTAB *getpfsslot(int h)
 {
     WORD n;
 
-    if ((h < 0) | (h >= NUMHANDLES))
+    if ((h < 0) || (h >= NUMHANDLES))
         return NULL;
 
     n = syshnd(h);

--- a/bdos/fsmain.c
+++ b/bdos/fsmain.c
@@ -476,7 +476,7 @@ OFD *getofd(int h)
 {
     WORD n;
 
-    if ((h < 0) | (h >= NUMHANDLES))
+    if ((h < 0) || (h >= NUMHANDLES))
         return NULL;
 
     n = syshnd(h);

--- a/bdos/fsopnclo.c
+++ b/bdos/fsopnclo.c
@@ -56,6 +56,9 @@
 #include "time.h"
 #include "console.h"
 #include "kprint.h"
+#if CONF_WITH_PLUGGABLE_FS
+#include "pfs.h"
+#endif
 
 /* the following characters are disallowed in the name when creating
  * or renaming files or folders.  this is *mostly* the same list as
@@ -446,6 +449,27 @@ long xclose(int h)
 
         return E_OK;
     }
+
+#if CONF_WITH_PLUGGABLE_FS
+    /*
+     * 'h' is a real sft[] handle at this point (either unchanged, or the
+     * handle a std-handle redirection was pointing at, above) - if it
+     * belongs to a pluggable driver, close it there instead of treating
+     * f_ofd as an OFD*.
+     */
+    if (sft[h-NUMSTD].f_pfs.fs)
+    {
+        rc = pfs_handle_close(&sft[h-NUMSTD].f_pfs);
+
+        if (!(--sft[h-NUMSTD].f_use))
+        {
+            sft[h-NUMSTD].f_pfs.fs = 0;
+            sft[h-NUMSTD].f_own = 0;
+        }
+
+        return rc;
+    }
+#endif
 
     if (!(fd = getofd(h)))
         return EIHNDL;

--- a/bdos/fsopnclo.c
+++ b/bdos/fsopnclo.c
@@ -470,10 +470,23 @@ long xclose(int h)
      */
     if (sft[h-NUMSTD].f_pfs.fs)
     {
+        struct pfs_ops *pfs = sft[h-NUMSTD].f_pfs.fs;
+
+        /*
+         * close() runs on every xclose() of this slot, same as ixclose()
+         * does for the legacy OFD path below; release() only runs once
+         * the last sft[] reference to this cookie is gone (mirrors
+         * sftdel() being called only when f_use reaches zero), so a
+         * duplicated handle (Fforce()-shared slot, or an xdup()-copied
+         * one) doesn't have its driver resources torn down while a
+         * sibling handle still expects them to be live.
+         */
         rc = pfs_handle_close(&sft[h-NUMSTD].f_pfs);
 
         if (!(--sft[h-NUMSTD].f_use))
         {
+            if (pfs->release)
+                pfs->release(&sft[h-NUMSTD].f_pfs);
             sft[h-NUMSTD].f_pfs.fs = 0;
             sft[h-NUMSTD].f_own = 0;
         }

--- a/bdos/fsopnclo.c
+++ b/bdos/fsopnclo.c
@@ -383,6 +383,17 @@ static void sftdel(FTAB *sftp)
     s->f_ofd = 0;
     s->f_own = 0;
     s->f_use = 0;
+#if CONF_WITH_PLUGGABLE_FS
+    /*
+     * this slot is only ever a legacy (non-pluggable) handle by the
+     * time sftdel() runs on it - see the CONF_WITH_PLUGGABLE_FS branch
+     * near the top of xclose() - but establish the invariant "free slot
+     * implies f_pfs.fs == NULL" here regardless, so opnfil()/makopn()
+     * (which know nothing about f_pfs) can never hand out a slot with a
+     * stale non-NULL f_pfs.fs left over from an earlier pluggable use.
+     */
+    s->f_pfs.fs = 0;
+#endif
 
     /*
      * if there are no other sft entries with same OFD, delete the OFD

--- a/bdos/proc.c
+++ b/bdos/proc.c
@@ -27,6 +27,9 @@
 #include "biosext.h"
 #include "asm.h"
 #include "../bios/tosvars.h"
+#if CONF_WITH_PLUGGABLE_FS
+#include "pfs.h"
+#endif
 
 
 /*
@@ -146,6 +149,20 @@ static void ixterm(PD *r)
         if ((h = r->p_curdir[i]) != 0)
             decr_curdir_usage(h);
     }
+
+#if CONF_WITH_PLUGGABLE_FS
+    /*
+     * p_curdir[] above indexes fs/pfs.c's own directory table instead of
+     * dirtbl[] for a pluggable drive - decr_curdir_usage() is harmless
+     * either way (it no-ops below NCURDIR's dirtbl[] range and dirtbl[]
+     * stays empty for the lifetime of a pluggable-fs build, since
+     * nothing calls incr_curdir_usage() once this option is on), but the
+     * pluggable table still needs its own matching cleanup so its slots
+     * (and any open Fsfirst/Fsnext searches this process owned) don't
+     * leak.
+     */
+    pfs_proc_exit(r);
+#endif
 
     /* free each item in the allocated list that is owned by 'r' */
 

--- a/bdos/proc.c
+++ b/bdos/proc.c
@@ -441,6 +441,14 @@ static void init_pd_files(PD *p)
         p->p_curdir[i] = dn;
         if (dn)
             dirtbl[dn].use++;
+#if CONF_WITH_PLUGGABLE_FS
+        /* p_curdir[] indexes fs/pfs.c's own table instead when this
+         * option is on (see the comment above PFS_MAX_CWD in fs/pfs.c);
+         * the dirtbl[] bump above is harmless but meaningless in that
+         * case, so also bump the table actually in use. */
+        if (dn)
+            pfs_cwd_addref((WORD)dn);
+#endif
     }
 
     /* and current drive */

--- a/bios/bios.c
+++ b/bios/bios.c
@@ -119,6 +119,10 @@ extern void usb_init(void); /* found in usb.h */
 extern void virtio_input_init(void); /* found in virtio_input.h */
 #endif
 
+#if CONF_WITH_PLUGGABLE_FS_TEST
+extern void pfs_test_init(void); /* found in fs/pfs_test.c */
+#endif
+
 /*==== Declarations =======================================================*/
 
 /* Drive specific declarations */
@@ -490,6 +494,13 @@ static void bios_init(void)
     KDEBUG(("blkdev_init()\n"));
     blkdev_init();      /* floppy and harddisk initialisation */
     KDEBUG(("after blkdev_init()\n"));
+
+#if CONF_WITH_PLUGGABLE_FS_TEST
+    /* after blkdev_init(), which resets drvbits - see fs/pfs_test.c */
+    KDEBUG(("pfs_test_init()\n"));
+    pfs_test_init();
+    KDEBUG(("after pfs_test_init()\n"));
+#endif
 
     /* initialize BIOS components */
 

--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -1,0 +1,54 @@
+#
+# fs/Kconfig - pluggable filesystem layer options
+#
+# This file is distributed under the GPL, version 2 or at your
+# option any later version.  See doc/license.txt for details.
+#
+
+menu "Pluggable filesystems"
+
+config CONF_WITH_PLUGGABLE_FS
+	bool "Pluggable filesystem driver support"
+	default n
+	help
+	  Routes GEMDOS filesystem calls (Fopen, Fread, Dsetpath, Fsfirst,
+	  ...) through a common pluggable interface, instead of calling the
+	  built-in FAT code directly.  The built-in FAT filesystem itself is
+	  wrapped as an instance of this interface, so it keeps working
+	  exactly as before; the point is to let a driver expose a whole
+	  filesystem (not just a block device) as a GEMDOS drive, which the
+	  built-in FAT code and block device layer alone cannot do.
+
+	  This has no visible effect by itself beyond the built-in FAT
+	  wrapper; it exists so a driver (e.g. a virtio-9p host directory
+	  bridge) can register against it.
+
+	  Say n unless a driver needs this.  Off by default: when off,
+	  GEMDOS calls the built-in FAT code directly, exactly as when this
+	  option does not exist, at zero extra size/RAM cost.  Only turn
+	  this on for machines with room to spare.
+
+config CONF_WITH_PLUGGABLE_FS_TEST
+	bool "Pluggable filesystem self-test driver"
+	depends on CONF_WITH_PLUGGABLE_FS
+	default n
+	help
+	  Registers a tiny built-in in-memory filesystem driver exposing a
+	  single fixed drive letter with one read-only file, purely to
+	  exercise the pluggable filesystem layer end-to-end without needing
+	  a real driver.  Development/test scaffolding only; say n unless
+	  you are testing the pluggable filesystem layer itself.
+
+config CONF_PFS_MAX_SEARCHES
+	int "Maximum concurrent pluggable Fsfirst/Fsnext searches"
+	depends on CONF_WITH_PLUGGABLE_FS
+	default 8
+	range 1 40
+	help
+	  Number of concurrent Fsfirst/Fsnext directory searches the
+	  pluggable filesystem layer can track at once, across all
+	  pluggable drives and processes.  Each slot costs a handful of
+	  bytes; raise this only if an application legitimately keeps many
+	  directory searches open at the same time.
+
+endmenu

--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -51,4 +51,19 @@ config CONF_PFS_MAX_SEARCHES
 	  bytes; raise this only if an application legitimately keeps many
 	  directory searches open at the same time.
 
+config CONF_PFS_MAX_CWD
+	int "Maximum cached pluggable current directories"
+	depends on CONF_WITH_PLUGGABLE_FS
+	default 40
+	range 1 40
+	help
+	  Number of distinct non-root current-directory cookies (across all
+	  drives and processes) the pluggable filesystem layer can cache at
+	  once - the pluggable-fs equivalent of the legacy dirtbl[]'s fixed
+	  NCURDIR (40) capacity. Each slot costs a path buffer plus a
+	  cookie, so lower this for a ROM/RAM-tight build that enables
+	  CONF_WITH_PLUGGABLE_FS but doesn't need the full legacy capacity;
+	  the default matches dirtbl[] so enabling pluggable fs support
+	  doesn't reduce this system limit.
+
 endmenu

--- a/fs/build.mk
+++ b/fs/build.mk
@@ -1,0 +1,11 @@
+#
+# fs/build.mk - objects making up the pluggable filesystem layer
+#
+# This directory is only built at all when CONF_WITH_PLUGGABLE_FS is set
+# (see optional-dirs-$(CONF_WITH_PLUGGABLE_FS) in the top level Makefile),
+# so the files below are unconditional within it.
+#
+
+obj-y += pfs.o fatfs_pfs.o
+
+obj-$(CONF_WITH_PLUGGABLE_FS_TEST) += pfs_test.o

--- a/fs/fatfs_pfs.c
+++ b/fs/fatfs_pfs.c
@@ -226,6 +226,12 @@ static LONG fat_readdir(PFSCOOKIE *dir, LONG *cursor, char *name, int namelen, P
 
         fat_readdir_pool[i].used = TRUE;
         *cursor = i + 1;
+        /* remember which pool slot this cookie's search owns, so
+         * fat_release() can free it if the search is abandoned before
+         * running to end-of-directory (a new Fsfirst() on the same DTA,
+         * or the owning process exiting - see fs/pfs.c's
+         * pfs_search_free()). */
+        dir->aux = i + 1;
 
         fat_readdir_result(name, namelen, outattr, &fat_readdir_pool[i].dta);
         return E_OK;
@@ -241,6 +247,7 @@ static LONG fat_readdir(PFSCOOKIE *dir, LONG *cursor, char *name, int namelen, P
         if (!f)
         {
             fat_readdir_pool[slot].used = FALSE;
+            dir->aux = 0;
             return ENMFIL;
         }
 
@@ -328,6 +335,26 @@ static LONG fat_mediach(struct pfs_ops *fs, WORD drive)
     return Mediach(drive);
 }
 
+/* DND-based directory cookies and sft[]-backed file handles both
+ * outlive a single call already (the DND tree is a cache, and file
+ * handles are freed by close), so there is nothing to release for
+ * those. The one thing that does need releasing is a directory
+ * cookie's attached fat_readdir_pool[] slot, if fat_readdir() gave it
+ * one (cookie->aux != 0) and the search was abandoned before running
+ * to end-of-directory - see fat_readdir()'s comment.
+ */
+static void fat_release(PFSCOOKIE *fc)
+{
+    if (fc->aux > 0)
+    {
+        WORD slot = (WORD)(fc->aux - 1);
+
+        if ((slot >= 0) && (slot < CONF_PFS_MAX_SEARCHES))
+            fat_readdir_pool[slot].used = FALSE;
+        fc->aux = 0;
+    }
+}
+
 struct pfs_ops fat_pfs_ops = {
     fat_root,
     fat_lookup,
@@ -344,9 +371,5 @@ struct pfs_ops fat_pfs_ops = {
     fat_chattr,
     fat_dfree,
     fat_mediach,
-    NULL            /* release: DND-based directory cookies and sft[]-
-                     * backed file handles both outlive a single call
-                     * already (the DND tree is a cache, and file
-                     * handles are freed by close), so there is nothing
-                     * per-cookie to release here. */
+    fat_release
 };

--- a/fs/fatfs_pfs.c
+++ b/fs/fatfs_pfs.c
@@ -45,7 +45,8 @@ static LONG fat_abspath(PFSCOOKIE *dir, const char *tail, char *buf, int buflen)
     *p++ = (char)('A' + dn->d_drv->m_drvnum);
     *p++ = ':';
 
-    len = buflen - 3;      /* -2 for "X:" already written, -1 for the null strlcpy always leaves room for */
+    len = buflen - 3;      /* -2 for "X:" already written, -1 to always
+                             * leave room for strlcpy()'s trailing null */
     end = dopath(dn, p, &len);
     /*
      * dopath() silently stops writing when it runs out of room (its own

--- a/fs/fatfs_pfs.c
+++ b/fs/fatfs_pfs.c
@@ -1,0 +1,352 @@
+/*
+ * fatfs_pfs.c - wraps the built-in FAT filesystem as a pfs_ops instance
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ *
+ * A thin adapter, not a reimplementation: every entry point here
+ * reconstructs an absolute path string (drive letter + dopath()'s walk
+ * up from a directory cookie's DND) and calls the existing, unmodified
+ * GEMDOS-level FAT functions (findit(), xopen(), ixcreat(), xmkdir(),
+ * ...) - never relying on a process's ambient current-directory state,
+ * since fs/pfs.c tracks that itself (see pfs.c's "current-directory
+ * tracking" section).  Only dopath(), ixsnext() and makbuf() needed
+ * exposing beyond bdos/fs.h's already-public FAT API; see
+ * bdos/fs_internal.h.
+ */
+
+#include "config.h"
+#include "portab.h"
+#include "pfs.h"
+#include "fs.h"
+#include "fs_internal.h"
+#include "gemerror.h"
+#include "biosbind.h"
+#include "string.h"
+#include "kprint.h"
+
+#define FAT_ALL_ATTR (FA_RO | FA_HIDDEN | FA_SYSTEM | FA_VOL | FA_SUBDIR | FA_ARCHIVE)
+
+/* Build an absolute path "X:\...\name" into 'buf' (size 'buflen'), where
+ * the "\...\" portion comes from walking 'dir's DND up to the root via
+ * dopath(), and the drive letter from that DND's own DMD - never from
+ * ambient process state.
+ */
+static LONG fat_abspath(PFSCOOKIE *dir, const char *tail, char *buf, int buflen)
+{
+    DND *dn = (DND *)dir->index;
+    char *p = buf;
+    int len;
+
+    if (buflen < 4)
+        return ERANGE;
+
+    *p++ = (char)('A' + dn->d_drv->m_drvnum);
+    *p++ = ':';
+
+    len = buflen - 3;      /* -2 for "X:" already written, -1 for the null strlcpy always leaves room for */
+    p = dopath(dn, p, &len);
+    if (len < 0)
+        len = 0;
+
+    strlcpy(p, tail, (size_t)len + 1);
+
+    return E_OK;
+}
+
+static LONG fat_root(struct pfs_ops *fs, WORD drive, PFSCOOKIE *out)
+{
+    char path[4];
+    const char *sp;
+    DND *dn;
+
+    (void)fs;
+
+    path[0] = (char)('A' + drive);
+    path[1] = ':';
+    path[2] = SLASH;
+    path[3] = 0;
+
+    dn = findit(path, &sp, 1);
+    if ((LONG)dn < 0)
+        return (LONG)dn;
+    if (!dn)
+        return EPTHNF;
+
+    out->fs = &fat_pfs_ops;
+    out->index = (LONG)dn;
+    out->aux = 0;
+    out->pos = 0;
+
+    return E_OK;
+}
+
+static LONG fat_lookup(PFSCOOKIE *dir, const char *path, PFSCOOKIE *out)
+{
+    char abspath[LEN_ZPATH];
+    const char *sp;
+    DND *dn;
+    LONG rc;
+
+    rc = fat_abspath(dir, path, abspath, sizeof(abspath));
+    if (rc < 0)
+        return rc;
+
+    dn = findit(abspath, &sp, 1);
+    if ((LONG)dn < 0)
+        return (LONG)dn;
+    if (!dn)
+        return EPTHNF;
+
+    out->fs = &fat_pfs_ops;
+    out->index = (LONG)dn;
+    out->aux = 0;
+    out->pos = 0;
+
+    return E_OK;
+}
+
+static LONG fat_open(PFSCOOKIE *dir, const char *name, WORD mode, PFSCOOKIE *out)
+{
+    char path[LEN_ZPATH];
+    LONG rc, h;
+
+    rc = fat_abspath(dir, name, path, sizeof(path));
+    if (rc < 0)
+        return rc;
+
+    h = xopen(path, mode);
+    if (h < 0)
+        return h;
+
+    out->fs = &fat_pfs_ops;
+    out->index = h;
+    out->aux = 0;
+    out->pos = 0;
+
+    return E_OK;
+}
+
+static LONG fat_create(PFSCOOKIE *dir, const char *name, UWORD attr, PFSCOOKIE *out)
+{
+    char path[LEN_ZPATH];
+    LONG rc, h;
+
+    rc = fat_abspath(dir, name, path, sizeof(path));
+    if (rc < 0)
+        return rc;
+
+    h = xcreat(path, (char)attr);
+    if (h < 0)
+        return h;
+
+    out->fs = &fat_pfs_ops;
+    out->index = h;
+    out->aux = 0;
+    out->pos = 0;
+
+    return E_OK;
+}
+
+static LONG fat_close(PFSCOOKIE *fc)
+{
+    return xclose((int)fc->index);
+}
+
+static LONG fat_read(PFSCOOKIE *fc, LONG pos, LONG len, UBYTE *buf)
+{
+    OFD *ofd = getofd((int)fc->index);
+
+    if (!ofd)
+        return EIHNDL;
+    if (ixlseek(ofd, pos) != pos)
+        return EREADF;
+
+    return ixread(ofd, len, buf);
+}
+
+static LONG fat_write(PFSCOOKIE *fc, LONG pos, LONG len, const UBYTE *buf)
+{
+    OFD *ofd = getofd((int)fc->index);
+
+    if (!ofd)
+        return EIHNDL;
+    if (ixlseek(ofd, pos) != pos)
+        return EWRITF;
+
+    return ixwrite(ofd, len, (void *)buf);
+}
+
+/* Private pool of DTAINFO search cursors, one per concurrent
+ * fs/pfs.c-driven directory listing on a FAT drive - independent of the
+ * caller's own DTA, since readdir()'s cursor contract is a single LONG,
+ * not a whole DTA buffer.  '*cursor' is (pool index + 1); 0 means
+ * "start a new listing".
+ */
+typedef struct {
+    BOOL used;
+    DTAINFO dta;
+} FAT_READDIR_SLOT;
+
+static FAT_READDIR_SLOT fat_readdir_pool[CONF_PFS_MAX_SEARCHES];
+
+static void fat_readdir_result(char *name, int namelen, PFSATTR *outattr, const DTAINFO *dt)
+{
+    strlcpy(name, dt->dt_fname, namelen);
+    outattr->size = (ULONG)dt->dt_fileln;
+    outattr->dos_attr = (UWORD)(UBYTE)dt->dt_fattr;
+    outattr->date = dt->dt_td.date;
+    outattr->time = dt->dt_td.time;
+}
+
+static LONG fat_readdir(PFSCOOKIE *dir, LONG *cursor, char *name, int namelen, PFSATTR *outattr)
+{
+    WORD slot;
+
+    if (*cursor == 0)
+    {
+        char path[LEN_ZPATH];
+        WORD i;
+        LONG rc;
+
+        for (i = 0; i < CONF_PFS_MAX_SEARCHES; i++)
+            if (!fat_readdir_pool[i].used)
+                break;
+        if (i == CONF_PFS_MAX_SEARCHES)
+            return ENHNDL;
+
+        rc = fat_abspath(dir, "*.*", path, sizeof(path));
+        if (rc < 0)
+            return rc;
+
+        fat_readdir_pool[i].dta.dt_offset_drive = -1;
+        rc = ixsfirst(path, FAT_ALL_ATTR, &fat_readdir_pool[i].dta);
+        if (rc < 0)
+            return rc;
+
+        fat_readdir_pool[i].used = TRUE;
+        *cursor = i + 1;
+
+        fat_readdir_result(name, namelen, outattr, &fat_readdir_pool[i].dta);
+        return E_OK;
+    }
+
+    slot = (WORD)(*cursor - 1);
+    if ((slot < 0) || (slot >= CONF_PFS_MAX_SEARCHES) || !fat_readdir_pool[slot].used)
+        return ENMFIL;
+
+    {
+        FCB *f = ixsnext(&fat_readdir_pool[slot].dta);
+
+        if (!f)
+        {
+            fat_readdir_pool[slot].used = FALSE;
+            return ENMFIL;
+        }
+
+        makbuf(f, &fat_readdir_pool[slot].dta);
+        fat_readdir_result(name, namelen, outattr, &fat_readdir_pool[slot].dta);
+    }
+
+    return E_OK;
+}
+
+static LONG fat_mkdir(PFSCOOKIE *dir, const char *name)
+{
+    char path[LEN_ZPATH];
+    LONG rc = fat_abspath(dir, name, path, sizeof(path));
+
+    if (rc < 0)
+        return rc;
+
+    return xmkdir(path);
+}
+
+static LONG fat_rmdir(PFSCOOKIE *dir, const char *name)
+{
+    char path[LEN_ZPATH];
+    LONG rc = fat_abspath(dir, name, path, sizeof(path));
+
+    if (rc < 0)
+        return rc;
+
+    return xrmdir(path);
+}
+
+static LONG fat_remove(PFSCOOKIE *dir, const char *name)
+{
+    char path[LEN_ZPATH];
+    LONG rc = fat_abspath(dir, name, path, sizeof(path));
+
+    if (rc < 0)
+        return rc;
+
+    return xunlink(path);
+}
+
+static LONG fat_rename(PFSCOOKIE *olddir, const char *oldname,
+                        PFSCOOKIE *newdir, const char *newname)
+{
+    char oldpath[LEN_ZPATH], newpath[LEN_ZPATH];
+    LONG rc;
+
+    rc = fat_abspath(olddir, oldname, oldpath, sizeof(oldpath));
+    if (rc < 0)
+        return rc;
+    rc = fat_abspath(newdir, newname, newpath, sizeof(newpath));
+    if (rc < 0)
+        return rc;
+
+    return xrename(0, oldpath, newpath);
+}
+
+static LONG fat_chattr(PFSCOOKIE *dir, const char *name, BOOL set, UWORD *dos_attr)
+{
+    char path[LEN_ZPATH];
+    LONG rc = fat_abspath(dir, name, path, sizeof(path));
+
+    if (rc < 0)
+        return rc;
+
+    rc = xchmod(path, set ? 1 : 0, (char)*dos_attr);
+    if (rc < 0)
+        return rc;
+
+    *dos_attr = (UWORD)rc;
+    return E_OK;
+}
+
+static LONG fat_dfree(struct pfs_ops *fs, WORD drive, ULONG out[4])
+{
+    (void)fs;
+    return xgetfree((long *)out, drive + 1);
+}
+
+static LONG fat_mediach(struct pfs_ops *fs, WORD drive)
+{
+    (void)fs;
+    return Mediach(drive);
+}
+
+struct pfs_ops fat_pfs_ops = {
+    fat_root,
+    fat_lookup,
+    fat_open,
+    fat_create,
+    fat_close,
+    fat_read,
+    fat_write,
+    fat_readdir,
+    fat_mkdir,
+    fat_rmdir,
+    fat_remove,
+    fat_rename,
+    fat_chattr,
+    fat_dfree,
+    fat_mediach,
+    NULL            /* release: DND-based directory cookies and sft[]-
+                     * backed file handles both outlive a single call
+                     * already (the DND tree is a cache, and file
+                     * handles are freed by close), so there is nothing
+                     * per-cookie to release here. */
+};

--- a/fs/fatfs_pfs.c
+++ b/fs/fatfs_pfs.c
@@ -36,6 +36,7 @@ static LONG fat_abspath(PFSCOOKIE *dir, const char *tail, char *buf, int buflen)
 {
     DND *dn = (DND *)dir->index;
     char *p = buf;
+    char *end;
     int len;
 
     if (buflen < 4)
@@ -45,11 +46,23 @@ static LONG fat_abspath(PFSCOOKIE *dir, const char *tail, char *buf, int buflen)
     *p++ = ':';
 
     len = buflen - 3;      /* -2 for "X:" already written, -1 for the null strlcpy always leaves room for */
-    p = dopath(dn, p, &len);
-    if (len < 0)
-        len = 0;
+    end = dopath(dn, p, &len);
+    /*
+     * dopath() silently stops writing when it runs out of room (its own
+     * comment: "len must never go < 0") rather than reporting truncation
+     * - it always ends a component it *did* finish with SLASH, so 'len'
+     * hitting exactly 0 without the last byte written being SLASH means
+     * it stopped mid-component.  Treat that - and 'tail' not fitting in
+     * whatever room is left - as ERANGE rather than silently operating
+     * on the wrong (truncated) path.
+     */
+    if ((len == 0) && ((end == p) || (end[-1] != SLASH)))
+        return ERANGE;
 
-    strlcpy(p, tail, (size_t)len + 1);
+    if (strlen(tail) > (size_t)len)
+        return ERANGE;
+
+    strlcpy(end, tail, (size_t)len + 1);
 
     return E_OK;
 }

--- a/fs/fatfs_pfs.c
+++ b/fs/fatfs_pfs.c
@@ -371,5 +371,9 @@ struct pfs_ops fat_pfs_ops = {
     fat_chattr,
     fat_dfree,
     fat_mediach,
-    fat_release
+    fat_release,
+    TRUE            /* native_handles: xopen()/ixcreat() already
+                     * allocate a real sft[] slot - see fat_open()/
+                     * fat_create() and pfs_do_open()/pfs_do_create()
+                     * in fs/pfs.c. */
 };

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -643,13 +643,26 @@ static LONG pfs_path_append(char *newpath, size_t cap, const char *tail)
 static LONG pfs_do_chdir(const char *path)
 {
     struct pfs_ops *fs;
-    WORD drive = pfs_path_drive(path, &path);
+    WORD drive;
     PFSCOOKIE dir;
     const char *name;
     PFSCOOKIE target;
     char newpath[LEN_ZPATH];
     BOOL dir_owned;
     LONG rc;
+    const char *t;
+
+    /* matches legacy xchdir()'s contains_wildcard_characters() check
+     * (bdos/fsdir.c) - Dsetpath() is not a search, and a driver's
+     * lookup() has no obligation to treat '*'/'?' as anything but
+     * literal characters, so without this a wildcard path would either
+     * behave inconsistently across drivers or just fail to resolve,
+     * instead of the fixed EPTHNF GEMDOS callers can already rely on. */
+    for (t = path; *t; t++)
+        if ((*t == '*') || (*t == '?'))
+            return EPTHNF;
+
+    drive = pfs_path_drive(path, &path);
 
     fs = pfs_drive_fs(drive);
     if (!fs)

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -266,8 +266,18 @@ static void pfs_dirtbl_release(WORD n)
     }
 }
 
-/* Cookie + absolute path string for 'drive' in the calling process. */
-static LONG pfs_cwd_get(struct pfs_ops *fs, WORD drive, PFSCOOKIE *out, const char **path)
+/* Cookie + absolute path string for 'drive' in the calling process.
+ *
+ * '*owned' tells the caller whether '*out' is a fresh reference it must
+ * release itself (TRUE - the cache missed, so this came straight from
+ * fs->root()) or a copy of the cookie pfs_dirtbl[] still owns (FALSE -
+ * the cache hit).  Releasing a borrowed copy would tear down a resource
+ * the cache still thinks is alive out from under it - harmless for FAT
+ * today (release() no-ops for a plain directory cookie), but a real
+ * hazard for a driver whose release() actually frees something (e.g. a
+ * future 9p driver's fid).
+ */
+static LONG pfs_cwd_get(struct pfs_ops *fs, WORD drive, PFSCOOKIE *out, const char **path, BOOL *owned)
 {
     WORD n = run->p_curdir[drive];
 
@@ -276,6 +286,7 @@ static LONG pfs_cwd_get(struct pfs_ops *fs, WORD drive, PFSCOOKIE *out, const ch
     {
         *out = pfs_dirtbl[n].cwd;
         *path = pfs_dirtbl[n].path;
+        *owned = FALSE;
         return E_OK;
     }
 
@@ -283,6 +294,7 @@ static LONG pfs_cwd_get(struct pfs_ops *fs, WORD drive, PFSCOOKIE *out, const ch
         return EINVFN;
 
     *path = "";
+    *owned = TRUE;
     return fs->root(fs, drive, out);
 }
 
@@ -329,6 +341,9 @@ typedef struct {
     DTA *owner;         /* NULL = free slot */
     PD *proc;
     PFSCOOKIE dir;
+    BOOL dir_owned;      /* does this slot own 'dir' (must release it),
+                          * or is it a borrowed alias of a pfs_dirtbl[]
+                          * entry (must not) - see pfs_cwd_get(). */
     LONG cursor;
     UWORD attr;
     char pattern[LEN_ZFNAME];
@@ -338,7 +353,7 @@ static PFS_SEARCH pfs_searches[CONF_PFS_MAX_SEARCHES];
 
 static void pfs_search_free(PFS_SEARCH *s)
 {
-    if (s->dir.fs && s->dir.fs->release)
+    if (s->dir_owned && s->dir.fs && s->dir.fs->release)
         s->dir.fs->release(&s->dir);
     s->owner = NULL;
     s->proc = NULL;
@@ -377,13 +392,23 @@ static void pfs_attr_to_dta(DTAINFO *dt, const char *name, const PFSATTR *a)
  * drive's root; relative paths resolve from the cached current
  * directory.
  */
+/* Resolve the containing directory of 'path', as above, and report via
+ * '*owned' whether the caller must release '*dircookie' itself (TRUE) or
+ * it's a borrowed alias of a cookie pfs_dirtbl[] still owns (FALSE - only
+ * possible when 'path' is relative and empty, i.e. "." - the resolved
+ * directory is the cached current directory itself, handed back as-is).
+ * Every caller must gate its own fs->release(dircookie) call on *owned,
+ * exactly like pfs_cwd_get() (which this delegates the same hazard to
+ * for the relative-path case) already documents.
+ */
 static LONG pfs_resolve_dir(struct pfs_ops *fs, WORD drive, const char *path,
-                             PFSCOOKIE *dircookie, const char **name)
+                             PFSCOOKIE *dircookie, const char **name, BOOL *owned)
 {
     char dirpart[LEN_ZPATH];
     const char *base;
     PFSCOOKIE start;
     const char *startpath;
+    BOOL start_owned;
     LONG rc;
 
     *name = pfs_split(path, dirpart, sizeof(dirpart));
@@ -393,11 +418,12 @@ static LONG pfs_resolve_dir(struct pfs_ops *fs, WORD drive, const char *path,
         if (!fs->root)
             return EINVFN;
         rc = fs->root(fs, drive, &start);
+        start_owned = TRUE;   /* fs->root() always hands back a fresh reference */
         base = dirpart[0] ? dirpart + 1 : dirpart;     /* skip the leading slash */
     }
     else
     {
-        rc = pfs_cwd_get(fs, drive, &start, &startpath);
+        rc = pfs_cwd_get(fs, drive, &start, &startpath, &start_owned);
         base = dirpart;
     }
     if (rc < 0)
@@ -405,15 +431,28 @@ static LONG pfs_resolve_dir(struct pfs_ops *fs, WORD drive, const char *path,
 
     if (!base[0])
     {
+        /* the resolved directory *is* 'start' - ownership passes through
+         * unchanged, whichever way pfs_cwd_get()/fs->root() set it. */
         *dircookie = start;
+        *owned = start_owned;
         return E_OK;
     }
 
+    /* every non-empty 'base' means fs->lookup() below produces a brand
+     * new cookie, always owned by the caller - regardless of whether
+     * 'start' (released right below, only if it was actually ours to
+     * release) was borrowed. */
+    *owned = TRUE;
+
     if (!fs->lookup)
+    {
+        if (start_owned && fs->release)
+            fs->release(&start);
         return EPTHNF;
+    }
 
     rc = fs->lookup(&start, base, dircookie);
-    if (fs->release)
+    if (start_owned && fs->release)
         fs->release(&start);
 
     return rc;
@@ -444,18 +483,19 @@ static LONG pfs_do_mkdir(const char *path)
     WORD drive = pfs_path_drive(path, &path);
     PFSCOOKIE dir;
     const char *name;
+    BOOL owned;
     LONG rc;
 
     fs = pfs_drive_fs(drive);
     if (!fs)
         return EDRIVE;
 
-    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name, &owned);
     if (rc < 0)
         return rc;
 
     rc = fs->mkdir ? fs->mkdir(&dir, name) : EACCDN;
-    if (fs->release)
+    if (owned && fs->release)
         fs->release(&dir);
 
     return rc;
@@ -467,18 +507,19 @@ static LONG pfs_do_rmdir(const char *path)
     WORD drive = pfs_path_drive(path, &path);
     PFSCOOKIE dir;
     const char *name;
+    BOOL owned;
     LONG rc;
 
     fs = pfs_drive_fs(drive);
     if (!fs)
         return EDRIVE;
 
-    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name, &owned);
     if (rc < 0)
         return rc;
 
     rc = fs->rmdir ? fs->rmdir(&dir, name) : EACCDN;
-    if (fs->release)
+    if (owned && fs->release)
         fs->release(&dir);
 
     return rc;
@@ -492,6 +533,7 @@ static LONG pfs_do_chdir(const char *path)
     const char *name;
     PFSCOOKIE target;
     char newpath[LEN_ZPATH];
+    BOOL dir_owned;
     LONG rc;
 
     fs = pfs_drive_fs(drive);
@@ -506,13 +548,14 @@ static LONG pfs_do_chdir(const char *path)
         if (!fs->root)
             return EINVFN;
         rc = fs->root(fs, drive, &dir);
+        dir_owned = TRUE;
         name = path[1] ? path + 1 : path;
         newpath[0] = 0;
     }
     else
     {
         const char *cwdpath;
-        rc = pfs_cwd_get(fs, drive, &dir, &cwdpath);
+        rc = pfs_cwd_get(fs, drive, &dir, &cwdpath, &dir_owned);
         name = path;
         strlcpy(newpath, cwdpath, sizeof(newpath));
     }
@@ -521,21 +564,28 @@ static LONG pfs_do_chdir(const char *path)
 
     if (!name[0])
     {
+        /* Dsetpath(".") or Dsetpath("\\") - 'dir' *is* the new current
+         * directory.  pfs_cwd_set() copies it into pfs_dirtbl[] on
+         * success, taking over whatever reference it held (owned or
+         * not) - release it ourselves only if that hand-off didn't
+         * happen (cwd_set failed) and it was ours to begin with. */
         rc = pfs_cwd_set(drive, fs, &dir, newpath);
-        if (fs->release)
+        if ((rc < 0) && dir_owned && fs->release)
             fs->release(&dir);
         return rc;
     }
 
     if (!fs->lookup)
     {
-        if (fs->release)
+        if (dir_owned && fs->release)
             fs->release(&dir);
         return EPTHNF;
     }
 
+    /* fs->lookup() always produces a fresh, caller-owned 'target',
+     * regardless of whether 'dir' was borrowed. */
     rc = fs->lookup(&dir, name, &target);
-    if (fs->release)
+    if (dir_owned && fs->release)
         fs->release(&dir);
     if (rc < 0)
         return rc;
@@ -563,7 +613,9 @@ static LONG pfs_do_chdir(const char *path)
         }
     }
 
-    if (fs->release)
+    /* same hand-off logic as above: 'target' is always owned here, but
+     * only ours to release if pfs_cwd_set() didn't take it over. */
+    if ((rc < 0) && fs->release)
         fs->release(&target);
 
     return rc;
@@ -575,19 +627,20 @@ static LONG pfs_do_getdir(char *buf, WORD drv)
     WORD drive = drv ? (WORD)(drv - 1) : run->p_curdrv;
     PFSCOOKIE cwd;
     const char *path;
+    BOOL owned;
     LONG rc;
 
     fs = pfs_drive_fs(drive);
     if (!fs)
         return EDRIVE;
 
-    rc = pfs_cwd_get(fs, drive, &cwd, &path);
+    rc = pfs_cwd_get(fs, drive, &cwd, &path, &owned);
     if (rc < 0)
     {
         *buf = 0;
         return rc;
     }
-    if (fs->release)
+    if (owned && fs->release)
         fs->release(&cwd);
 
     strlcpy(buf, path, LEN_ZPATH);
@@ -619,18 +672,19 @@ static LONG pfs_do_open(const char *path, WORD mode)
     WORD drive = pfs_path_drive(path, &path);
     PFSCOOKIE dir, fc;
     const char *name;
+    BOOL owned;
     LONG rc;
 
     fs = pfs_drive_fs(drive);
     if (!fs)
         return EDRIVE;
 
-    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name, &owned);
     if (rc < 0)
         return rc;
 
     rc = fs->open ? fs->open(&dir, name, mode, &fc) : EACCDN;
-    if (fs->release)
+    if (owned && fs->release)
         fs->release(&dir);
     if (rc < 0)
         return rc;
@@ -655,18 +709,19 @@ static LONG pfs_do_create(const char *path, UWORD attr)
     WORD drive = pfs_path_drive(path, &path);
     PFSCOOKIE dir, fc;
     const char *name;
+    BOOL owned;
     LONG rc;
 
     fs = pfs_drive_fs(drive);
     if (!fs)
         return EDRIVE;
 
-    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name, &owned);
     if (rc < 0)
         return rc;
 
     rc = fs->create ? fs->create(&dir, name, attr, &fc) : EACCDN;
-    if (fs->release)
+    if (owned && fs->release)
         fs->release(&dir);
     if (rc < 0)
         return rc;
@@ -691,18 +746,19 @@ static LONG pfs_do_unlink(const char *path)
     WORD drive = pfs_path_drive(path, &path);
     PFSCOOKIE dir;
     const char *name;
+    BOOL owned;
     LONG rc;
 
     fs = pfs_drive_fs(drive);
     if (!fs)
         return EDRIVE;
 
-    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name, &owned);
     if (rc < 0)
         return rc;
 
     rc = fs->remove ? fs->remove(&dir, name) : EACCDN;
-    if (fs->release)
+    if (owned && fs->release)
         fs->release(&dir);
 
     return rc;
@@ -715,19 +771,20 @@ static LONG pfs_do_chmod(const char *path, WORD wrt, WORD mod)
     PFSCOOKIE dir;
     const char *name;
     UWORD attr;
+    BOOL owned;
     LONG rc;
 
     fs = pfs_drive_fs(drive);
     if (!fs)
         return EDRIVE;
 
-    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name, &owned);
     if (rc < 0)
         return rc;
 
     attr = (UWORD)mod;
     rc = fs->chattr ? fs->chattr(&dir, name, wrt ? TRUE : FALSE, &attr) : EINVFN;
-    if (fs->release)
+    if (owned && fs->release)
         fs->release(&dir);
     if (rc < 0)
         return rc;
@@ -742,6 +799,7 @@ static LONG pfs_do_rename(const char *p1, const char *p2)
     WORD drive2 = pfs_path_drive(p2, &p2);
     PFSCOOKIE dir1, dir2;
     const char *name1, *name2;
+    BOOL owned1, owned2;
     LONG rc;
 
     if (drive1 != drive2)
@@ -751,22 +809,22 @@ static LONG pfs_do_rename(const char *p1, const char *p2)
     if (!fs)
         return EDRIVE;
 
-    rc = pfs_resolve_dir(fs, drive1, p1, &dir1, &name1);
+    rc = pfs_resolve_dir(fs, drive1, p1, &dir1, &name1, &owned1);
     if (rc < 0)
         return rc;
 
-    rc = pfs_resolve_dir(fs, drive1, p2, &dir2, &name2);
+    rc = pfs_resolve_dir(fs, drive1, p2, &dir2, &name2, &owned2);
     if (rc < 0)
     {
-        if (fs->release) fs->release(&dir1);
+        if (owned1 && fs->release) fs->release(&dir1);
         return rc;
     }
 
     rc = fs->rename ? fs->rename(&dir1, name1, &dir2, name2) : EACCDN;
     if (fs->release)
     {
-        fs->release(&dir1);
-        fs->release(&dir2);
+        if (owned1) fs->release(&dir1);
+        if (owned2) fs->release(&dir2);
     }
 
     return rc;
@@ -778,6 +836,7 @@ static LONG pfs_do_sfirst(char *path, WORD att)
     WORD drive = pfs_path_drive(path, (const char **)&path);
     PFSCOOKIE dir;
     const char *name;
+    BOOL owned;
     WORD i;
     LONG rc;
 
@@ -785,7 +844,7 @@ static LONG pfs_do_sfirst(char *path, WORD att)
     if (!fs)
         return EDRIVE;
 
-    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name, &owned);
     if (rc < 0)
         return rc;
 
@@ -807,7 +866,7 @@ static LONG pfs_do_sfirst(char *path, WORD att)
                 break;
         if (i == CONF_PFS_MAX_SEARCHES)
         {
-            if (fs->release) fs->release(&dir);
+            if (owned && fs->release) fs->release(&dir);
             return ENHNDL;
         }
     }
@@ -815,6 +874,7 @@ static LONG pfs_do_sfirst(char *path, WORD att)
     pfs_searches[i].owner = run->p_xdta;
     pfs_searches[i].proc = run;
     pfs_searches[i].dir = dir;
+    pfs_searches[i].dir_owned = owned;
     pfs_searches[i].cursor = 0;
     pfs_searches[i].attr = att;
     strlcpy(pfs_searches[i].pattern, name, sizeof(pfs_searches[i].pattern));

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -574,6 +574,72 @@ static LONG pfs_do_rmdir(const char *path)
     return rc;
 }
 
+/* Append 'tail' (a possibly multi-component relative path, e.g. what
+ * pfs_do_chdir() just handed to fs->lookup()) onto the cached
+ * current-directory path string '*newpath' (capacity 'cap'), folding "."
+ * and ".." components the way a canonical path does rather than blindly
+ * concatenating them.  fs->lookup() itself may resolve those components
+ * just fine (whatever tree-walking the driver does for the resolved
+ * cookie, e.g. FAT's dcrack()/findit()), but the *cached path string* is
+ * built up independently here - Dgetpath() returns it directly - so
+ * without this folding it could end up with a dangling ".." component
+ * that the built-in FAT implementation's DND-tree-derived Dgetpath()
+ * (dopath()) could never produce.  ".." above the root is clamped there,
+ * matching dopath()'s own behavior of never walking past a NULL
+ * d_parent.  Returns E_OK, or ERANGE if a component wouldn't fit.
+ */
+static LONG pfs_path_append(char *newpath, size_t cap, const char *tail)
+{
+    const char *p = tail;
+
+    for (;;)
+    {
+        const char *start = p;
+        size_t len;
+
+        while (*p && (*p != SLASH))
+            p++;
+        len = (size_t)(p - start);
+
+        if ((len == 1) && (start[0] == '.'))
+        {
+            /* "." - no-op */
+        }
+        else if ((len == 2) && (start[0] == '.') && (start[1] == '.'))
+        {
+            /* pop the last component - no strrchr() in include/string.h,
+             * so scan for it directly. */
+            char *last = newpath;
+            char *q;
+
+            for (q = newpath; *q; q++)
+                if (*q == SLASH)
+                    last = q;
+
+            if (last != newpath)
+                *last = 0;
+            else
+                newpath[0] = 0;
+        }
+        else if (len)
+        {
+            size_t curlen = strlen(newpath);
+            size_t sep = curlen ? 1 : 0;
+
+            if (curlen + sep + len >= cap)
+                return ERANGE;
+            if (sep)
+                newpath[curlen++] = SLASH;
+            memcpy(newpath + curlen, start, len);
+            newpath[curlen + len] = 0;
+        }
+
+        if (!*p)
+            return E_OK;
+        p++;    /* skip the SLASH */
+    }
+}
+
 static LONG pfs_do_chdir(const char *path)
 {
     struct pfs_ops *fs;
@@ -644,28 +710,13 @@ static LONG pfs_do_chdir(const char *path)
     if (rc < 0)
         return rc;
 
-    /* append "\name" (or just "name" if newpath is still empty, i.e. the
-     * new directory is directly under the drive root) to the cached
-     * path string; a path that doesn't fit is an error, not something
-     * to silently truncate - this string is what Dgetpath() returns and
-     * what later relative lookups are built from. */
-    {
-        size_t len = strlen(newpath);
-        size_t namelen = strlen(name);
-        size_t sep = len ? 1 : 0;
-
-        if (len + sep + namelen >= sizeof(newpath))
-        {
-            rc = ERANGE;
-        }
-        else
-        {
-            if (sep)
-                newpath[len++] = SLASH;
-            memcpy(newpath + len, name, namelen + 1);      /* + null terminator */
-            rc = pfs_cwd_set(drive, fs, &target, newpath);
-        }
-    }
+    /* fold 'name's components (which may include "." / "..") onto the
+     * cached path string - this is what Dgetpath() returns and what
+     * later relative lookups are built from, so it needs to stay
+     * canonical, not just whatever fs->lookup() was able to resolve. */
+    rc = pfs_path_append(newpath, sizeof(newpath), name);
+    if (rc >= 0)
+        rc = pfs_cwd_set(drive, fs, &target, newpath);
 
     /* same hand-off logic as above: 'target' is always owned here, but
      * only ours to release if pfs_cwd_set() didn't take it over. */

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -1,0 +1,971 @@
+/*
+ * pfs.c - pluggable filesystem layer core
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ *
+ * Owns: the per-drive driver table, GEMDOS path-based call dispatch,
+ * current-directory tracking, and Fsfirst/Fsnext search state.  See
+ * fs/pfs.h for the driver-facing interface, and the design notes in
+ * this branch's PR description for the overall architecture.
+ */
+
+#include "config.h"
+#include "portab.h"
+#include "pfs.h"
+#include "fs.h"
+#include "gemerror.h"
+#include "biosbind.h"
+#include "string.h"
+#include "kprint.h"
+#include "../bios/tosvars.h"    /* for drvbits, same convention as
+                                 * bdos/proc.c and bdos/umem.c */
+
+/*
+ * GEMDOS function numbers this layer dispatches.  Fread(0x3F)/
+ * Fwrite(0x40)/Fclose(0x3E) are deliberately absent - see pfs.h.
+ */
+#define FN_DFREE        0x36
+#define FN_DCREATE      0x39
+#define FN_DDELETE      0x3A
+#define FN_DSETPATH     0x3B
+#define FN_FCREATE      0x3C
+#define FN_FOPEN        0x3D
+#define FN_FDELETE      0x41
+#define FN_FATTRIB      0x43
+#define FN_DGETPATH     0x47
+#define FN_FSFIRST      0x4E
+#define FN_FSNEXT       0x4F
+#define FN_FRENAME      0x56
+
+BOOL pfs_is_fs_call(WORD fn)
+{
+    switch (fn)
+    {
+    case FN_DFREE:
+    case FN_DCREATE:
+    case FN_DDELETE:
+    case FN_DSETPATH:
+    case FN_FCREATE:
+    case FN_FOPEN:
+    case FN_FDELETE:
+    case FN_FATTRIB:
+    case FN_DGETPATH:
+    case FN_FSFIRST:
+    case FN_FSNEXT:
+    case FN_FRENAME:
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
+
+/* ------------------------------------------------------------------ */
+/* drive table                                                        */
+/* ------------------------------------------------------------------ */
+
+static struct pfs_ops *pfs_drive[BLKDEVNUM];
+
+LONG pfs_register_drive(WORD drive, struct pfs_ops *fs)
+{
+    PFSCOOKIE root;
+    LONG rc;
+
+    if ((drive < 0) || (drive >= BLKDEVNUM))
+        return EDRIVE;
+
+    if (!fs->root)
+        return EINVFN;
+
+    rc = fs->root(fs, drive, &root);
+    if (rc < 0)
+        return rc;
+    if (fs->release)
+        fs->release(&root);
+
+    pfs_drive[drive] = fs;
+    drvbits |= (1L << drive);
+
+    return E_OK;
+}
+
+/* Which driver serves 'drive'?  Anything nobody explicitly claimed
+ * falls back to the built-in FAT code, lazily mounted on first access
+ * exactly like ckdrv() does today - fat_pfs_ops.root() takes care of
+ * that the first time it is actually called for a given drive.
+ */
+static struct pfs_ops *pfs_drive_fs(WORD drive)
+{
+    if ((drive < 0) || (drive >= BLKDEVNUM))
+        return NULL;
+
+    return pfs_drive[drive] ? pfs_drive[drive] : &fat_pfs_ops;
+}
+
+
+/* ------------------------------------------------------------------ */
+/* path helpers                                                       */
+/* ------------------------------------------------------------------ */
+
+/* GEMDOS drive letter (0=A:) an absolute or relative path names, and a
+ * pointer just past any "X:" prefix.  Defaults to the current drive.
+ */
+static WORD pfs_path_drive(const char *path, const char **rest)
+{
+    WORD drive = run->p_curdrv;
+
+    if (path[0] && (path[1] == ':'))
+    {
+        char c = path[0];
+        if ((c >= 'a') && (c <= 'z'))
+            c -= 'a' - 'A';
+        drive = c - 'A';
+        path += 2;
+    }
+
+    *rest = path;
+    return drive;
+}
+
+/* Split 'path' (already past any drive prefix) into the directory
+ * portion (copied into 'dirbuf', empty string if 'path' has no
+ * separator) and returns a pointer to the final component within
+ * 'path' itself.
+ */
+static const char *pfs_split(const char *path, char *dirbuf, int dirbuflen)
+{
+    const char *last = NULL;
+    const char *p;
+    int len;
+
+    for (p = path; *p; p++)
+        if (*p == SLASH)
+            last = p;
+
+    if (!last)
+    {
+        dirbuf[0] = 0;
+        return path;
+    }
+
+    len = (int)(last - path);
+    if (len >= dirbuflen)
+        len = dirbuflen - 1;
+    memcpy(dirbuf, path, len);
+    dirbuf[len] = 0;
+
+    return last + 1;
+}
+
+/* Simple DOS-style '?'/'*' wildcard match, case-insensitive, applied
+ * separately to the base and extension (split at the last '.').  '*'
+ * matches the rest of the segment it appears in; '?' matches exactly
+ * one character.  Both 'name' and 'pattern' are already GEMDOS 8.3
+ * names, as guaranteed by pfs_ops.readdir()'s contract.
+ */
+static BOOL pfs_seg_match(const char *name, const char *pattern)
+{
+    for (;;)
+    {
+        if (*pattern == '*')
+            return TRUE;        /* matches whatever remains */
+
+        if (*pattern == 0)
+            return *name == 0;
+
+        if (*name == 0)
+            return FALSE;
+
+        if ((*pattern != '?') &&
+            (toupper((UBYTE)*pattern) != toupper((UBYTE)*name)))
+            return FALSE;
+
+        name++;
+        pattern++;
+    }
+}
+
+static BOOL pfs_match(const char *name, const char *pattern)
+{
+    char nbase[9], next[4], pbase[9], pext[4];
+    const char *dot;
+    int len;
+
+    dot = strchr(name, '.');
+    len = dot ? (int)(dot - name) : (int)strlen(name);
+    if (len > 8) len = 8;
+    memcpy(nbase, name, len); nbase[len] = 0;
+    strlcpy(next, dot ? dot + 1 : "", sizeof(next));
+
+    dot = strchr(pattern, '.');
+    len = dot ? (int)(dot - pattern) : (int)strlen(pattern);
+    if (len > 8) len = 8;
+    memcpy(pbase, pattern, len); pbase[len] = 0;
+    strlcpy(pext, dot ? dot + 1 : "", sizeof(pext));
+
+    return pfs_seg_match(nbase, pbase) && pfs_seg_match(next, pext);
+}
+
+
+/* ------------------------------------------------------------------ */
+/* current-directory tracking                                         */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Reuses PD.p_curdir[] (already part of the real Atari basepage layout,
+ * sized BLKDEVNUM) as an index into this table instead of the legacy
+ * dirtbl[] - safe because fat_pfs_ops never relies on ambient
+ * CWD/dirtbl[] state (it always reconstructs absolute paths, see
+ * fs/fatfs_pfs.c), so dirtbl[] is simply unused for the lifetime of a
+ * pluggable-fs build.  Index 0 is reserved to mean "not cached yet, use
+ * this drive's root" - which is exactly what a freshly Pexec()'d
+ * process's zero-initialised p_curdir[] already reads as.
+ */
+#define PFS_MAX_CWD 16
+
+typedef struct {
+    struct pfs_ops *fs;
+    WORD drive;
+    WORD use;
+    PFSCOOKIE cwd;
+    char path[LEN_ZPATH];      /* absolute, no drive prefix, no leading
+                                 * or trailing backslash; empty = root */
+} PFS_DIRTBL_ENTRY;
+
+static PFS_DIRTBL_ENTRY pfs_dirtbl[PFS_MAX_CWD];
+
+/* Cookie + absolute path string for 'drive' in the calling process. */
+static LONG pfs_cwd_get(struct pfs_ops *fs, WORD drive, PFSCOOKIE *out, const char **path)
+{
+    WORD n = run->p_curdir[drive];
+
+    if ((n > 0) && (n < PFS_MAX_CWD) && pfs_dirtbl[n].use &&
+        (pfs_dirtbl[n].fs == fs) && (pfs_dirtbl[n].drive == drive))
+    {
+        *out = pfs_dirtbl[n].cwd;
+        *path = pfs_dirtbl[n].path;
+        return E_OK;
+    }
+
+    if (!fs->root)
+        return EINVFN;
+
+    *path = "";
+    return fs->root(fs, drive, out);
+}
+
+/* Record a newly-resolved current directory for 'drive', replacing
+ * whatever slot the process previously had for it.
+ */
+static LONG pfs_cwd_set(WORD drive, struct pfs_ops *fs, PFSCOOKIE *cwd, const char *path)
+{
+    WORD old = run->p_curdir[drive];
+    WORD i;
+
+    if ((old > 0) && (old < PFS_MAX_CWD) && pfs_dirtbl[old].use)
+    {
+        if (!--pfs_dirtbl[old].use)
+            pfs_dirtbl[old].fs = NULL;
+    }
+
+    if (!path[0])
+    {
+        /* root: no slot needed, the sentinel (0) already means this */
+        run->p_curdir[drive] = 0;
+        return E_OK;
+    }
+
+    for (i = 1; i < PFS_MAX_CWD; i++)
+        if (!pfs_dirtbl[i].use)
+            break;
+    if (i == PFS_MAX_CWD)
+        return ENSMEM;
+
+    pfs_dirtbl[i].fs = fs;
+    pfs_dirtbl[i].drive = drive;
+    pfs_dirtbl[i].use = 1;
+    pfs_dirtbl[i].cwd = *cwd;
+    strlcpy(pfs_dirtbl[i].path, path, sizeof(pfs_dirtbl[i].path));
+
+    run->p_curdir[drive] = i;
+
+    return E_OK;
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Fsfirst/Fsnext search state                                        */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+    DTA *owner;         /* NULL = free slot */
+    PD *proc;
+    PFSCOOKIE dir;
+    LONG cursor;
+    UWORD attr;
+    char pattern[LEN_ZFNAME];
+} PFS_SEARCH;
+
+static PFS_SEARCH pfs_searches[CONF_PFS_MAX_SEARCHES];
+
+static void pfs_search_free(PFS_SEARCH *s)
+{
+    if (s->dir.fs && s->dir.fs->release)
+        s->dir.fs->release(&s->dir);
+    s->owner = NULL;
+    s->proc = NULL;
+}
+
+/* Is a directory entry with attribute byte 'entry_attr' visible to an
+ * Fsfirst/Fsnext search whose caller-supplied filter is 'searchattr'?
+ * Standard GEMDOS rule: FA_RO/FA_ARCHIVE entries are always visible;
+ * FA_HIDDEN/FA_SYSTEM/FA_SUBDIR/FA_VOL entries are visible only if the
+ * search filter also sets that bit.
+ */
+static BOOL pfs_attr_visible(UWORD entry_attr, UWORD searchattr)
+{
+    UWORD gated = entry_attr & (FA_HIDDEN | FA_SYSTEM | FA_SUBDIR | FA_VOL);
+
+    return (gated & ~searchattr) == 0;
+}
+
+static void pfs_attr_to_dta(DTAINFO *dt, const char *name, const PFSATTR *a)
+{
+    dt->dt_fattr = (char)a->dos_attr;
+    dt->dt_td.time = a->time;
+    dt->dt_td.date = a->date;
+    dt->dt_fileln = (long)a->size;
+    strlcpy(dt->dt_fname, name, sizeof(dt->dt_fname));
+}
+
+
+/* ------------------------------------------------------------------ */
+/* dir-cookie resolution for a path-based call                        */
+/* ------------------------------------------------------------------ */
+
+/* Resolve the containing directory of 'path' (drive prefix already
+ * stripped) into 'dircookie', and return a pointer to the final
+ * component.  Absolute paths (leading backslash) resolve from the
+ * drive's root; relative paths resolve from the cached current
+ * directory.
+ */
+static LONG pfs_resolve_dir(struct pfs_ops *fs, WORD drive, const char *path,
+                             PFSCOOKIE *dircookie, const char **name)
+{
+    char dirpart[LEN_ZPATH];
+    const char *base;
+    PFSCOOKIE start;
+    const char *startpath;
+    LONG rc;
+
+    *name = pfs_split(path, dirpart, sizeof(dirpart));
+
+    if (path[0] == SLASH)
+    {
+        if (!fs->root)
+            return EINVFN;
+        rc = fs->root(fs, drive, &start);
+        base = dirpart[0] ? dirpart + 1 : dirpart;     /* skip the leading slash */
+    }
+    else
+    {
+        rc = pfs_cwd_get(fs, drive, &start, &startpath);
+        base = dirpart;
+    }
+    if (rc < 0)
+        return rc;
+
+    if (!base[0])
+    {
+        *dircookie = start;
+        return E_OK;
+    }
+
+    if (!fs->lookup)
+        return EPTHNF;
+
+    rc = fs->lookup(&start, base, dircookie);
+    if (fs->release)
+        fs->release(&start);
+
+    return rc;
+}
+
+
+/* ------------------------------------------------------------------ */
+/* per-call handlers                                                  */
+/* ------------------------------------------------------------------ */
+
+static LONG pfs_do_dfree(WORD drv, ULONG *buf)
+{
+    struct pfs_ops *fs;
+    WORD drive = drv ? (WORD)(drv - 1) : run->p_curdrv;
+
+    fs = pfs_drive_fs(drive);
+    if (!fs)
+        return EDRIVE;
+    if (!fs->dfree)
+        return EINVFN;
+
+    return fs->dfree(fs, drive, buf);
+}
+
+static LONG pfs_do_mkdir(const char *path)
+{
+    struct pfs_ops *fs;
+    WORD drive = pfs_path_drive(path, &path);
+    PFSCOOKIE dir;
+    const char *name;
+    LONG rc;
+
+    fs = pfs_drive_fs(drive);
+    if (!fs)
+        return EDRIVE;
+
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    if (rc < 0)
+        return rc;
+
+    rc = fs->mkdir ? fs->mkdir(&dir, name) : EACCDN;
+    if (fs->release)
+        fs->release(&dir);
+
+    return rc;
+}
+
+static LONG pfs_do_rmdir(const char *path)
+{
+    struct pfs_ops *fs;
+    WORD drive = pfs_path_drive(path, &path);
+    PFSCOOKIE dir;
+    const char *name;
+    LONG rc;
+
+    fs = pfs_drive_fs(drive);
+    if (!fs)
+        return EDRIVE;
+
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    if (rc < 0)
+        return rc;
+
+    rc = fs->rmdir ? fs->rmdir(&dir, name) : EACCDN;
+    if (fs->release)
+        fs->release(&dir);
+
+    return rc;
+}
+
+static LONG pfs_do_chdir(const char *path)
+{
+    struct pfs_ops *fs;
+    WORD drive = pfs_path_drive(path, &path);
+    PFSCOOKIE dir;
+    const char *name;
+    PFSCOOKIE target;
+    char newpath[LEN_ZPATH];
+    LONG rc;
+
+    fs = pfs_drive_fs(drive);
+    if (!fs)
+        return EDRIVE;
+
+    /* the whole path is a directory path here - resolve it exactly like
+     * pfs_resolve_dir()'s containing-directory step, but for the full
+     * path rather than stopping one component short. */
+    if (path[0] == SLASH)
+    {
+        if (!fs->root)
+            return EINVFN;
+        rc = fs->root(fs, drive, &dir);
+        name = path[1] ? path + 1 : path;
+        newpath[0] = 0;
+    }
+    else
+    {
+        const char *cwdpath;
+        rc = pfs_cwd_get(fs, drive, &dir, &cwdpath);
+        name = path;
+        strlcpy(newpath, cwdpath, sizeof(newpath));
+    }
+    if (rc < 0)
+        return rc;
+
+    if (!name[0])
+    {
+        rc = pfs_cwd_set(drive, fs, &dir, newpath);
+        if (fs->release)
+            fs->release(&dir);
+        return rc;
+    }
+
+    if (!fs->lookup)
+    {
+        if (fs->release)
+            fs->release(&dir);
+        return EPTHNF;
+    }
+
+    rc = fs->lookup(&dir, name, &target);
+    if (fs->release)
+        fs->release(&dir);
+    if (rc < 0)
+        return rc;
+
+    if (newpath[0] && (strlen(newpath) < sizeof(newpath) - 1))
+        strcat(newpath, "\\");
+    {
+        size_t len = strlen(newpath);
+        if (len < sizeof(newpath) - 1)
+            strlcpy(newpath + len, name, sizeof(newpath) - len);
+    }
+
+    rc = pfs_cwd_set(drive, fs, &target, newpath);
+    if (fs->release)
+        fs->release(&target);
+
+    return rc;
+}
+
+static LONG pfs_do_getdir(char *buf, WORD drv)
+{
+    struct pfs_ops *fs;
+    WORD drive = drv ? (WORD)(drv - 1) : run->p_curdrv;
+    PFSCOOKIE cwd;
+    const char *path;
+    LONG rc;
+
+    fs = pfs_drive_fs(drive);
+    if (!fs)
+        return EDRIVE;
+
+    rc = pfs_cwd_get(fs, drive, &cwd, &path);
+    if (rc < 0)
+    {
+        *buf = 0;
+        return rc;
+    }
+    if (fs->release)
+        fs->release(&cwd);
+
+    strlcpy(buf, path, LEN_ZPATH);
+
+    return E_OK;
+}
+
+static LONG pfs_alloc_handle(PFSCOOKIE *fc)
+{
+    WORD i;
+
+    for (i = 0; i < OPNFILES; i++)
+        if (!sft[i].f_own)
+            break;
+    if (i == OPNFILES)
+        return ENHNDL;
+
+    sft[i].f_own = run;
+    sft[i].f_use = 1;
+    sft[i].f_ofd = NULL;
+    sft[i].f_pfs = *fc;
+
+    return i + NUMSTD;
+}
+
+static LONG pfs_do_open(const char *path, WORD mode)
+{
+    struct pfs_ops *fs;
+    WORD drive = pfs_path_drive(path, &path);
+    PFSCOOKIE dir, fc;
+    const char *name;
+    LONG rc;
+
+    fs = pfs_drive_fs(drive);
+    if (!fs)
+        return EDRIVE;
+
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    if (rc < 0)
+        return rc;
+
+    rc = fs->open ? fs->open(&dir, name, mode, &fc) : EACCDN;
+    if (fs->release)
+        fs->release(&dir);
+    if (rc < 0)
+        return rc;
+
+    fc.pos = 0;
+    rc = pfs_alloc_handle(&fc);
+    if (rc < 0)
+    {
+        if (fs->close) fs->close(&fc);
+        if (fs->release) fs->release(&fc);
+    }
+
+    return rc;
+}
+
+static LONG pfs_do_create(const char *path, UWORD attr)
+{
+    struct pfs_ops *fs;
+    WORD drive = pfs_path_drive(path, &path);
+    PFSCOOKIE dir, fc;
+    const char *name;
+    LONG rc;
+
+    fs = pfs_drive_fs(drive);
+    if (!fs)
+        return EDRIVE;
+
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    if (rc < 0)
+        return rc;
+
+    rc = fs->create ? fs->create(&dir, name, attr, &fc) : EACCDN;
+    if (fs->release)
+        fs->release(&dir);
+    if (rc < 0)
+        return rc;
+
+    fc.pos = 0;
+    rc = pfs_alloc_handle(&fc);
+    if (rc < 0)
+    {
+        if (fs->close) fs->close(&fc);
+        if (fs->release) fs->release(&fc);
+    }
+
+    return rc;
+}
+
+static LONG pfs_do_unlink(const char *path)
+{
+    struct pfs_ops *fs;
+    WORD drive = pfs_path_drive(path, &path);
+    PFSCOOKIE dir;
+    const char *name;
+    LONG rc;
+
+    fs = pfs_drive_fs(drive);
+    if (!fs)
+        return EDRIVE;
+
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    if (rc < 0)
+        return rc;
+
+    rc = fs->remove ? fs->remove(&dir, name) : EACCDN;
+    if (fs->release)
+        fs->release(&dir);
+
+    return rc;
+}
+
+static LONG pfs_do_chmod(const char *path, WORD wrt, WORD mod)
+{
+    struct pfs_ops *fs;
+    WORD drive = pfs_path_drive(path, &path);
+    PFSCOOKIE dir;
+    const char *name;
+    UWORD attr;
+    LONG rc;
+
+    fs = pfs_drive_fs(drive);
+    if (!fs)
+        return EDRIVE;
+
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    if (rc < 0)
+        return rc;
+
+    attr = (UWORD)mod;
+    rc = fs->chattr ? fs->chattr(&dir, name, wrt ? TRUE : FALSE, &attr) : EINVFN;
+    if (fs->release)
+        fs->release(&dir);
+    if (rc < 0)
+        return rc;
+
+    return attr;
+}
+
+static LONG pfs_do_rename(const char *p1, const char *p2)
+{
+    struct pfs_ops *fs;
+    WORD drive1 = pfs_path_drive(p1, &p1);
+    WORD drive2 = pfs_path_drive(p2, &p2);
+    PFSCOOKIE dir1, dir2;
+    const char *name1, *name2;
+    LONG rc;
+
+    if (drive1 != drive2)
+        return ENSAME;
+
+    fs = pfs_drive_fs(drive1);
+    if (!fs)
+        return EDRIVE;
+
+    rc = pfs_resolve_dir(fs, drive1, p1, &dir1, &name1);
+    if (rc < 0)
+        return rc;
+
+    rc = pfs_resolve_dir(fs, drive1, p2, &dir2, &name2);
+    if (rc < 0)
+    {
+        if (fs->release) fs->release(&dir1);
+        return rc;
+    }
+
+    rc = fs->rename ? fs->rename(&dir1, name1, &dir2, name2) : EACCDN;
+    if (fs->release)
+    {
+        fs->release(&dir1);
+        fs->release(&dir2);
+    }
+
+    return rc;
+}
+
+static LONG pfs_do_sfirst(char *path, WORD att)
+{
+    struct pfs_ops *fs;
+    WORD drive = pfs_path_drive(path, (const char **)&path);
+    PFSCOOKIE dir;
+    const char *name;
+    WORD i;
+    LONG rc;
+
+    fs = pfs_drive_fs(drive);
+    if (!fs)
+        return EDRIVE;
+
+    rc = pfs_resolve_dir(fs, drive, path, &dir, &name);
+    if (rc < 0)
+        return rc;
+
+    for (i = 0; i < CONF_PFS_MAX_SEARCHES; i++)
+        if (!pfs_searches[i].owner)
+            break;
+    if (i == CONF_PFS_MAX_SEARCHES)
+    {
+        if (fs->release) fs->release(&dir);
+        return ENHNDL;
+    }
+
+    pfs_searches[i].owner = run->p_xdta;
+    pfs_searches[i].proc = run;
+    pfs_searches[i].dir = dir;
+    pfs_searches[i].cursor = 0;
+    pfs_searches[i].attr = att;
+    strlcpy(pfs_searches[i].pattern, name, sizeof(pfs_searches[i].pattern));
+
+    if (!fs->readdir)
+    {
+        pfs_search_free(&pfs_searches[i]);
+        return EPTHNF;
+    }
+
+    for (;;)
+    {
+        char name8_3[LEN_ZFNAME];
+        PFSATTR attr;
+
+        rc = fs->readdir(&pfs_searches[i].dir, &pfs_searches[i].cursor,
+                          name8_3, sizeof(name8_3), &attr);
+        if (rc < 0)
+        {
+            pfs_search_free(&pfs_searches[i]);
+            return rc;
+        }
+
+        if (pfs_match(name8_3, pfs_searches[i].pattern) &&
+            pfs_attr_visible(attr.dos_attr, att))
+        {
+            pfs_attr_to_dta((DTAINFO *)run->p_xdta, name8_3, &attr);
+            return E_OK;
+        }
+    }
+}
+
+static LONG pfs_do_snext(void)
+{
+    WORD i;
+
+    for (i = 0; i < CONF_PFS_MAX_SEARCHES; i++)
+        if (pfs_searches[i].owner == run->p_xdta)
+            break;
+    if (i == CONF_PFS_MAX_SEARCHES)
+        return ENMFIL;
+
+    for (;;)
+    {
+        char name8_3[LEN_ZFNAME];
+        PFSATTR attr;
+        struct pfs_ops *fs = pfs_searches[i].dir.fs;
+        LONG rc;
+
+        if (!fs || !fs->readdir)
+        {
+            pfs_search_free(&pfs_searches[i]);
+            return ENMFIL;
+        }
+
+        rc = fs->readdir(&pfs_searches[i].dir, &pfs_searches[i].cursor,
+                          name8_3, sizeof(name8_3), &attr);
+        if (rc < 0)
+        {
+            pfs_search_free(&pfs_searches[i]);
+            return rc;
+        }
+
+        if (pfs_match(name8_3, pfs_searches[i].pattern) &&
+            pfs_attr_visible(attr.dos_attr, pfs_searches[i].attr))
+        {
+            pfs_attr_to_dta((DTAINFO *)run->p_xdta, name8_3, &attr);
+            return E_OK;
+        }
+    }
+}
+
+void pfs_proc_exit(PD *r)
+{
+    WORD i;
+
+    for (i = 0; i < CONF_PFS_MAX_SEARCHES; i++)
+        if (pfs_searches[i].proc == r)
+            pfs_search_free(&pfs_searches[i]);
+
+    /*
+     * decrement pfs_dirtbl[] usage for every drive this process cached a
+     * current directory for - p_curdir[] indexes pfs_dirtbl[] here, not
+     * the legacy dirtbl[] (see the comment above PFS_MAX_CWD), so this
+     * needs its own loop rather than reusing bdos/proc.c's
+     * decr_curdir_usage() calls, which stay harmlessly pointed at the
+     * (otherwise unused, while this option is on) legacy table.
+     */
+    for (i = 0; i < BLKDEVNUM; i++)
+    {
+        WORD n = r->p_curdir[i];
+
+        if ((n > 0) && (n < PFS_MAX_CWD) && pfs_dirtbl[n].use)
+        {
+            if (!--pfs_dirtbl[n].use)
+                pfs_dirtbl[n].fs = NULL;
+        }
+    }
+}
+
+
+/* ------------------------------------------------------------------ */
+/* handle-based dispatch (Fread/Fwrite/Fclose)                        */
+/* ------------------------------------------------------------------ */
+
+LONG pfs_handle_read(PFSCOOKIE *fc, LONG len, UBYTE *buf)
+{
+    LONG n;
+
+    if (!fc->fs->read)
+        return EACCDN;
+
+    n = fc->fs->read(fc, fc->pos, len, buf);
+    if (n > 0)
+        fc->pos += n;
+
+    return n;
+}
+
+LONG pfs_handle_write(PFSCOOKIE *fc, LONG len, const UBYTE *buf)
+{
+    LONG n;
+
+    if (!fc->fs->write)
+        return EACCDN;
+
+    n = fc->fs->write(fc, fc->pos, len, buf);
+    if (n > 0)
+        fc->pos += n;
+
+    return n;
+}
+
+LONG pfs_handle_close(PFSCOOKIE *fc)
+{
+    LONG rc = fc->fs->close ? fc->fs->close(fc) : E_OK;
+
+    if (fc->fs->release)
+        fc->fs->release(fc);
+
+    return rc;
+}
+
+
+/* ------------------------------------------------------------------ */
+/* top-level dispatch                                                  */
+/* ------------------------------------------------------------------ */
+
+#ifdef __arm__
+LONG pfs_dispatch(WORD fn, LONG *pw)
+{
+    switch (fn)
+    {
+    case FN_DFREE:
+        return pfs_do_dfree((WORD)pw[2], (ULONG *)pw[1]);
+    case FN_DCREATE:
+        return pfs_do_mkdir((char *)pw[1]);
+    case FN_DDELETE:
+        return pfs_do_rmdir((char *)pw[1]);
+    case FN_DSETPATH:
+        return pfs_do_chdir((char *)pw[1]);
+    case FN_FCREATE:
+        return pfs_do_create((char *)pw[1], (UWORD)pw[2]);
+    case FN_FOPEN:
+        return pfs_do_open((char *)pw[1], (WORD)pw[2]);
+    case FN_FDELETE:
+        return pfs_do_unlink((char *)pw[1]);
+    case FN_FATTRIB:
+        return pfs_do_chmod((char *)pw[1], (WORD)pw[2], (WORD)pw[3]);
+    case FN_DGETPATH:
+        return pfs_do_getdir((char *)pw[1], (WORD)pw[2]);
+    case FN_FSFIRST:
+        return pfs_do_sfirst((char *)pw[1], (WORD)pw[2]);
+    case FN_FSNEXT:
+        return pfs_do_snext();
+    case FN_FRENAME:
+        return pfs_do_rename((char *)pw[2], (char *)pw[3]);
+    default:
+        return EINVFN;
+    }
+}
+#else
+LONG pfs_dispatch(WORD fn, WORD *pw)
+{
+    switch (fn)
+    {
+    case FN_DFREE:
+        return pfs_do_dfree(pw[3], *(ULONG **)&pw[1]);
+    case FN_DCREATE:
+        return pfs_do_mkdir(*(char **)&pw[1]);
+    case FN_DDELETE:
+        return pfs_do_rmdir(*(char **)&pw[1]);
+    case FN_DSETPATH:
+        return pfs_do_chdir(*(char **)&pw[1]);
+    case FN_FCREATE:
+        return pfs_do_create(*(char **)&pw[1], pw[3]);
+    case FN_FOPEN:
+        return pfs_do_open(*(char **)&pw[1], pw[3]);
+    case FN_FDELETE:
+        return pfs_do_unlink(*(char **)&pw[1]);
+    case FN_FATTRIB:
+        return pfs_do_chmod(*(char **)&pw[1], pw[3], pw[4]);
+    case FN_DGETPATH:
+        return pfs_do_getdir(*(char **)&pw[1], pw[3]);
+    case FN_FSFIRST:
+        return pfs_do_sfirst(*(char **)&pw[1], pw[3]);
+    case FN_FSNEXT:
+        return pfs_do_snext();
+    case FN_FRENAME:
+        return pfs_do_rename(*(char **)&pw[2], *(char **)&pw[4]);
+    default:
+        return EINVFN;
+    }
+}
+#endif

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -550,7 +550,12 @@ static LONG pfs_do_chdir(const char *path)
             return EINVFN;
         rc = fs->root(fs, drive, &dir);
         dir_owned = TRUE;
-        name = path[1] ? path + 1 : path;
+        name = path + 1;       /* always strip the leading SLASH - even
+                                 * when that's all 'path' is ("\\"),
+                                 * leaving name[0]==0 so the Dsetpath("\\")
+                                 * case below is recognised instead of
+                                 * handing a leading-slash string to
+                                 * fs->lookup(). */
         newpath[0] = 0;
     }
     else

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -223,7 +223,7 @@ static BOOL pfs_match(const char *name, const char *pattern)
  * this drive's root" - which is exactly what a freshly Pexec()'d
  * process's zero-initialised p_curdir[] already reads as.
  */
-#define PFS_MAX_CWD 16
+#define PFS_MAX_CWD CONF_PFS_MAX_CWD
 
 typedef struct {
     struct pfs_ops *fs;

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -159,10 +159,11 @@ static const char *pfs_split(const char *path, char *dirbuf, int dirbuflen)
 }
 
 /* Simple DOS-style '?'/'*' wildcard match, case-insensitive, applied
- * separately to the base and extension (split at the last '.').  '*'
+ * separately to the base and extension (split at the name's '.').  '*'
  * matches the rest of the segment it appears in; '?' matches exactly
  * one character.  Both 'name' and 'pattern' are already GEMDOS 8.3
- * names, as guaranteed by pfs_ops.readdir()'s contract.
+ * names, as guaranteed by pfs_ops.readdir()'s contract - so there is at
+ * most one '.', and splitting on the first one found is unambiguous.
  */
 static BOOL pfs_seg_match(const char *name, const char *pattern)
 {
@@ -848,6 +849,29 @@ static LONG pfs_do_sfirst(char *path, WORD att)
     if (rc < 0)
         return rc;
 
+    /*
+     * A search's directory cookie lives in pfs_searches[] for as long as
+     * the search runs, independently of whatever pfs_resolve_dir()
+     * resolved it from - readdir() may attach driver-private state to
+     * this exact copy (fat_readdir_pool[], via cookie->aux), which must
+     * be freed by pfs_search_free() when the search is abandoned.  That
+     * can only happen if this slot owns its cookie outright, so a
+     * borrowed one (the cached current directory, see pfs_resolve_dir())
+     * is upgraded here to an independent reference via an empty-path
+     * lookup() - see fs/pfs.h's "empty path = dup" convention - rather
+     * than stored as a bare alias pfs_search_free() must not release.
+     */
+    if (!owned)
+    {
+        PFSCOOKIE owned_dir;
+
+        rc = fs->lookup ? fs->lookup(&dir, "", &owned_dir) : EINVFN;
+        if (rc < 0)
+            return rc;
+        dir = owned_dir;
+        owned = TRUE;
+    }
+
     /* a new Fsfirst() on a DTA that already has a search running (common
      * - callers rarely exhaust a search before starting another) must
      * replace it, not leak a second slot and leave pfs_do_snext()
@@ -1004,14 +1028,17 @@ LONG pfs_handle_write(PFSCOOKIE *fc, LONG len, const UBYTE *buf)
     return n;
 }
 
+/* Only calls the driver's close(), never release() - a single cookie can
+ * be referenced by several sft[] entries at once (std-handle redirection
+ * via Fforce()/ixforce() bumps the same slot's f_use; xdup() copies the
+ * cookie into a second slot), so release() must wait until the caller
+ * (bdos/fsopnclo.c's xclose()) sees the last reference go away, exactly
+ * like the legacy OFD path calls ixclose() on every close but only frees
+ * the sft[] slot itself (sftdel()) once f_use reaches zero.
+ */
 LONG pfs_handle_close(PFSCOOKIE *fc)
 {
-    LONG rc = fc->fs->close ? fc->fs->close(fc) : E_OK;
-
-    if (fc->fs->release)
-        fc->fs->release(fc);
-
-    return rc;
+    return fc->fs->close ? fc->fs->close(fc) : E_OK;
 }
 
 

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -375,15 +375,30 @@ static void pfs_search_free(PFS_SEARCH *s)
 
 /* Is a directory entry with attribute byte 'entry_attr' visible to an
  * Fsfirst/Fsnext search whose caller-supplied filter is 'searchattr'?
- * Standard GEMDOS rule: FA_RO/FA_ARCHIVE entries are always visible;
- * FA_HIDDEN/FA_SYSTEM/FA_SUBDIR/FA_VOL entries are visible only if the
- * search filter also sets that bit.
+ * Deliberately bug-for-bug matches bdos/fsdir.c's match()/ixsfirst(), not
+ * a "clean" reading of the GEMDOS spec, since this is what FAT already
+ * does today and this layer has to reproduce that exactly (see
+ * fs/fatfs_pfs.c's file header) - including its quirk that an entry
+ * combining a gated bit (FA_HIDDEN/FA_SYSTEM/FA_SUBDIR/FA_VOL) with
+ * FA_ARCHIVE or FA_RO is visible even when the gated bit wasn't
+ * requested, because ixsfirst() ORs FA_ARCHIVE|FA_RO into the search
+ * mask before match()'s plain bitwise-AND test - a plain "is the gated
+ * subset a subset of the requested bits" check (as this function
+ * previously was) does not reproduce that.
  */
 static BOOL pfs_attr_visible(UWORD entry_attr, UWORD searchattr)
 {
-    UWORD gated = entry_attr & (FA_HIDDEN | FA_SYSTEM | FA_SUBDIR | FA_VOL);
+    UWORD effective;
 
-    return (gated & ~searchattr) == 0;
+    if (searchattr == FA_VOL)
+        return (entry_attr & FA_VOL) != 0;
+
+    effective = searchattr | FA_ARCHIVE | FA_RO;
+
+    if (!entry_attr)
+        return TRUE;
+
+    return (effective & entry_attr) != 0;
 }
 
 static void pfs_attr_to_dta(DTAINFO *dt, const char *name, const PFSATTR *a)

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -75,7 +75,7 @@ LONG pfs_register_drive(WORD drive, struct pfs_ops *fs)
     if ((drive < 0) || (drive >= BLKDEVNUM))
         return EDRIVE;
 
-    if (!fs->root)
+    if (!fs || !fs->root)
         return EINVFN;
 
     rc = fs->root(fs, drive, &root);
@@ -635,6 +635,9 @@ static LONG pfs_do_open(const char *path, WORD mode)
     if (rc < 0)
         return rc;
 
+    if (fs->native_handles)
+        return fc.index;
+
     fc.pos = 0;
     rc = pfs_alloc_handle(&fc);
     if (rc < 0)
@@ -667,6 +670,9 @@ static LONG pfs_do_create(const char *path, UWORD attr)
         fs->release(&dir);
     if (rc < 0)
         return rc;
+
+    if (fs->native_handles)
+        return fc.index;
 
     fc.pos = 0;
     rc = pfs_alloc_handle(&fc);
@@ -829,7 +835,11 @@ static LONG pfs_do_sfirst(char *path, WORD att)
         if (rc < 0)
         {
             pfs_search_free(&pfs_searches[i]);
-            return rc;
+            /* Fsfirst() reports "nothing matched" as EFILNF - ENMFIL
+             * ("no more files") is Fsnext()'s exhaustion code, not
+             * Fsfirst()'s, matching xsfirst()'s own convention
+             * (bdos/fsdir.c). */
+            return (rc == ENMFIL) ? EFILNF : rc;
         }
 
         if (pfs_match(name8_3, pfs_searches[i].pattern) &&
@@ -846,7 +856,7 @@ static LONG pfs_do_snext(void)
     WORD i;
 
     for (i = 0; i < CONF_PFS_MAX_SEARCHES; i++)
-        if (pfs_searches[i].owner == run->p_xdta)
+        if ((pfs_searches[i].owner == run->p_xdta) && (pfs_searches[i].proc == run))
             break;
     if (i == CONF_PFS_MAX_SEARCHES)
         return ENMFIL;

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -235,6 +235,37 @@ typedef struct {
 
 static PFS_DIRTBL_ENTRY pfs_dirtbl[PFS_MAX_CWD];
 
+/* One more process now shares pfs_dirtbl[n] - e.g. bdos/proc.c's
+ * init_pd_files() inheriting p_curdir[] into a freshly created process,
+ * mirroring the bump it already does to the legacy dirtbl[n].use for a
+ * non-pluggable drive. n==0 (root sentinel) is a no-op, matching how it
+ * is never a real slot.
+ */
+void pfs_cwd_addref(WORD n)
+{
+    if ((n > 0) && (n < PFS_MAX_CWD) && pfs_dirtbl[n].use)
+        pfs_dirtbl[n].use++;
+}
+
+/* Drop this process's reference to pfs_dirtbl[n] (n==0, the root
+ * sentinel, is a no-op); releases the driver's cookie once nothing
+ * references the slot any more.  Shared by pfs_cwd_set() (replacing a
+ * process's own cached directory) and pfs_proc_exit() (process
+ * termination).
+ */
+static void pfs_dirtbl_release(WORD n)
+{
+    if ((n > 0) && (n < PFS_MAX_CWD) && pfs_dirtbl[n].use)
+    {
+        if (!--pfs_dirtbl[n].use)
+        {
+            if (pfs_dirtbl[n].fs->release)
+                pfs_dirtbl[n].fs->release(&pfs_dirtbl[n].cwd);
+            pfs_dirtbl[n].fs = NULL;
+        }
+    }
+}
+
 /* Cookie + absolute path string for 'drive' in the calling process. */
 static LONG pfs_cwd_get(struct pfs_ops *fs, WORD drive, PFSCOOKIE *out, const char **path)
 {
@@ -263,11 +294,7 @@ static LONG pfs_cwd_set(WORD drive, struct pfs_ops *fs, PFSCOOKIE *cwd, const ch
     WORD old = run->p_curdir[drive];
     WORD i;
 
-    if ((old > 0) && (old < PFS_MAX_CWD) && pfs_dirtbl[old].use)
-    {
-        if (!--pfs_dirtbl[old].use)
-            pfs_dirtbl[old].fs = NULL;
-    }
+    pfs_dirtbl_release(old);
 
     if (!path[0])
     {
@@ -513,15 +540,29 @@ static LONG pfs_do_chdir(const char *path)
     if (rc < 0)
         return rc;
 
-    if (newpath[0] && (strlen(newpath) < sizeof(newpath) - 1))
-        strcat(newpath, "\\");
+    /* append "\name" (or just "name" if newpath is still empty, i.e. the
+     * new directory is directly under the drive root) to the cached
+     * path string; a path that doesn't fit is an error, not something
+     * to silently truncate - this string is what Dgetpath() returns and
+     * what later relative lookups are built from. */
     {
         size_t len = strlen(newpath);
-        if (len < sizeof(newpath) - 1)
-            strlcpy(newpath + len, name, sizeof(newpath) - len);
+        size_t namelen = strlen(name);
+        size_t sep = len ? 1 : 0;
+
+        if (len + sep + namelen >= sizeof(newpath))
+        {
+            rc = ERANGE;
+        }
+        else
+        {
+            if (sep)
+                newpath[len++] = SLASH;
+            memcpy(newpath + len, name, namelen + 1);      /* + null terminator */
+            rc = pfs_cwd_set(drive, fs, &target, newpath);
+        }
     }
 
-    rc = pfs_cwd_set(drive, fs, &target, newpath);
     if (fs->release)
         fs->release(&target);
 
@@ -742,13 +783,27 @@ static LONG pfs_do_sfirst(char *path, WORD att)
     if (rc < 0)
         return rc;
 
+    /* a new Fsfirst() on a DTA that already has a search running (common
+     * - callers rarely exhaust a search before starting another) must
+     * replace it, not leak a second slot and leave pfs_do_snext()
+     * matching whichever of the two comes first in the table. */
     for (i = 0; i < CONF_PFS_MAX_SEARCHES; i++)
-        if (!pfs_searches[i].owner)
+        if ((pfs_searches[i].owner == run->p_xdta) && (pfs_searches[i].proc == run))
             break;
-    if (i == CONF_PFS_MAX_SEARCHES)
+    if (i < CONF_PFS_MAX_SEARCHES)
     {
-        if (fs->release) fs->release(&dir);
-        return ENHNDL;
+        pfs_search_free(&pfs_searches[i]);
+    }
+    else
+    {
+        for (i = 0; i < CONF_PFS_MAX_SEARCHES; i++)
+            if (!pfs_searches[i].owner)
+                break;
+        if (i == CONF_PFS_MAX_SEARCHES)
+        {
+            if (fs->release) fs->release(&dir);
+            return ENHNDL;
+        }
     }
 
     pfs_searches[i].owner = run->p_xdta;
@@ -843,15 +898,7 @@ void pfs_proc_exit(PD *r)
      * (otherwise unused, while this option is on) legacy table.
      */
     for (i = 0; i < BLKDEVNUM; i++)
-    {
-        WORD n = r->p_curdir[i];
-
-        if ((n > 0) && (n < PFS_MAX_CWD) && pfs_dirtbl[n].use)
-        {
-            if (!--pfs_dirtbl[n].use)
-                pfs_dirtbl[n].fs = NULL;
-        }
-    }
+        pfs_dirtbl_release(r->p_curdir[i]);
 }
 
 

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -78,6 +78,19 @@ LONG pfs_register_drive(WORD drive, struct pfs_ops *fs)
     if (!fs || !fs->root)
         return EINVFN;
 
+    /*
+     * Reject re-registering an already-claimed drive rather than
+     * silently swapping the driver out from under it - existing
+     * handles and pfs_dirtbl[]/pfs_searches[] cookies would keep
+     * pointing at the old driver's cookies while pfs_drive[] now
+     * dispatches new calls to a different one, an inconsistency no
+     * caller here is prepared to reconcile.  A driver that genuinely
+     * wants to replace another's claim needs an explicit unregister
+     * step - not needed by anything in this tree yet.
+     */
+    if (pfs_drive[drive])
+        return EACCDN;
+
     rc = fs->root(fs, drive, &root);
     if (rc < 0)
         return rc;
@@ -789,7 +802,15 @@ static LONG pfs_do_chmod(const char *path, WORD wrt, WORD mod)
         return rc;
 
     attr = (UWORD)mod;
-    rc = fs->chattr ? fs->chattr(&dir, name, wrt ? TRUE : FALSE, &attr) : EINVFN;
+    if (fs->chattr)
+        rc = fs->chattr(&dir, name, wrt ? TRUE : FALSE, &attr);
+    else
+        rc = wrt ? EACCDN : EINVFN;    /* unimplemented write op -> EACCDN,
+                                         * matching mkdir/remove/rename's
+                                         * convention for "not supported by
+                                         * this driver"; a plain get with
+                                         * nothing to read is EINVFN, as
+                                         * before. */
     if (owned && fs->release)
         fs->release(&dir);
     if (rc < 0)

--- a/fs/pfs.c
+++ b/fs/pfs.c
@@ -189,7 +189,27 @@ static BOOL pfs_seg_match(const char *name, const char *pattern)
             return *name == 0;
 
         if (*name == 0)
-            return FALSE;
+        {
+            /*
+             * 'name' ran out but 'pattern' hasn't - the built-in FAT
+             * matcher (bdos/fsdir.c's builds()/match()) packs both
+             * sides into fixed-width, space-padded 8.3 fields, so a
+             * shorter name still has implicit trailing spaces for the
+             * rest of 'pattern' to compare against: '?' matches that
+             * padding like it matches anything else, a literal space
+             * genuinely equals it, and a '*' anywhere in the remainder
+             * still matches the (empty) rest - only a literal
+             * non-space character is a real mismatch.
+             */
+            for (; *pattern; pattern++)
+            {
+                if (*pattern == '*')
+                    return TRUE;
+                if ((*pattern != '?') && (*pattern != ' '))
+                    return FALSE;
+            }
+            return TRUE;
+        }
 
         if ((*pattern != '?') &&
             (toupper((UBYTE)*pattern) != toupper((UBYTE)*name)))

--- a/fs/pfs.h
+++ b/fs/pfs.h
@@ -118,6 +118,19 @@ struct pfs_ops {
      * per-cookie cleanup.
      */
     void (*release)(PFSCOOKIE *fc);
+
+    /* TRUE if open()/create() already returns a real, live GEMDOS
+     * handle in the successful cookie's 'index' - fat_pfs_ops does,
+     * since xopen()/ixcreat() already allocate their own sft[] slot
+     * internally.  The core then hands that handle straight back to
+     * the caller instead of also wrapping it in a second sft[] slot of
+     * its own (which would needlessly consume two system handles per
+     * open file).  Leave FALSE (the default for an omitted trailing
+     * field) for a driver with no handle management of its own, e.g. a
+     * future 9p driver - the core allocates and owns the handle for
+     * those, same as before this field existed.
+     */
+    BOOL native_handles;
 };
 
 /* Claim 'drive' (0 = A:, 1 = B:, ...) for 'fs', up front (e.g. from a

--- a/fs/pfs.h
+++ b/fs/pfs.h
@@ -183,4 +183,13 @@ LONG pfs_handle_close(PFSCOOKIE *fc);
  */
 void pfs_proc_exit(PD *r);
 
+/* Called from bdos/proc.c's init_pd_files() for each non-zero p_curdir[]
+ * entry ('n', an index into fs/pfs.c's own directory table) it copies
+ * into a newly created process - mirrors the bump init_pd_files()
+ * already does to the legacy dirtbl[n].use for a non-pluggable drive,
+ * so a pluggable current-directory slot shared by a parent and child
+ * process is not invalidated by one of them exiting first.
+ */
+void pfs_cwd_addref(WORD n);
+
 #endif /* PFS_H */

--- a/fs/pfs.h
+++ b/fs/pfs.h
@@ -69,6 +69,17 @@ struct pfs_ops {
      * standalone "file cookie" independent of a (directory, name) pair,
      * and not every driver can produce one (FAT only tree-caches
      * directories, not files).
+     *
+     * An empty 'path' ("") means "give me a fresh, independently
+     * releasable reference to 'dir' itself" - a dup, not a no-op alias.
+     * fs/pfs.c relies on this to upgrade a borrowed cookie (one it must
+     * not release, e.g. the cached current directory) into one it owns
+     * and must eventually release(), for state that outlives the call
+     * that resolved 'dir' (see pfs_do_sfirst()'s search table).  For a
+     * driver whose cookies carry no refcounted resource (like FAT's,
+     * which just wrap a cached DND*), this can simply be `*out = *dir;`;
+     * a driver that does refcount (e.g. a future 9p fid) must actually
+     * bump it here.
      */
     LONG (*lookup)(PFSCOOKIE *dir, const char *path, PFSCOOKIE *out);
 
@@ -184,6 +195,12 @@ LONG pfs_dispatch(WORD fn, WORD *pw);
  * the FTAB slot's embedded cookie; position tracking is entirely
  * internal to these three (see PFSCOOKIE.pos above) - callers just
  * pass the handle's ongoing sequential position through, GEMDOS-style.
+ *
+ * pfs_handle_close() only calls the driver's close(), not release() -
+ * the same cookie can be referenced by more than one sft[] entry at once
+ * (Fforce()-shared slots, xdup()-copied slots), so the caller must call
+ * fs->release() itself, and only once the last sft[] reference is gone -
+ * see bdos/fsopnclo.c's xclose().
  */
 LONG pfs_handle_read(PFSCOOKIE *fc, LONG len, UBYTE *buf);
 LONG pfs_handle_write(PFSCOOKIE *fc, LONG len, const UBYTE *buf);

--- a/fs/pfs.h
+++ b/fs/pfs.h
@@ -45,11 +45,19 @@ typedef struct pfs_attr {
 } PFSATTR;
 
 /*
- * Per-driver operations vtable.  Every entry is optional; a NULL entry
- * makes the layer return EINVFN (or EACCDN for a write-type call) to the
- * GEMDOS caller.  All functions return a GEMDOS/BDOS status: 0 or positive
- * on success, a negative gemerror.h code on failure - the same convention
- * used throughout bdos/ and bios/.
+ * Per-driver operations vtable.  Every entry is optional; fs/pfs.c treats
+ * a NULL entry as "this driver doesn't support that operation" and
+ * returns a GEMDOS/BDOS error without calling it, but the exact code
+ * depends on which entry: EINVFN for root()/dfree() (the driver can't
+ * function at all without them), EPTHNF for lookup() (nothing beyond the
+ * root is resolvable), EACCDN for the write-type calls
+ * (open/create/mkdir/rmdir/remove/rename/chattr-when-setting, matching
+ * GEMDOS's usual "not permitted" code for an unsupported operation), and
+ * E_OK for a missing close() (nothing to do, see pfs_handle_close()) -
+ * see each entry's own comment below for anything call-specific.  All
+ * functions return a GEMDOS/BDOS status: 0 or positive on success, a
+ * negative gemerror.h code on failure - the same convention used
+ * throughout bdos/ and bios/.
  */
 struct pfs_ops {
     /* Root directory cookie for 'drive' on this driver instance.  A

--- a/fs/pfs.h
+++ b/fs/pfs.h
@@ -107,13 +107,21 @@ struct pfs_ops {
     LONG (*rename)(PFSCOOKIE *olddir, const char *oldname,
                     PFSCOOKIE *newdir, const char *newname);
 
-    /* Fattrib-style get-or-set: reads *dos_attr when 'set' is FALSE,
-     * writes it when TRUE.  Fdatime is deliberately not covered here -
-     * unlike Fattrib it addresses an already-open handle, not a
-     * (directory, name) pair, so it belongs with the handle-based
-     * Fread/Fwrite/Fclose dispatch (see pfs_handle_read() etc. above)
-     * rather than this vtable; left as a follow-up since nothing in
-     * this PR's scope needs it yet. */
+    /* Fattrib-style get-or-set: on entry, '*dos_attr' holds the attribute
+     * bits to apply when 'set' is TRUE and is unused when 'set' is FALSE
+     * (a plain "get"). On a successful return, '*dos_attr' must hold
+     * whatever pfs_do_chmod() should hand straight back as the GEMDOS
+     * Fattrib() result: the current on-disk attributes for a "get", and
+     * for a "set", the value actually applied - i.e. an echo of the
+     * input, NOT the pre-change attributes, matching xchmod()'s own
+     * convention (bdos/fsdir.c) which fat_chattr() (fs/fatfs_pfs.c)
+     * already follows.
+     *
+     * Fdatime is deliberately not covered here - unlike Fattrib it
+     * addresses an already-open handle, not a (directory, name) pair, so
+     * it belongs with the handle-based Fread/Fwrite/Fclose dispatch (see
+     * pfs_handle_read() etc. above) rather than this vtable; left as a
+     * follow-up since nothing in this PR's scope needs it yet. */
     LONG (*chattr)(PFSCOOKIE *dir, const char *name, BOOL set, UWORD *dos_attr);
 
     /* out[0..3] = {free clusters, total clusters, bytes/sector,

--- a/fs/pfs.h
+++ b/fs/pfs.h
@@ -1,0 +1,186 @@
+/*
+ * pfs.h - pluggable filesystem layer for GEMDOS drives
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ *
+ * A drive letter can be claimed by a driver implementing 'struct pfs_ops'
+ * instead of by the built-in FAT filesystem.  When CONF_WITH_PLUGGABLE_FS
+ * is set, every drive - including the built-in FAT ones, wrapped by
+ * fatfs_pfs.c as fat_pfs_ops - is dispatched through this interface from
+ * bdos/bdosmain.c's osif().  See docs/superpowers/specs for the design
+ * this implements.
+ */
+
+#ifndef PFS_H
+#define PFS_H
+
+#include "portab.h"
+#include "pd.h"         /* for PD, used by pfs_proc_exit() below */
+
+struct pfs_ops;
+
+/* Opaque handle identifying a file or directory within one driver
+ * instance.  The core never looks inside index/aux; a driver is free to
+ * store whatever it needs there (fatfs_pfs.c stores a DND or OFD
+ * pointer, a future 9p driver would store a fid/qid).
+ */
+typedef struct pfs_cookie {
+    struct pfs_ops *fs;
+    LONG index;
+    LONG aux;
+    LONG pos;   /* core-managed sequential Fread/Fwrite position for an
+                 * open file; drivers never touch this directly - see
+                 * pfs_handle_read()/pfs_handle_write() in fs/pfs.c */
+} PFSCOOKIE;
+
+/* GEMDOS-native file/directory attributes, as used by Fsfirst/Fsnext,
+ * Fattrib and Dfree.
+ */
+typedef struct pfs_attr {
+    ULONG size;
+    UWORD dos_attr;     /* FA_RDONLY / FA_DIR / ... , see include/fatfs.h or similar */
+    UWORD date;         /* GEMDOS packed date, as returned by Fsfirst */
+    UWORD time;         /* GEMDOS packed time, as returned by Fsfirst */
+} PFSATTR;
+
+/*
+ * Per-driver operations vtable.  Every entry is optional; a NULL entry
+ * makes the layer return EINVFN (or EACCDN for a write-type call) to the
+ * GEMDOS caller.  All functions return a GEMDOS/BDOS status: 0 or positive
+ * on success, a negative gemerror.h code on failure - the same convention
+ * used throughout bdos/ and bios/.
+ */
+struct pfs_ops {
+    /* Root directory cookie for 'drive' on this driver instance.  A
+     * single 'fat_pfs_ops' instance serves every FAT drive letter, so
+     * 'drive' - not just 'fs' - identifies which one; a driver bound to
+     * one fixed drive (a foreign driver registered via
+     * pfs_register_drive()) can simply ignore it.
+     */
+    LONG (*root)(struct pfs_ops *fs, WORD drive, PFSCOOKIE *out);
+
+    /* Resolve a *directory* path (possibly several components, "." and
+     * ".." allowed) starting at directory cookie 'dir'.  Used for
+     * Dsetpath/current-directory tracking and to walk down to the
+     * containing directory of a longer Fopen/Fcreate/... path before
+     * calling one of the per-name entries below with the final component.
+     * Never used to resolve a plain file - GEMDOS has no notion of a
+     * standalone "file cookie" independent of a (directory, name) pair,
+     * and not every driver can produce one (FAT only tree-caches
+     * directories, not files).
+     */
+    LONG (*lookup)(PFSCOOKIE *dir, const char *path, PFSCOOKIE *out);
+
+    /* Every one of the following takes the containing directory cookie
+     * plus a single final path component ('name'), matching how GEMDOS
+     * itself always addresses a file: by (directory, name), never by a
+     * pre-resolved file handle of its own.
+     */
+    LONG (*open)(PFSCOOKIE *dir, const char *name, WORD mode, PFSCOOKIE *out);
+    LONG (*create)(PFSCOOKIE *dir, const char *name, UWORD attr, PFSCOOKIE *out);
+    LONG (*close)(PFSCOOKIE *fc);
+    LONG (*read)(PFSCOOKIE *fc, LONG pos, LONG len, UBYTE *buf);
+    LONG (*write)(PFSCOOKIE *fc, LONG pos, LONG len, const UBYTE *buf);
+
+    /* One directory entry per call.  '*cursor' is 0 to start a new
+     * listing; the driver updates it to whatever it needs to resume, and
+     * returns ENMFIL once the listing is exhausted.
+     */
+    LONG (*readdir)(PFSCOOKIE *dir, LONG *cursor, char *name, int namelen,
+                     PFSATTR *outattr);
+
+    LONG (*mkdir)(PFSCOOKIE *dir, const char *name);
+    LONG (*rmdir)(PFSCOOKIE *dir, const char *name);
+    LONG (*remove)(PFSCOOKIE *dir, const char *name);
+    LONG (*rename)(PFSCOOKIE *olddir, const char *oldname,
+                    PFSCOOKIE *newdir, const char *newname);
+
+    /* Fattrib-style get-or-set: reads *dos_attr when 'set' is FALSE,
+     * writes it when TRUE.  Fdatime is deliberately not covered here -
+     * unlike Fattrib it addresses an already-open handle, not a
+     * (directory, name) pair, so it belongs with the handle-based
+     * Fread/Fwrite/Fclose dispatch (see pfs_handle_read() etc. above)
+     * rather than this vtable; left as a follow-up since nothing in
+     * this PR's scope needs it yet. */
+    LONG (*chattr)(PFSCOOKIE *dir, const char *name, BOOL set, UWORD *dos_attr);
+
+    /* out[0..3] = {free clusters, total clusters, bytes/sector,
+     * sectors/cluster}, matching Dfree's on-stack result order. */
+    LONG (*dfree)(struct pfs_ops *fs, WORD drive, ULONG out[4]);
+
+    /* 0 = media unchanged, 1 = media changed, matching BIOS Mediach(). */
+    LONG (*mediach)(struct pfs_ops *fs, WORD drive);
+
+    /* Release any driver resources tied to a cookie the core is done
+     * with (a directory cookie returned by lookup()/root(), or a file
+     * cookie after close()).  May be NULL if the driver needs no
+     * per-cookie cleanup.
+     */
+    void (*release)(PFSCOOKIE *fc);
+};
+
+/* Claim 'drive' (0 = A:, 1 = B:, ...) for 'fs', up front (e.g. from a
+ * driver's own boot-time init, like virtio_blk_init() claims a block
+ * device letter).  Calls fs->root() once to confirm the driver can
+ * mount; on success sets drvbits so Drvmap()/the desktop see the new
+ * drive.  Returns E_OK or a negative gemerror.h code.
+ *
+ * Not used for the built-in FAT code: any drive letter nothing else has
+ * claimed falls back to fat_pfs_ops lazily, on first access, exactly
+ * like ckdrv() mounts a drive on first touch today - see fs/pfs.c.
+ */
+LONG pfs_register_drive(WORD drive, struct pfs_ops *fs);
+
+/* The built-in FAT filesystem, wrapped as a pfs_ops instance (see
+ * fs/fatfs_pfs.c).  One shared instance serves every FAT drive letter -
+ * pfs_dispatch()'s drive resolution falls back to this for any drive
+ * pfs_register_drive() hasn't explicitly claimed.
+ */
+extern struct pfs_ops fat_pfs_ops;
+
+/* True if GEMDOS function number 'fn' is one this layer handles
+ * (Fopen/Fread/Dsetpath/Fsfirst/... - see fs/pfs.c). Used by osif()'s
+ * dispatch hook.
+ */
+BOOL pfs_is_fs_call(WORD fn);
+
+/* Dispatch GEMDOS function 'fn' with BDOS's raw argument words 'pw'
+ * (pw[0] is the function number itself, pw[1..] the arguments) to the
+ * pluggable filesystem layer.  Only called when pfs_is_fs_call(fn) is
+ * true.  Note Fread(0x3F)/Fwrite(0x40)/Fclose(0x3E) are NOT among the
+ * calls pfs_is_fs_call() recognises: those stay on GEMDOS's normal
+ * handle-dispatch path and are instead made pluggable-aware directly in
+ * xread()/xwrite()/xclose() (bdos/fsio.c, fsopnclo.c) via the three
+ * functions below, so every caller of those three - not just osif() -
+ * reaches a pluggable handle correctly (e.g. process-termination
+ * cleanup in bdos/proc.c). Returns the same LONG osif() itself would
+ * return to the caller.  'pw' is exactly osif()'s own argument-words
+ * pointer, which is LONG-sized on ARM (one slot per real argument) and
+ * WORD-sized on m68k (one slot per 16-bit stack unit) - see osif() in
+ * bdos/bdosmain.c.
+ */
+#ifdef __arm__
+LONG pfs_dispatch(WORD fn, LONG *pw);
+#else
+LONG pfs_dispatch(WORD fn, WORD *pw);
+#endif
+
+/* Handle-based dispatch for a handle already resolved (by the bdos/
+ * caller, via getpfsslot()) to belong to a pluggable driver.  'fc' is
+ * the FTAB slot's embedded cookie; position tracking is entirely
+ * internal to these three (see PFSCOOKIE.pos above) - callers just
+ * pass the handle's ongoing sequential position through, GEMDOS-style.
+ */
+LONG pfs_handle_read(PFSCOOKIE *fc, LONG len, UBYTE *buf);
+LONG pfs_handle_write(PFSCOOKIE *fc, LONG len, const UBYTE *buf);
+LONG pfs_handle_close(PFSCOOKIE *fc);
+
+/* Called from bdos/proc.c's ixterm() when process 'r' terminates: frees
+ * any current-directory cookie and Fsfirst/Fsnext search slots (fs/pfs.c
+ * internal tables - not sft[], which the caller already handles) 'r'
+ * owned, so they don't leak.
+ */
+void pfs_proc_exit(PD *r);
+
+#endif /* PFS_H */

--- a/fs/pfs_test.c
+++ b/fs/pfs_test.c
@@ -154,6 +154,8 @@ static struct pfs_ops pfs_test_ops = {
     pfstest_dfree,
     pfstest_mediach,
     NULL                /* release: nothing to release */
+    /* native_handles omitted: defaults to FALSE, since this driver has
+     * no handle management of its own - see fs/pfs.h. */
 };
 
 void pfs_test_init(void)

--- a/fs/pfs_test.c
+++ b/fs/pfs_test.c
@@ -1,0 +1,164 @@
+/*
+ * pfs_test.c - throwaway pluggable filesystem self-test driver
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ *
+ * Exists only to exercise fs/pfs.c end-to-end (path dispatch, handle
+ * table tagging, the directory-search side table) without needing a
+ * real transport - gated behind CONF_WITH_PLUGGABLE_FS_TEST, development/
+ * test scaffolding only, not a starting point for a real driver.
+ *
+ * One fixed drive letter, one fixed read-only file "PFSTEST.TXT" in its
+ * root directory; nothing else exists on this drive.
+ */
+
+#include "config.h"
+
+#if CONF_WITH_PLUGGABLE_FS_TEST
+
+#include "portab.h"
+#include "pfs.h"
+#include "fs.h"
+#include "gemerror.h"
+#include "string.h"
+
+#ifndef CONF_PFS_TEST_DRIVE
+#define CONF_PFS_TEST_DRIVE 15     /* P: */
+#endif
+
+static const char pfs_test_filename[] = "PFSTEST.TXT";
+static const char pfs_test_contents[] = "Hello from the pluggable filesystem layer!\r\n";
+
+/* The only two objects this driver ever hands out: the root directory,
+ * and the one file.  'index' distinguishes them (0 = root, 1 = file);
+ * nothing else is ever looked up.
+ */
+#define PFS_TEST_ROOT 0
+#define PFS_TEST_FILE 1
+
+static LONG pfstest_root(struct pfs_ops *fs, WORD drive, PFSCOOKIE *out)
+{
+    (void)drive;
+
+    out->fs = fs;
+    out->index = PFS_TEST_ROOT;
+    out->aux = 0;
+    out->pos = 0;
+
+    return E_OK;
+}
+
+static LONG pfstest_lookup(PFSCOOKIE *dir, const char *path, PFSCOOKIE *out)
+{
+    if (dir->index != PFS_TEST_ROOT)
+        return EPTHNF;
+
+    /* only an empty (root-relative-to-itself) path is ever valid here -
+     * this drive has no subdirectories. */
+    if (path[0])
+        return EPTHNF;
+
+    *out = *dir;
+    return E_OK;
+}
+
+static LONG pfstest_open(PFSCOOKIE *dir, const char *name, WORD mode, PFSCOOKIE *out)
+{
+    if (dir->index != PFS_TEST_ROOT)
+        return EPTHNF;
+    if (strcmp(name, pfs_test_filename) != 0)
+        return EFILNF;
+    if (mode != 0)      /* read-only drive: only RO_MODE opens */
+        return EACCDN;
+
+    out->fs = dir->fs;
+    out->index = PFS_TEST_FILE;
+    out->aux = 0;
+    out->pos = 0;
+
+    return E_OK;
+}
+
+static LONG pfstest_read(PFSCOOKIE *fc, LONG pos, LONG len, UBYTE *buf)
+{
+    LONG total = (LONG)sizeof(pfs_test_contents) - 1;
+
+    if (fc->index != PFS_TEST_FILE)
+        return EIHNDL;
+
+    if (pos >= total)
+        return 0;
+    if (pos + len > total)
+        len = total - pos;
+
+    memcpy(buf, pfs_test_contents + pos, (size_t)len);
+
+    return len;
+}
+
+static LONG pfstest_readdir(PFSCOOKIE *dir, LONG *cursor, char *name, int namelen, PFSATTR *outattr)
+{
+    if (dir->index != PFS_TEST_ROOT)
+        return ENMFIL;
+    if (*cursor != 0)
+        return ENMFIL;      /* one entry, already returned */
+
+    *cursor = 1;
+    strlcpy(name, pfs_test_filename, namelen);
+    outattr->size = sizeof(pfs_test_contents) - 1;
+    outattr->dos_attr = FA_RO;
+    outattr->date = 0;
+    outattr->time = 0;
+
+    return E_OK;
+}
+
+static LONG pfstest_dfree(struct pfs_ops *fs, WORD drive, ULONG out[4])
+{
+    (void)fs;
+    (void)drive;
+
+    out[0] = 0;         /* free clusters: read-only, nothing to allocate */
+    out[1] = 1;         /* total clusters */
+    out[2] = 512;       /* bytes/sector */
+    out[3] = 1;         /* sectors/cluster */
+
+    return E_OK;
+}
+
+static LONG pfstest_mediach(struct pfs_ops *fs, WORD drive)
+{
+    (void)fs;
+    (void)drive;
+
+    return 0;           /* never changes */
+}
+
+void pfs_test_init(void);      /* called from bios/bios.c after blkdev_init() */
+
+static struct pfs_ops pfs_test_ops = {
+    pfstest_root,
+    pfstest_lookup,
+    pfstest_open,
+    NULL,               /* create: read-only */
+    NULL,               /* close: nothing to release */
+    pfstest_read,
+    NULL,               /* write: read-only */
+    pfstest_readdir,
+    NULL,               /* mkdir */
+    NULL,               /* rmdir */
+    NULL,               /* remove */
+    NULL,               /* rename */
+    NULL,               /* chattr */
+    pfstest_dfree,
+    pfstest_mediach,
+    NULL                /* release: nothing to release */
+};
+
+void pfs_test_init(void)
+{
+    pfs_register_drive(CONF_PFS_TEST_DRIVE, &pfs_test_ops);
+}
+
+#endif /* CONF_WITH_PLUGGABLE_FS_TEST */


### PR DESCRIPTION
Fixes #159

## What this adds

A mechanism (`fs/pfs.c`, gated by the new `CONF_WITH_PLUGGABLE_FS` Kconfig
option) that lets a driver expose a whole filesystem as a GEMDOS drive,
instead of only a block device underneath the built-in FAT code. The
built-in FAT filesystem itself is wrapped as an ordinary `pfs_ops` instance
(`fs/fatfs_pfs.c`) so it stays on equal footing with any future driver —
per the explicit design goal, FAT is "just another pluggable fs" when the
option is on, and is hooked in directly only when the option is off.

- `fs/pfs.h` — the driver-facing vtable (`struct pfs_ops`) and dispatch API.
- `fs/pfs.c` — drive table, GEMDOS path-based call dispatch, per-process
  current-directory tracking, Fsfirst/Fsnext search state.
- `fs/fatfs_pfs.c` — thin adapter wrapping the *existing, unmodified*
  GEMDOS-level FAT functions (`findit()`, `xopen()`, `xmkdir()`, ...) by
  reconstructing absolute paths, rather than reimplementing FAT.
- `fs/pfs_test.c` — throwaway self-test driver (`CONF_WITH_PLUGGABLE_FS_TEST`)
  used only to exercise the mechanism end-to-end; not a starting point for
  real driver work.
- Minimal, surgical `bdos/` touches: one dispatch hook in `bdosmain.c`'s
  `osif()`, a `PFSCOOKIE` embedded by value in `FTAB` so pluggable handles
  reuse the existing `sft[]` pool, and `xread()`/`xwrite()`/`xclose()` made
  pluggable-aware directly (so every caller — not just `osif()` — reaches a
  pluggable handle, e.g. process-termination cleanup in `proc.c`). Only two
  previously-`static` FAT helpers (`dopath()`, `ixsnext()`, plus `makbuf()`)
  needed exposing via a new `bdos/fs_internal.h`.

Default is **off** (`default n`), so existing configs are unaffected unless
they opt in.

## Verification done this session

- **Zero-cost when disabled**: built `rpi2_defconfig` before and after this
  change with the option at its default `n` — the resulting `kernel7.img` is
  **byte-for-byte identical**.
- **Compiles clean** on ARM (`rpi2_defconfig`, `virt-arm_defconfig`,
  `virt-arm-cli_defconfig`) with `CONF_WITH_PLUGGABLE_FS` +
  `CONF_WITH_PLUGGABLE_FS_TEST` both on, no new warnings.
- **Boots clean** under QEMU (`virt-arm`, `-M virt,highmem=off -cpu
  cortex-a7`): reaches the AES event loop (`evnt_multi()`) with no
  `guest_errors`/`unimp`, and the boot info screen correctly lists the
  self-test driver's drive (`GEMDOS drives: P`) — confirming
  `pfs_register_drive()` → `drvbits` → `Drvmap()` works end to end.

## Not yet verified (known gaps)

- **m68k build**: no m68k toolchain available in this environment (the
  `vriviere/mintelf` PPA is blocked by this environment's egress policy) —
  needs this PR's CI to confirm.
- **Interactive EmuCON round-trip** (actually listing/reading the test
  drive's file via `dir`/`type`): attempted over QEMU's `-serial stdio`, but
  keystroke delivery into the guest console was flaky in this sandbox
  (consistent with a caveat already documented in the `ptos-smoketest`
  skill for this exact setup) — got partial delivery once, inconclusive
  otherwise. The registration/dispatch/boot path is verified; the full
  open+read round-trip through EmuCON is not.
- **Real FAT-backed regression test** (an actual FAT disk image attached,
  read/write/create/delete exercised through the pluggable path): not run
  in this session — this is the most important remaining check given this
  PR reroutes the live FAT code path when the option is on, and should
  happen before this is considered safe to enable anywhere real.

Left as **draft** pending those checks.
