### PR TITLE
Select the multi-language country/keyboard from the ARM boot command line

### DIFF
--- a/bios/Kconfig
+++ b/bios/Kconfig
@@ -469,6 +469,22 @@ config CONF_WITH_NVRAM
 	default n if TARGET_192 || TARGET_CART
 	default y
 
+config CONF_WITH_BOOTARGS_LANG
+	bool "Boot command line language/keyboard override"
+	depends on MACHINE_RPI || MACHINE_VIRT_ARM
+	default y
+	help
+	  These machines have no NVRAM (see CONF_WITH_NVRAM) to store the
+	  country/keyboard setting a multi-language image picks at run
+	  time.  Say y to read it instead from a "ptos.lang=xx" parameter
+	  on the ARM boot loader's command line, where xx is one of the
+	  two-letter country codes listed in country.mk (e.g. "de", "fr",
+	  "uk").  On the Raspberry Pi, set this in cmdline.txt; under QEMU,
+	  pass -append "ptos.lang=xx".  Only takes effect on a
+	  multi-language image (say n to BUILD_UNIQUE_COUNTRY); with no
+	  matching parameter, or on a single-country image, the country
+	  baked in at build time is used as before.
+
 endmenu
 
 menu "Miscellaneous BIOS features"

--- a/bios/Kconfig
+++ b/bios/Kconfig
@@ -479,8 +479,9 @@ config CONF_WITH_BOOTARGS_LANG
 	  time.  Say y to read it instead from a "ptos.lang=xx" parameter
 	  on the ARM boot loader's command line, where xx is one of the
 	  two-letter country codes listed in country.mk (e.g. "de", "fr",
-	  "uk").  On the Raspberry Pi, set this in cmdline.txt; under QEMU,
-	  pass -append "ptos.lang=xx".  Only takes effect on a
+	  "uk").  On the Raspberry Pi, set this in cmdline.txt.  Under QEMU,
+	  use -append "ptos.lang=xx" when the chosen loader actually passes bootargs
+	  (see doc/country.txt).  Only takes effect on a
 	  multi-language image (say n to BUILD_UNIQUE_COUNTRY); with no
 	  matching parameter, or on a single-country image, the country
 	  baked in at build time is used as before.

--- a/bios/bootargs.c
+++ b/bios/bootargs.c
@@ -1,0 +1,260 @@
+/*
+ * bootargs.c - country/keyboard override parsed from the ARM boot
+ * command line
+ *
+ * Copyright (C) 2026 The EmuTOS development team
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+/*
+ * Machines built with CONF_MULTILANG pick their country/keyboard/font at
+ * run time (see bios/country.c).  Atari hardware reads the choice from
+ * NVRAM (CONF_WITH_NVRAM); the ARM machines have none, so this file reads
+ * it from the boot loader's command line instead, via whichever of the
+ * two boot-info formats the 32-bit ARM Linux boot protocol allows:
+ *
+ * - a classic ATAG list (a linear list of {size,tag,data...} records
+ *   ending in ATAG_NONE), found e.g. on the Raspberry Pi under QEMU when
+ *   booted with "-kernel kernel.img -append '...'" (verified empirically:
+ *   QEMU's raspi1ap/raspi2b machines build an ATAG_CORE/ATAG_MEM/
+ *   ATAG_CMDLINE list for a raw kernel image; loading the same kernel as
+ *   an ELF, or booting with -bios as documented for this OS, gets no boot
+ *   info passed at all -- r0-r2 come back zero, see arm_boot.h);
+ *
+ * - a flattened device tree (FDT), with the command line in its
+ *   /chosen/bootargs property.  This is the only format QEMU's ARM
+ *   "virt" machine (-M virt) uses -- it has no ATAG support -- and is
+ *   also what real Raspberry Pi firmware passes by default nowadays.
+ *
+ * Real hardware always uses one or the other, never both, and hands
+ * arm_boot_regs.atags pointing at whichever it is; the magic number at
+ * that address says which.  Both are read-only, walked once at boot,
+ * with no assumption that either format was actually used -- a null or
+ * unrecognized pointer just means no override.
+ */
+
+#include "config.h"
+
+#if CONF_WITH_BOOTARGS_LANG
+
+#include "portab.h"
+#include "arm_boot.h"
+#include "ctrycodes.h"
+#include "string.h"
+#include "bootargs.h"
+
+/* ---- ATAG list (Linux Documentation/arch/arm/booting.rst) ---- */
+
+#define ATAG_NONE       0x00000000UL
+#define ATAG_CORE       0x54410001UL
+#define ATAG_CMDLINE    0x54410009UL
+#define ATAG_MAX_TAGS   256     /* safety net against a corrupt/bogus list */
+
+struct atag_header {
+    ULONG size;     /* size of this tag in 4-byte words, header included */
+    ULONG tag;
+};
+
+/* Walk a classic ATAG list looking for ATAG_CMDLINE.  Returns the NUL
+ * terminated command line string, or NULL if there is none. */
+static const char *atag_find_cmdline(const struct atag_header *tag)
+{
+    int i;
+
+    for (i = 0; i < ATAG_MAX_TAGS; i++)
+    {
+        if (tag->size == 0)
+            break;
+        if (tag->tag == ATAG_CMDLINE)
+            return (const char *)(tag + 1);
+        tag = (const struct atag_header *)((const ULONG *)tag + tag->size);
+    }
+    return NULL;
+}
+
+/* ---- Flattened device tree (devicetree.org, "Devicetree Specification") ---- */
+
+#define FDT_MAGIC       0xd00dfeedUL
+#define FDT_BEGIN_NODE  0x00000001UL
+#define FDT_END_NODE    0x00000002UL
+#define FDT_PROP        0x00000003UL
+#define FDT_NOP         0x00000004UL
+#define FDT_END         0x00000009UL
+
+struct fdt_header {
+    ULONG magic;
+    ULONG totalsize;
+    ULONG off_dt_struct;
+    ULONG off_dt_strings;
+    ULONG off_mem_rsvmap;
+    ULONG version;
+    ULONG last_comp_version;
+    ULONG boot_cpuid_phys;
+    ULONG size_dt_strings;
+    ULONG size_dt_struct;
+};
+
+/* Every field of an FDT is big-endian, regardless of the CPU. */
+static ULONG fdt32_to_cpu(ULONG v)
+{
+    return ((v & 0x000000ffUL) << 24) | ((v & 0x0000ff00UL) << 8)
+         | ((v & 0x00ff0000UL) >> 8)  | ((v & 0xff000000UL) >> 24);
+}
+
+/* Walk a flattened device tree's structure block looking for a
+ * "bootargs" property (expected under /chosen, but this looks for it
+ * anywhere, which is simpler and harmless).  Returns the NUL terminated
+ * command line string, or NULL if there is none. */
+static const char *fdt_find_bootargs(const struct fdt_header *fdt)
+{
+    const UBYTE *cur, *end, *strings_base;
+
+    if (fdt32_to_cpu(fdt->magic) != FDT_MAGIC)
+        return NULL;
+
+    cur = (const UBYTE *)fdt + fdt32_to_cpu(fdt->off_dt_struct);
+    end = (const UBYTE *)fdt + fdt32_to_cpu(fdt->totalsize);
+    strings_base = (const UBYTE *)fdt + fdt32_to_cpu(fdt->off_dt_strings);
+
+    while (cur + 4 <= end)
+    {
+        ULONG token = fdt32_to_cpu(*(const ULONG *)cur);
+        cur += 4;
+
+        switch (token)
+        {
+        case FDT_BEGIN_NODE:
+            /* NUL terminated unit name, then pad to a 4 byte boundary */
+            while (cur < end && *cur)
+                cur++;
+            cur++;
+            cur = (const UBYTE *)(((ULONG)cur + 3) & ~3UL);
+            break;
+
+        case FDT_END_NODE:
+        case FDT_NOP:
+            break;
+
+        case FDT_PROP:
+        {
+            ULONG len, nameoff;
+            const char *propname;
+
+            if (cur + 8 > end)
+                return NULL;
+            len = fdt32_to_cpu(*(const ULONG *)cur);
+            cur += 4;
+            nameoff = fdt32_to_cpu(*(const ULONG *)cur);
+            cur += 4;
+            propname = (const char *)(strings_base + nameoff);
+
+            if (strcmp(propname, "bootargs") == 0)
+                return (const char *)cur;
+
+            cur += len;
+            cur = (const UBYTE *)(((ULONG)cur + 3) & ~3UL);
+            break;
+        }
+
+        case FDT_END:
+            return NULL;
+
+        default:
+            /* malformed structure block: bail out rather than loop
+             * forever on a token we don't recognize */
+            return NULL;
+        }
+    }
+    return NULL;
+}
+
+/* ---- command line parsing ---- */
+
+/* Two letter country codes recognized on the command line.  Must match
+ * COUNTRIES in country.mk: every multi-language image supports exactly
+ * this set of countries at run time (see bios/ctables.h). */
+static const struct {
+    const char *name;
+    int country;
+} country_names[] = {
+    { "us", COUNTRY_US },
+    { "de", COUNTRY_DE },
+    { "fr", COUNTRY_FR },
+    { "cz", COUNTRY_CZ },
+    { "gr", COUNTRY_GR },
+    { "es", COUNTRY_ES },
+    { "fi", COUNTRY_FI },
+    { "sg", COUNTRY_SG },
+    { "ru", COUNTRY_RU },
+    { "it", COUNTRY_IT },
+    { "uk", COUNTRY_UK },
+    { "no", COUNTRY_NO },
+    { "se", COUNTRY_SE },
+};
+
+#define LANG_PARAM      "ptos.lang="
+#define LANG_PARAM_LEN  (sizeof(LANG_PARAM) - 1)
+
+/* Find "ptos.lang=xx" in a kernel-style, space separated command line
+ * and return the matching COUNTRY_xx code, or -1 if the parameter is
+ * absent or does not name a recognized country. */
+static int parse_lang_param(const char *cmdline)
+{
+    const char *p = cmdline;
+
+    if (!p)
+        return -1;
+
+    while (*p)
+    {
+        if (strncmp(p, LANG_PARAM, LANG_PARAM_LEN) == 0)
+        {
+            const char *value = p + LANG_PARAM_LEN;
+            size_t i;
+
+            for (i = 0; i < ARRAY_SIZE(country_names); i++)
+            {
+                const char *name = country_names[i].name;
+                size_t namelen = strlen(name);
+
+                if (strncasecmp(value, name, namelen) == 0
+                    && (value[namelen] == '\0' || value[namelen] == ' '))
+                {
+                    return country_names[i].country;
+                }
+            }
+            return -1;
+        }
+
+        /* skip to the next whitespace separated token */
+        while (*p && *p != ' ')
+            p++;
+        while (*p == ' ')
+            p++;
+    }
+    return -1;
+}
+
+int bootargs_get_country(void)
+{
+    ULONG ptr = arm_boot_regs.atags;
+    const ULONG *magic;
+    const char *cmdline;
+
+    if (!ptr)
+        return -1;
+
+    magic = (const ULONG *)ptr;
+    if (fdt32_to_cpu(*magic) == FDT_MAGIC)
+        cmdline = fdt_find_bootargs((const struct fdt_header *)ptr);
+    else if (*magic == ATAG_CORE)
+        cmdline = atag_find_cmdline((const struct atag_header *)ptr);
+    else
+        cmdline = NULL;
+
+    return parse_lang_param(cmdline);
+}
+
+#endif /* CONF_WITH_BOOTARGS_LANG */

--- a/bios/bootargs.c
+++ b/bios/bootargs.c
@@ -240,17 +240,22 @@ static int parse_lang_param(const char *cmdline)
 int bootargs_get_country(void)
 {
     ULONG ptr = arm_boot_regs.atags;
-    const ULONG *magic;
+    const ULONG *fdt_magic;
+    const struct atag_header *first_tag;
     const char *cmdline;
 
     if (!ptr)
         return -1;
 
-    magic = (const ULONG *)ptr;
-    if (fdt32_to_cpu(*magic) == FDT_MAGIC)
+    /* An FDT starts with a magic word; an ATAG list starts with the
+     * ATAG_CORE record's {size,tag} header, tag second -- check that,
+     * not the size word first. */
+    fdt_magic = (const ULONG *)ptr;
+    first_tag = (const struct atag_header *)ptr;
+    if (fdt32_to_cpu(*fdt_magic) == FDT_MAGIC)
         cmdline = fdt_find_bootargs((const struct fdt_header *)ptr);
-    else if (*magic == ATAG_CORE)
-        cmdline = atag_find_cmdline((const struct atag_header *)ptr);
+    else if (first_tag->tag == ATAG_CORE)
+        cmdline = atag_find_cmdline(first_tag);
     else
         cmdline = NULL;
 

--- a/bios/bootargs.c
+++ b/bios/bootargs.c
@@ -109,14 +109,24 @@ static ULONG fdt32_to_cpu(ULONG v)
  * command line string, or NULL if there is none. */
 static const char *fdt_find_bootargs(const struct fdt_header *fdt)
 {
-    const UBYTE *cur, *end, *strings_base;
+    const UBYTE *cur, *end, *strings_base, *strings_end;
+    ULONG totalsize, off_struct, off_strings, size_strings;
 
     if (fdt32_to_cpu(fdt->magic) != FDT_MAGIC)
         return NULL;
 
-    cur = (const UBYTE *)fdt + fdt32_to_cpu(fdt->off_dt_struct);
-    end = (const UBYTE *)fdt + fdt32_to_cpu(fdt->totalsize);
-    strings_base = (const UBYTE *)fdt + fdt32_to_cpu(fdt->off_dt_strings);
+    totalsize = fdt32_to_cpu(fdt->totalsize);
+    off_struct = fdt32_to_cpu(fdt->off_dt_struct);
+    off_strings = fdt32_to_cpu(fdt->off_dt_strings);
+    size_strings = fdt32_to_cpu(fdt->size_dt_strings);
+
+    if (off_struct >= totalsize || off_strings >= totalsize || off_strings + size_strings > totalsize)
+        return NULL;
+
+    end = (const UBYTE *)fdt + totalsize;
+    cur = (const UBYTE *)fdt + off_struct;
+    strings_base = (const UBYTE *)fdt + off_strings;
+    strings_end = strings_base + size_strings;
 
     while (cur + 4 <= end)
     {

--- a/bios/bootargs.h
+++ b/bios/bootargs.h
@@ -1,0 +1,29 @@
+/*
+ * bootargs.h - country/keyboard override parsed from the ARM boot
+ * command line, for machines with CONF_MULTILANG but no NVRAM to store
+ * the setting in (see bios/country.c's detect_akp()).
+ *
+ * Copyright (C) 2026 The EmuTOS development team
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef BOOTARGS_H
+#define BOOTARGS_H
+
+#if CONF_WITH_BOOTARGS_LANG
+
+/*
+ * Look for a "ptos.lang=xx" parameter in the ARM boot loader's command
+ * line -- an ATAG_CMDLINE record, or an FDT /chosen/bootargs property,
+ * whichever arm_boot_regs.atags actually points to (see
+ * include/arch/arm/arm_boot.h) -- and return the matching COUNTRY_xx
+ * code from ctrycodes.h.  Returns -1 if there is no boot command line,
+ * or it does not name a country code recognized in country.mk.
+ */
+int bootargs_get_country(void);
+
+#endif /* CONF_WITH_BOOTARGS_LANG */
+
+#endif /* BOOTARGS_H */

--- a/bios/build.mk
+++ b/bios/build.mk
@@ -20,7 +20,7 @@ obj-y += memory.o processor.o intmask.o vectors.o bios.o xbios.o acsi.o biosmem.
 	 dma.o dmasound.o floppy.o font.o ide.o ikbd.o initinfo.o kprint.o \
 	 lineainit.o machine.o mfp.o midi.o mouse.o nvram.o panicasm.o \
 	 parport.o screen.o serport.o sound.o videl.o vt52.o xhdi.o delay.o \
-	 sd.o memory2.o bootparams.o scsi.o
+	 sd.o memory2.o bootparams.o bootargs.o scsi.o
 
 # screen_mode_desc_valid() (screen_mode.c) has exactly one caller,
 # vdi_backend_select() (vdi/vdi_backend.c), which only exists when the VDI

--- a/bios/country.c
+++ b/bios/country.c
@@ -21,6 +21,7 @@
 #include "nvram.h"
 #include "tosvars.h"
 #include "header.h"
+#include "bootargs.h"
 
 /*
  * country tables - we define the data structures here, then include the
@@ -140,7 +141,11 @@ static int get_charset_index(void)
  * the default values are taken from os_conf;
  *
  * if configured for multilanguage and NVRAM, and NVRAM is readable,
- * we override the defaults with the values from NVRAM
+ * we override the defaults with the values from NVRAM;
+ *
+ * if configured for multilanguage and there is no NVRAM (every ARM
+ * machine), we instead look for a "ptos.lang=xx" parameter on the boot
+ * loader's command line (see bios/bootargs.c)
  */
 void detect_akp(void)
 {
@@ -158,6 +163,18 @@ void detect_akp(void)
             /* Override with the NVRAM settings */
             country = buf[0];
             keyboard = buf[1];
+        }
+    }
+#endif
+
+#if CONF_WITH_BOOTARGS_LANG && CONF_MULTILANG
+    {
+        int override = bootargs_get_country();
+        if (override >= 0)
+        {
+            /* Override with the boot command line settings */
+            country = override;
+            keyboard = override;
         }
     }
 #endif

--- a/bios/machine/raspi/startup.S
+++ b/bios/machine/raspi/startup.S
@@ -119,8 +119,9 @@ _main:
     /*
      * The boot loader hands us r0 = 0, r1 = the ARM Linux machine type and
      * r2 = the address of the ATAG list, or of a flattened device tree when
-     * the firmware built one.  Nothing consumes them yet, but r0-r2 are
-     * reused a few instructions below, so save them while they still mean
+     * the firmware built one.  bios/bootargs.c reads this to recognize a
+     * "ptos.lang=xx" parameter on the command line.  r0-r2 are reused a
+     * few instructions below, so save them while they still mean
      * something.  Note that QEMU started with -bios does not set them up at
      * all, so a reader must not assume the pointer is valid.
      */
@@ -431,7 +432,8 @@ _start_in_hyp: .ds.l 1
 /*
  * r0, r1 and r2 as saved at the top of _main.  This is BSS, so like
  * _start_in_hyp above it has to be carried across the bzero() in
- * raspi_vcmem_init().  The layout matches arm_boot_regs_t in raspi_io.h.
+ * raspi_vcmem_init().  The layout matches arm_boot_regs_t in
+ * include/arch/arm/arm_boot.h.
  */
 .global _arm_boot_regs
 _arm_boot_regs: .ds.l 3

--- a/bios/machine/virt-arm/startup.S
+++ b/bios/machine/virt-arm/startup.S
@@ -93,6 +93,21 @@ os_dummy:
  */
 .balign 4
 _main:
+    /*
+     * The boot loader hands us r0 = 0, r1 = the ARM Linux machine type
+     * (or 0xffffffff for "use the device tree") and r2 = the address of
+     * the ATAG list or of a flattened device tree, per the standard ARM
+     * Linux boot protocol -- see bios/machine/raspi/startup.S, which
+     * does the same thing.  r0-r2 are needed for the MMU bring-up call
+     * below and are not preserved across it, so stash them in
+     * callee-saved registers (AAPCS guarantees _virt_uart0_init() and
+     * _virt_mmu_bootstrap() leave r8-r10 alone) until BSS has been
+     * cleared and arm_boot_regs can actually be written to.
+     */
+    mov r8, r0
+    mov r9, r1
+    mov r10, r2
+
     ldr sp, =0x47ff0000
     bl  _virt_uart0_init
     adr r4, hello_msg_phys     /* PC-relative: correct at the physical PC we're
@@ -160,6 +175,15 @@ virt_arm_post_mmu:
     str r2, [r0], #4
     b   1b
 2:
+
+    /*
+     * Now that BSS is cleared (arm_boot_regs lives there, like every
+     * other global) and virtual addressing is live, store the boot
+     * loader registers saved in r8-r10 above.  Mirrors
+     * bios/machine/raspi/startup.S.
+     */
+    ldr r3, =_arm_boot_regs
+    stmia r3, {r8-r10}
 
     /*
      * Install the exception vector table above.  Nothing has touched VBAR
@@ -296,3 +320,15 @@ _arm_dispatch_fiq:
  * at the top of _main), so it is always 0. */
     .globl _start_in_hyp
 _start_in_hyp: .word 0
+
+/*
+ * r0, r1 and r2 as saved near the top of _main.  This is BSS, so it is
+ * cleared by the loop above _before_ _main stores into it (unlike
+ * bios/machine/raspi/startup.S, which has to preserve it across a
+ * bzero() called much later from C).  The layout matches arm_boot_regs_t
+ * in include/arch/arm/arm_boot.h.
+ */
+.bss
+.balign 4
+.global _arm_boot_regs
+_arm_boot_regs: .ds.l 3

--- a/doc/country.txt
+++ b/doc/country.txt
@@ -76,6 +76,47 @@ See in bios.c:
 Here, function get_lang_name() is the method from country.c to obtain
 the language name.
 
+Overriding at boot time on ARM (no NVRAM)
+------------------------------------------
+
+CONF_WITH_NVRAM depends on CONF_ATARI_HARDWARE, so it is never set on
+the Raspberry Pi or on QEMU's ARM 'virt' machine: those machines have
+no NVRAM at all, so a multi-language image built for them normally has
+no way to override the country/keyboard baked in as the COUNTRY
+Makefile variable, short of rebuilding.
+
+CONF_WITH_BOOTARGS_LANG (bios/Kconfig, on by default for those
+machines) adds a second override source that does not need NVRAM: a
+"ptos.lang=xx" parameter on the ARM boot loader's command line, where
+xx is one of the two-letter country codes in country.mk (e.g. "de",
+"fr", "uk" -- case insensitive). bios/bootargs.c reads it from
+whichever boot-info format the boot loader actually used -- a classic
+ATAG list, or a flattened device tree's /chosen/bootargs property --
+and detect_akp() (bios/country.c) applies it exactly the way it
+applies an NVRAM override, just from a different source.
+
+To set it:
+
+- on real Raspberry Pi hardware, add it to cmdline.txt on the boot
+  partition, e.g.:
+
+    ptos.lang=de
+
+- under QEMU, pass it with -append, e.g.:
+
+    qemu-system-arm -M raspi1ap -kernel kernel.img -append "ptos.lang=de"
+
+  Note this needs -kernel, not the -bios invocation documented
+  elsewhere for this OS (doc/install.txt, the ptos-smoketest skill):
+  QEMU only builds ATAG/FDT boot info for a kernel loaded with
+  -kernel, and only for the QEMU ARM 'virt' machine does that boot
+  info reliably reach the guest; on the Raspberry Pi machine models,
+  it needs a raw (non-ELF) kernel image specifically -- loading the
+  same image as an ELF file gets no boot info passed at all, same as
+  -bios. With no "ptos.lang=" parameter recognized (or no boot info
+  at all, as with -bios), the country baked in at build time is used,
+  same as always.
+
 New country check list
 ----------------------
 
@@ -130,5 +171,6 @@ bios/ctables.h - table from country.mk usable from C code
 bios/header.h - contains the default country for the TOS header
 bios/keyb_xx.h - keyboard layout for keyboard 'xx'
 bios/fnt_xx_*.c - fonts for charset 'xx'
+bios/bootargs.c - ARM boot command line country/keyboard override (no NVRAM)
 bios/country.h - defines for keyboard and charset names
 bios/ctrycodes.h - defines for country names

--- a/doc/country.txt
+++ b/doc/country.txt
@@ -28,7 +28,7 @@ Where is it in the code
   bios/ctrycodes.h
 
 - language: this is covered by the 'nls' stuff, in files
-  util/langs.[ch], util/nls.c, util/nlsasm.S
+  util/langs.h, util/nls.c
 
 - keyboard:
   bios/country.h holds #defines for the keyboard codes;
@@ -102,20 +102,46 @@ To set it:
 
     ptos.lang=de
 
-- under QEMU, pass it with -append, e.g.:
+- under QEMU: as of this writing, there is no known invocation that
+  both boots pTOS successfully AND delivers -append to it. This was
+  checked empirically, not assumed; do not follow older advice to use
+  "-kernel kernel.img" (the raw Raspberry Pi image) -- it does not work:
 
-    qemu-system-arm -M raspi1ap -kernel kernel.img -append "ptos.lang=de"
+    - -bios kernel7.img (the normal, documented way to run this OS on
+      the Raspberry Pi machine models -- doc/install.txt, the
+      ptos-smoketest skill) boots correctly, but QEMU rejects -append
+      outright with this loader.
 
-  Note this needs -kernel, not the -bios invocation documented
-  elsewhere for this OS (doc/install.txt, the ptos-smoketest skill):
-  QEMU only builds ATAG/FDT boot info for a kernel loaded with
-  -kernel, and only for the QEMU ARM 'virt' machine does that boot
-  info reliably reach the guest; on the Raspberry Pi machine models,
-  it needs a raw (non-ELF) kernel image specifically -- loading the
-  same image as an ELF file gets no boot info passed at all, same as
-  -bios. With no "ptos.lang=" parameter recognized (or no boot info
-  at all, as with -bios), the country baked in at build time is used,
-  same as always.
+    - -kernel emutos.elf (the ELF build, the only invocation that
+      exists for the QEMU ARM 'virt' machine) also boots correctly,
+      but -append has no effect: arm_boot_regs.atags comes back zero,
+      same as with -bios. This applies to both the Raspberry Pi and
+      'virt' machine models.
+
+    - -kernel kernel7.img (the raw, non-ELF Raspberry Pi image) is the
+      only invocation that actually populates arm_boot_regs.atags with
+      real boot info, confirming bios/bootargs.c's ATAG parsing works
+      end to end -- but QEMU's raw-kernel loader expects the Linux
+      "zImage" format (a magic header, self-relocating code), which
+      kernel7.img is not (it follows the real Raspberry Pi GPU
+      firmware's loading convention instead, which -bios matches).
+      QEMU computes a bogus load address from it and jumps into
+      unmapped memory before any pTOS code runs at all. This is a gap
+      in QEMU's raw-image loading heuristics, not a bug introduced by
+      CONF_WITH_BOOTARGS_LANG, and it reproduces with -append entirely
+      absent from the command line.
+
+  bios/bootargs.c was instead verified by compiling it standalone on
+  the host and feeding it the real ATAG and FDT bytes QEMU generates
+  for "ptos.lang=de" (captured via -machine dumpdtb= and a minimal
+  standalone test binary) -- this caught and fixed a real bug in the
+  ATAG magic check before it shipped. A real Raspberry Pi should work
+  as described above, since that is the boot path bios/bootargs.c was
+  written against; this has not been confirmed on physical hardware.
+
+  With no "ptos.lang=" parameter recognized (or no boot info at all,
+  as with every currently working QEMU invocation), the country baked
+  in at build time is used, same as always.
 
 New country check list
 ----------------------

--- a/include/arch/arm/arm_boot.h
+++ b/include/arch/arm/arm_boot.h
@@ -1,0 +1,39 @@
+/*
+ * arm_boot.h - the boot loader registers as ARM startup code found them
+ *
+ * Copyright (C) 2026 The EmuTOS development team
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef ARM_BOOT_H
+#define ARM_BOOT_H
+
+#if defined(MACHINE_RPI) || defined(MACHINE_VIRT_ARM)
+
+#include "portab.h"
+
+/*
+ * Registers as they were handed to us by the boot loader: r0 is zero, r1
+ * is the ARM Linux machine type (or 0xffffffff, meaning "ignore this, use
+ * the device tree instead") and r2 points at the ATAG list or at a
+ * flattened device tree, per the standard 32-bit ARM Linux boot protocol.
+ * Startup code saves them within the first few instructions after entry,
+ * before the registers are needed for anything else -- see
+ * bios/machine/raspi/startup.S and bios/machine/virt-arm/startup.S.
+ *
+ * QEMU started with -bios (the invocation that actually boots this OS)
+ * does not set these up at all, so a reader must not assume the pointer
+ * is valid; a bare-metal boot loader or real hardware may not either.
+ */
+typedef struct {
+    ULONG r0;
+    ULONG machine_type;
+    ULONG atags;
+} arm_boot_regs_t;
+
+extern arm_boot_regs_t arm_boot_regs;
+
+#endif /* MACHINE_RPI || MACHINE_VIRT_ARM */
+#endif /* ARM_BOOT_H */

--- a/include/raspi_io.h
+++ b/include/raspi_io.h
@@ -12,6 +12,8 @@
 
 #ifdef MACHINE_RPI
 
+#include "arm_boot.h"
+
 #define GPU_L2_CACHE_ENABLED
 
 #define GPU_IO_BASE         0x7e000000
@@ -49,20 +51,6 @@ typedef struct {
 extern raspi_board_t raspi_board;
 
 void raspi_board_init(void);
-
-/*
- * Registers as they were handed to us by the boot loader: r0 is zero, r1
- * is the ARM Linux machine type and r2 points at the ATAG list or at a
- * flattened device tree.  Nothing reads them yet, but they only exist for
- * the first few instructions of startup.S, so they are saved there.
- */
-typedef struct {
-    ULONG r0;
-    ULONG machine_type;
-    ULONG atags;
-} arm_boot_regs_t;
-
-extern arm_boot_regs_t arm_boot_regs;
 
 #define ARM_IO_BASE     (raspi_board.io_base)
 #define ARM_IO_END      (ARM_IO_BASE + 0xFFFFFF)


### PR DESCRIPTION
Fixes #161

Adds a way to select the country/keyboard for multi-language (`CONF_MULTILANG`) images on hardware without NVRAM (every ARM/Raspberry Pi target), by parsing a parameter off the boot command line the firmware already hands pTOS — currently captured in `arm_boot_regs.atags` but never read. See #161 for the full scope.

