### PR TITLE
Add USB HID boot-protocol keyboard support

### DIFF
--- a/bios/arch/arm/vectors.c
+++ b/bios/arch/arm/vectors.c
@@ -108,6 +108,7 @@ void int_vbl(void)
 
 #if CONF_WITH_USB
 extern void usb_mouse_timerc (void);
+extern void usb_keyboard_timerc (void);
 #endif
 
 // ==== Timer C interrupt handler ============================================
@@ -125,6 +126,7 @@ void int_timerc(void)
 #       endif
 #       if CONF_WITH_USB
             usb_mouse_timerc();
+            usb_keyboard_timerc();
 #       endif
 
         // Fake vbl interrupt every 4 timer_c calls (50Hz)

--- a/usb/build.mk
+++ b/usb/build.mk
@@ -5,7 +5,7 @@
 # BIOS private headers; see usb_copts in the top level Makefile.
 #
 
-obj-y += usb.o ucd.o udd.o usb_api.o usb_hub.o udd_mouse.o
+obj-y += usb.o ucd.o udd.o usb_api.o usb_hub.o udd_mouse.o udd_keyboard.o
 
 obj-$(CONF_WITH_USB_DWC2) += ucd_dwc2.o
 obj-$(CONF_WITH_USB_XHCI) += ucd_xhci.o

--- a/usb/udd_keyboard.c
+++ b/usb/udd_keyboard.c
@@ -126,6 +126,35 @@ keyboard_disconnect (struct usb_device *dev)
 {
     if (dev == kbd_data.pusb_dev)
     {
+        /* Synthesize releases for anything still held, so an unplug
+         * mid-keypress can't leave a modifier (Shift/Ctrl/Alt) latched
+         * or a key auto-repeating forever from the AES's point of view --
+         * it never sees a final report telling it those went up. */
+        int i;
+
+        for (i = 0; i < 6; i++)
+        {
+            UBYTE key = kbd_data.keys[i];
+            if (key && key < USB_KEYTBL_SIZE)
+            {
+                UBYTE scancode = usb_keytbl[key];
+                if (scancode)
+                    kbd_int (scancode | KEY_RELEASED);
+            }
+        }
+
+        for (i = 0; i < 8; i++)
+        {
+            if (kbd_data.modifier & (1 << i))
+            {
+                UBYTE scancode = usb_modtbl[i];
+                if (scancode)
+                    kbd_int (scancode | KEY_RELEASED);
+            }
+        }
+
+        kbd_data.modifier = 0;
+        memset (kbd_data.keys, 0, sizeof (kbd_data.keys));
         kbd_data.pusb_dev = NULL;
     }
 
@@ -177,6 +206,20 @@ void usb_keyboard_timerc (void)
 
         if ((r != 0) || (actlen < 8))
             return;
+
+        /* Usages 0x01-0x03 (ErrorRollOver/POSTFail/ErrorUndefined) mean
+         * the device can't report its actual key state this poll (e.g.
+         * more than 6 keys held at once) -- every array slot is filled
+         * with one of these instead of real usages. Treating them as
+         * real keycodes would make every currently-held key look
+         * released (it won't be found in this bogus array) and then
+         * "pressed" again once real reports resume. Skip the report
+         * instead, leaving the last known-good state in place. */
+        for (i = 0; i < 6; i++)
+        {
+            if (report[2 + i] >= 1 && report[2 + i] <= 3)
+                return;
+        }
 
         kbd_data.new_modifier = report[0];
         for (i = 0; i < 6; i++)
@@ -291,8 +334,9 @@ keyboard_probe (struct usb_device *dev, unsigned int ifnum)
         return -1;
     }
 
-    if ((ep_desc->bmAttributes &
-         USB_ENDPOINT_XFERTYPE_MASK) == USB_ENDPOINT_XFER_INT)
+    if (((ep_desc->bmAttributes &
+          USB_ENDPOINT_XFERTYPE_MASK) == USB_ENDPOINT_XFER_INT) &&
+        (ep_desc->bEndpointAddress & USB_ENDPOINT_DIR_MASK) == USB_DIR_IN)
     {
         kbd_data.ep_int =
             ep_desc->bEndpointAddress & USB_ENDPOINT_NUMBER_MASK;

--- a/usb/udd_keyboard.c
+++ b/usb/udd_keyboard.c
@@ -1,0 +1,343 @@
+#include "usb_global.h"
+
+#include "usb.h"
+#include "usb_api.h"
+#include "ikbd.h"               /* for kbd_int() */
+
+/*
+ * USB HID boot-keyboard class driver.
+ *
+ * Modeled on udd_mouse.c: probes for a HID boot-protocol keyboard
+ * interface, then polls its interrupt endpoint from the raspi timer-C
+ * tick (see usb_keyboard_timerc() below, hooked up next to
+ * usb_mouse_timerc() in bios/arch/arm/vectors.c).
+ */
+
+static long keyboard_ioctl (struct uddif *, short, long);
+static long keyboard_disconnect (struct usb_device *dev);
+static long keyboard_probe (struct usb_device *dev, unsigned int ifnum);
+
+static char lname[] = "USB keyboard class driver\0";
+
+static struct uddif keyboard_uif = {
+    0,                          /* *next */
+    USB_API_VERSION,            /* API */
+    USB_DEVICE,                 /* class */
+    lname,                      /* lname */
+    "keyboard",                 /* name */
+    0,                          /* unit */
+    0,                          /* flags */
+    keyboard_probe,             /* probe */
+    keyboard_disconnect,        /* disconnect */
+    0,                          /* resrvd1 */
+    keyboard_ioctl,             /* ioctl */
+    0,                          /* resrvd2 */
+};
+
+struct kbd_data
+{
+    struct usb_device *pusb_dev;        /* this usb_device */
+    unsigned char ep_int;       /* interrupt endpoint */
+    unsigned long irqpipe;      /* pipe for polling */
+    unsigned char irqmaxp;      /* max packet for irq pipe */
+    unsigned char irqinterval;  /* interval for irq pipe */
+    UBYTE modifier;              /* last modifier byte (boot report byte 0) */
+    UBYTE keys[6];                /* last set of up to 6 pressed key usages */
+    UBYTE new_modifier;
+    UBYTE new_keys[6];
+};
+
+static struct kbd_data kbd_data;
+
+/*
+ * USB HID keyboard usage ID (Usage Page 0x07) -> Atari IKBD scancode.
+ * Index 0 means "no scancode for this usage" (also covers the "error
+ * rollover" usages 0x01-0x03 the boot report uses to signal more keys
+ * are down than it can report). Atari's IKBD scancodes are numbered the
+ * same as the IBM PC XT Scan Code Set 1 (confirmed against
+ * bios/keyb_us.h and reused by bios/virtio_input_keytbl.c), but HID
+ * usage IDs use their own, alphabetic-for-letters numbering, so unlike
+ * the evdev table this needs an explicit entry per key rather than an
+ * identity range.
+ */
+#define USB_KEYTBL_SIZE 0x66
+
+static const UBYTE usb_keytbl[USB_KEYTBL_SIZE] =
+{
+    /* 0x00-0x03: no key / rollover error */
+    0, 0, 0, 0,
+    /* 0x04-0x1d: a-z */
+    30, 48, 46, 32, 18, 33, 34, 35, 23, 36,
+    37, 38, 50, 49, 24, 25, 16, 19, 31, 20,
+    22, 47, 17, 45, 21, 44,
+    /* 0x1e-0x27: 1-9, 0 */
+    2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+    /* 0x28-0x2c: Enter, Escape, Backspace, Tab, Space */
+    28, 1, 14, 15, 57,
+    /* 0x2d-0x38: - = [ ] \ (Non-US #) ; ' ` , . / */
+    12, 13, 26, 27, 43, 0, 39, 40, 41, 51,
+    52, 53,
+    /* 0x39: CapsLock */
+    58,
+    /* 0x3a-0x43: F1-F10 */
+    59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
+    /* 0x44-0x45: F11, F12 -- no Atari scancode, unmapped */
+    0, 0,
+    /* 0x46-0x48: PrintScreen, ScrollLock, Pause -- unmapped */
+    0, 0, 0,
+    /* 0x49-0x52: Insert, Home, PageUp, Delete, End, PageDown,
+     *            Right, Left, Down, Up */
+    82, 71, 73, 83, 79, 81, 77, 75, 80, 72,
+    /* 0x53-0x65: NumLock, keypad and Application key -- unmapped
+     * (the ST numeric keypad has its own separate scancodes not
+     * reachable from a PC keyboard's keypad block) */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+/*
+ * Modifier byte bits (boot report byte 0) -> Atari scancode. The ST
+ * has one physical Ctrl and one Alt key, so left/right variants both
+ * map to the same scancode (matches bios/virtio_input_keytbl.c's
+ * handling of the same asymmetry). Left/Right GUI (Windows/Command)
+ * have no ST equivalent and are left unmapped.
+ */
+static const UBYTE usb_modtbl[8] =
+{
+    29,   /* bit 0: LCtrl  -> Ctrl   */
+    42,   /* bit 1: LShift -> LShift */
+    56,   /* bit 2: LAlt   -> Alt    */
+    0,    /* bit 3: LGui   -> (none) */
+    29,   /* bit 4: RCtrl  -> Ctrl   */
+    54,   /* bit 5: RShift -> RShift */
+    56,   /* bit 6: RAlt   -> Alt    */
+    0,    /* bit 7: RGui   -> (none) */
+};
+
+#define KEY_RELEASED 0x80
+
+static long keyboard_ioctl (struct uddif *u, short cmd, long arg)
+{
+    return E_OK;
+}
+
+static long
+keyboard_disconnect (struct usb_device *dev)
+{
+    if (dev == kbd_data.pusb_dev)
+    {
+        kbd_data.pusb_dev = NULL;
+    }
+
+    return 0;
+}
+
+static long
+usb_keyboard_irq (struct usb_device *dev)
+{
+    return 0;
+}
+
+/* TRUE if usage 'key' (nonzero) is present anywhere in the 6-entry array */
+static BOOL
+usb_keyboard_key_in(const UBYTE *keys, UBYTE key)
+{
+    int i;
+
+    if (!key)
+        return FALSE;
+
+    for (i = 0; i < 6; i++)
+    {
+        if (keys[i] == key)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+void usb_keyboard_timerc (void);
+void usb_keyboard_timerc (void)
+{
+    long actlen = 0;
+    long r;
+    UBYTE changed_mod;
+    int i;
+
+    if (kbd_data.pusb_dev == NULL)
+        return;
+
+    {
+        UBYTE report[8];
+
+        r = usb_bulk_msg (kbd_data.pusb_dev,
+                          kbd_data.irqpipe,
+                          report,
+                          kbd_data.irqmaxp > 8 ? 8 : kbd_data.irqmaxp,
+                          &actlen, USB_CNTL_TIMEOUT * 5, 1);
+
+        if ((r != 0) || (actlen < 8))
+            return;
+
+        kbd_data.new_modifier = report[0];
+        for (i = 0; i < 6; i++)
+            kbd_data.new_keys[i] = report[2 + i];
+    }
+
+    /* Released keys first, so a key that vanishes from one slot and
+     * reappears in another in the same report doesn't get treated as
+     * "still held" by the release/press ordering below. */
+    for (i = 0; i < 6; i++)
+    {
+        UBYTE key = kbd_data.keys[i];
+
+        if (key && key < USB_KEYTBL_SIZE &&
+            !usb_keyboard_key_in(kbd_data.new_keys, key))
+        {
+            UBYTE scancode = usb_keytbl[key];
+            if (scancode)
+                kbd_int (scancode | KEY_RELEASED);
+        }
+    }
+
+    changed_mod = kbd_data.modifier ^ kbd_data.new_modifier;
+    for (i = 0; i < 8; i++)
+    {
+        if ((changed_mod & (1 << i)) && !(kbd_data.new_modifier & (1 << i)))
+        {
+            UBYTE scancode = usb_modtbl[i];
+            if (scancode)
+                kbd_int (scancode | KEY_RELEASED);
+        }
+    }
+
+    for (i = 0; i < 8; i++)
+    {
+        if ((changed_mod & (1 << i)) && (kbd_data.new_modifier & (1 << i)))
+        {
+            UBYTE scancode = usb_modtbl[i];
+            if (scancode)
+                kbd_int (scancode);
+        }
+    }
+
+    for (i = 0; i < 6; i++)
+    {
+        UBYTE key = kbd_data.new_keys[i];
+
+        if (key && key < USB_KEYTBL_SIZE &&
+            !usb_keyboard_key_in(kbd_data.keys, key))
+        {
+            UBYTE scancode = usb_keytbl[key];
+            if (scancode)
+                kbd_int (scancode);
+        }
+    }
+
+    kbd_data.modifier = kbd_data.new_modifier;
+    for (i = 0; i < 6; i++)
+        kbd_data.keys[i] = kbd_data.new_keys[i];
+}
+
+static long
+keyboard_probe (struct usb_device *dev, unsigned int ifnum)
+{
+    struct usb_interface *iface;
+    struct usb_endpoint_descriptor *ep_desc;
+
+    /*
+     * Only one keyboard at a time
+     */
+    if (kbd_data.pusb_dev)
+    {
+        return -1;
+    }
+
+    if (dev == NULL)
+    {
+        return -1;
+    }
+
+    usb_disable_asynch (1);     /* asynch transfer not allowed */
+
+    iface = &dev->config.if_desc[ifnum];
+    if (!iface)
+    {
+        return -1;
+    }
+
+    if (iface->desc.bInterfaceClass != USB_CLASS_HID)
+    {
+        return -1;
+    }
+
+    if (iface->desc.bInterfaceSubClass != USB_SUB_HID_BOOT)
+    {
+        return -1;
+    }
+
+    if (iface->desc.bInterfaceProtocol != 1)   /* 1 = keyboard, 2 = mouse */
+    {
+        return -1;
+    }
+
+    if (iface->desc.bNumEndpoints != 1)
+    {
+        return -1;
+    }
+
+    ep_desc = &iface->ep_desc[0];
+    if (!ep_desc)
+    {
+        return -1;
+    }
+
+    if ((ep_desc->bmAttributes &
+         USB_ENDPOINT_XFERTYPE_MASK) == USB_ENDPOINT_XFER_INT)
+    {
+        kbd_data.ep_int =
+            ep_desc->bEndpointAddress & USB_ENDPOINT_NUMBER_MASK;
+        kbd_data.irqinterval = ep_desc->bInterval;
+    }
+    else
+    {
+        return -1;
+    }
+
+    kbd_data.pusb_dev = dev;
+
+    kbd_data.irqinterval =
+        (kbd_data.irqinterval > 0) ? kbd_data.irqinterval : 255;
+    kbd_data.irqpipe =
+        usb_rcvintpipe (kbd_data.pusb_dev, (long) kbd_data.ep_int);
+    kbd_data.irqmaxp = usb_maxpacket (dev, kbd_data.irqpipe);
+    dev->irq_handle = usb_keyboard_irq;
+    kbd_data.modifier = 0;
+    memset (kbd_data.keys, 0, sizeof (kbd_data.keys));
+    memset (kbd_data.new_keys, 0, sizeof (kbd_data.new_keys));
+
+    usb_set_protocol (dev, iface->desc.bInterfaceNumber, 0); /* boot */
+    usb_set_idle (dev, iface->desc.bInterfaceNumber, 0, 0);
+
+    KINFO (("%s: exit keyboard_probe success\n", __FILE__));
+
+    return 0;
+}
+
+int usb_keyboard_init (void);
+int usb_keyboard_init (void)
+{
+    long ret;
+
+    KINFO (("%s: enter init\n", __FILE__));
+
+    ret = udd_register (&keyboard_uif);
+
+    if (ret)
+    {
+        KINFO (("%s: udd register failed! %ld\n", __FILE__, ret));
+        return 1;
+    }
+
+    KINFO(("%s: udd register ok\n", __FILE__));
+    return 0;
+}

--- a/usb/udd_keyboard.c
+++ b/usb/udd_keyboard.c
@@ -126,12 +126,18 @@ keyboard_disconnect (struct usb_device *dev)
 {
     if (dev == kbd_data.pusb_dev)
     {
+        /* Clear pusb_dev first: usb_keyboard_timerc() (called from the
+         * Timer-C interrupt) gates purely on pusb_dev != NULL, so this
+         * stops it from polling a device that's being torn down before
+         * touching anything else in kbd_data. */
+        int i;
+
+        kbd_data.pusb_dev = NULL;
+
         /* Synthesize releases for anything still held, so an unplug
          * mid-keypress can't leave a modifier (Shift/Ctrl/Alt) latched
          * or a key auto-repeating forever from the AES's point of view --
          * it never sees a final report telling it those went up. */
-        int i;
-
         for (i = 0; i < 6; i++)
         {
             UBYTE key = kbd_data.keys[i];
@@ -155,7 +161,6 @@ keyboard_disconnect (struct usb_device *dev)
 
         kbd_data.modifier = 0;
         memset (kbd_data.keys, 0, sizeof (kbd_data.keys));
-        kbd_data.pusb_dev = NULL;
     }
 
     return 0;
@@ -347,12 +352,10 @@ keyboard_probe (struct usb_device *dev, unsigned int ifnum)
         return -1;
     }
 
-    kbd_data.pusb_dev = dev;
-
     kbd_data.irqinterval =
         (kbd_data.irqinterval > 0) ? kbd_data.irqinterval : 255;
     kbd_data.irqpipe =
-        usb_rcvintpipe (kbd_data.pusb_dev, (long) kbd_data.ep_int);
+        usb_rcvintpipe (dev, (long) kbd_data.ep_int);
     kbd_data.irqmaxp = usb_maxpacket (dev, kbd_data.irqpipe);
     dev->irq_handle = usb_keyboard_irq;
     kbd_data.modifier = 0;
@@ -361,6 +364,11 @@ keyboard_probe (struct usb_device *dev, unsigned int ifnum)
 
     usb_set_protocol (dev, iface->desc.bInterfaceNumber, 0); /* boot */
     usb_set_idle (dev, iface->desc.bInterfaceNumber, 0, 0);
+
+    /* Publish pusb_dev last: usb_keyboard_timerc() (Timer-C interrupt)
+     * gates purely on pusb_dev != NULL, so everything else above must
+     * already be valid by the time this becomes visible to it. */
+    kbd_data.pusb_dev = dev;
 
     KINFO (("%s: exit keyboard_probe success\n", __FILE__));
 

--- a/usb/usb.c
+++ b/usb/usb.c
@@ -51,6 +51,7 @@ static long asynch_allowed;
 extern void dwc2_init(void);
 #endif
 extern int usb_mouse_init(void);
+extern int usb_keyboard_init(void);
 
 /***************************************************************************
  * Init USB Device
@@ -82,6 +83,7 @@ void usb_init(void)
     xhci_init();
 #endif
     usb_mouse_init();
+    usb_keyboard_init();
 }
 
 /******************************************************************************
@@ -455,22 +457,22 @@ long usb_get_descriptor(struct usb_device *dev, unsigned char type,
  */
 long usb_get_configuration_len(struct usb_device *dev, long cfgno)
 {
-	long result;
-	unsigned char buffer[9];
-	struct usb_config_descriptor *config;
+    long result;
+    unsigned char buffer[9];
+    struct usb_config_descriptor *config;
 
-	config = (struct usb_config_descriptor *)&buffer[0];
-	result = usb_get_descriptor(dev, USB_DT_CONFIG, cfgno, buffer, 9);
-	if (result < 9) {
-		if (result < 0)
-			ALERT(("unable to get descriptor, error %lX\n",
-				dev->status));
-		else
-			ALERT(("config descriptor too short " \
-				"(expected %i, got %i)\n", 9, result));
-		return -1;
-	}
-	return le2cpu16(config->wTotalLength);
+    config = (struct usb_config_descriptor *)&buffer[0];
+    result = usb_get_descriptor(dev, USB_DT_CONFIG, cfgno, buffer, 9);
+    if (result < 9) {
+        if (result < 0)
+            ALERT(("unable to get descriptor, error %lX\n",
+                dev->status));
+        else
+            ALERT(("config descriptor too short " \
+                "(expected %i, got %i)\n", 9, result));
+        return -1;
+    }
+    return le2cpu16(config->wTotalLength);
 }
 
 /**********************************************************************
@@ -742,21 +744,21 @@ errout:
  */
 
 void usb_find_usb2_hub_address_port(struct usb_device *udev,
-			       uint8_t *hub_address, uint8_t *hub_port)
+                   uint8_t *hub_address, uint8_t *hub_port)
 {
-	/* Find out the nearest parent which is high speed */
-	while (udev->parent->parent != NULL)
-		if (udev->parent->speed != USB_SPEED_HIGH) {
-			udev = udev->parent;
-		} else {
-			*hub_address = udev->parent->devnum;
-			*hub_port = udev->portnr;
-			return;
-		}
+    /* Find out the nearest parent which is high speed */
+    while (udev->parent->parent != NULL)
+        if (udev->parent->speed != USB_SPEED_HIGH) {
+            udev = udev->parent;
+        } else {
+            *hub_address = udev->parent->devnum;
+            *hub_port = udev->portnr;
+            return;
+        }
 
-	KINFO(("Error: Cannot find high speed parent of usb-1 device\n"));
-	*hub_address = 0;
-	*hub_port = 0;
+    KINFO(("Error: Cannot find high speed parent of usb-1 device\n"));
+    *hub_address = 0;
+    *hub_port = 0;
 }
 
 
@@ -860,269 +862,269 @@ void usb_free_device(long dev_index)
 
 static int usb_hub_port_reset(struct usb_device *dev, struct usb_device *hub)
 {
-	return 0;
+    return 0;
 }
 
 static long get_descriptor_len(struct usb_device *dev, long len, long expect_len)
 {
-	struct usb_device_descriptor *desc;
-	unsigned char tmpbuf[USB_BUFSIZ];
-	long err;
+    struct usb_device_descriptor *desc;
+    unsigned char tmpbuf[USB_BUFSIZ];
+    long err;
 
-	desc = (struct usb_device_descriptor *)tmpbuf;
+    desc = (struct usb_device_descriptor *)tmpbuf;
 
-	err = usb_get_descriptor(dev, USB_DT_DEVICE, 0, desc, len);
-	if (err < expect_len) {
-		if (err < 0) {
-			ALERT(("unable to get device descriptor (error=%d)\n",
-				err));
-			return err;
-		} else {
-			ALERT(("USB device descriptor short read (expected %i, got %i)\n",
-				expect_len, err));
-			return -1;
-		}
-	}
-	memcpy(&dev->descriptor, tmpbuf, sizeof(dev->descriptor));
+    err = usb_get_descriptor(dev, USB_DT_DEVICE, 0, desc, len);
+    if (err < expect_len) {
+        if (err < 0) {
+            ALERT(("unable to get device descriptor (error=%d)\n",
+                err));
+            return err;
+        } else {
+            ALERT(("USB device descriptor short read (expected %i, got %i)\n",
+                expect_len, err));
+            return -1;
+        }
+    }
+    memcpy(&dev->descriptor, tmpbuf, sizeof(dev->descriptor));
 
-	return 0;
+    return 0;
 }
 
 static long usb_setup_descriptor(struct usb_device *dev, BOOL do_read)
 {
-	/*
-	 * This is a Windows scheme of initialization sequence, with double
-	 * reset of the device (Linux uses the same sequence)
-	 * Some equipment is said to work only with such init sequence; this
-	 * patch is based on the work by Alan Stern:
-	 * http://sourceforge.net/mailarchive/forum.php?
-	 * thread_id=5729457&forum_id=5398
-	 */
+    /*
+     * This is a Windows scheme of initialization sequence, with double
+     * reset of the device (Linux uses the same sequence)
+     * Some equipment is said to work only with such init sequence; this
+     * patch is based on the work by Alan Stern:
+     * http://sourceforge.net/mailarchive/forum.php?
+     * thread_id=5729457&forum_id=5398
+     */
 
-	/*
-	 * send 64-byte GET-DEVICE-DESCRIPTOR request.  Since the descriptor is
-	 * only 18 bytes long, this will terminate with a short packet.  But if
-	 * the maxpacket size is 8 or 16 the device may be waiting to transmit
-	 * some more, or keeps on retransmitting the 8 byte header.
-	 */
+    /*
+     * send 64-byte GET-DEVICE-DESCRIPTOR request.  Since the descriptor is
+     * only 18 bytes long, this will terminate with a short packet.  But if
+     * the maxpacket size is 8 or 16 the device may be waiting to transmit
+     * some more, or keeps on retransmitting the 8 byte header.
+     */
 
-	if (dev->speed == USB_SPEED_LOW) {
-		dev->descriptor.bMaxPacketSize0 = 8;
-		dev->maxpacketsize = PACKET_SIZE_8;
-	} else {
-		dev->descriptor.bMaxPacketSize0 = 64;
-		dev->maxpacketsize = PACKET_SIZE_64;
-	}
-	dev->epmaxpacketin[0] = dev->descriptor.bMaxPacketSize0;
-	dev->epmaxpacketout[0] = dev->descriptor.bMaxPacketSize0;
+    if (dev->speed == USB_SPEED_LOW) {
+        dev->descriptor.bMaxPacketSize0 = 8;
+        dev->maxpacketsize = PACKET_SIZE_8;
+    } else {
+        dev->descriptor.bMaxPacketSize0 = 64;
+        dev->maxpacketsize = PACKET_SIZE_64;
+    }
+    dev->epmaxpacketin[0] = dev->descriptor.bMaxPacketSize0;
+    dev->epmaxpacketout[0] = dev->descriptor.bMaxPacketSize0;
 
-	if (do_read && dev->speed == USB_SPEED_FULL) {
-		long err;
+    if (do_read && dev->speed == USB_SPEED_FULL) {
+        long err;
 
-		/*
-		 * Validate we've received only at least 8 bytes, not that
-		 * we've received the entire descriptor. The reasoning is:
-		 * - The code only uses fields in the first 8 bytes, so
-		 *   that's all we need to have fetched at this stage.
-		 * - The smallest maxpacket size is 8 bytes. Before we know
-		 *   the actual maxpacket the device uses, the USB controller
-		 *   may only accept a single packet. Consequently we are only
-		 *   guaranteed to receive 1 packet (at least 8 bytes) even in
-		 *   a non-error case.
-		 *
-		 * At least the DWC2 controller needs to be programmed with
-		 * the number of packets in addition to the number of bytes.
-		 * A request for 64 bytes of data with the maxpacket guessed
-		 * as 64 (above) yields a request for 1 packet.
-		 */
-		err = get_descriptor_len(dev, 64, 8);
-		if (err)
-			return err;
-	}
+        /*
+         * Validate we've received only at least 8 bytes, not that
+         * we've received the entire descriptor. The reasoning is:
+         * - The code only uses fields in the first 8 bytes, so
+         *   that's all we need to have fetched at this stage.
+         * - The smallest maxpacket size is 8 bytes. Before we know
+         *   the actual maxpacket the device uses, the USB controller
+         *   may only accept a single packet. Consequently we are only
+         *   guaranteed to receive 1 packet (at least 8 bytes) even in
+         *   a non-error case.
+         *
+         * At least the DWC2 controller needs to be programmed with
+         * the number of packets in addition to the number of bytes.
+         * A request for 64 bytes of data with the maxpacket guessed
+         * as 64 (above) yields a request for 1 packet.
+         */
+        err = get_descriptor_len(dev, 64, 8);
+        if (err)
+            return err;
+    }
 
-	dev->epmaxpacketin[0] = dev->descriptor.bMaxPacketSize0;
-	dev->epmaxpacketout[0] = dev->descriptor.bMaxPacketSize0;
-	switch (dev->descriptor.bMaxPacketSize0) {
-	case 8:
-		dev->maxpacketsize  = PACKET_SIZE_8;
-		break;
-	case 16:
-		dev->maxpacketsize = PACKET_SIZE_16;
-		break;
-	case 32:
-		dev->maxpacketsize = PACKET_SIZE_32;
-		break;
-	case 64:
-		dev->maxpacketsize = PACKET_SIZE_64;
-		break;
-	default:
-		ALERT(("%s: invalid max packet size\n", __func__));
-		return -1;
-	}
+    dev->epmaxpacketin[0] = dev->descriptor.bMaxPacketSize0;
+    dev->epmaxpacketout[0] = dev->descriptor.bMaxPacketSize0;
+    switch (dev->descriptor.bMaxPacketSize0) {
+    case 8:
+        dev->maxpacketsize  = PACKET_SIZE_8;
+        break;
+    case 16:
+        dev->maxpacketsize = PACKET_SIZE_16;
+        break;
+    case 32:
+        dev->maxpacketsize = PACKET_SIZE_32;
+        break;
+    case 64:
+        dev->maxpacketsize = PACKET_SIZE_64;
+        break;
+    default:
+        ALERT(("%s: invalid max packet size\n", __func__));
+        return -1;
+    }
 
-	return 0;
+    return 0;
 }
 
 static long usb_prepare_device(struct usb_device *dev, long addr, BOOL do_read,
-			      struct usb_device *parent)
+                  struct usb_device *parent)
 {
-	long err;
+    long err;
 
-	err = usb_setup_descriptor(dev, do_read);
+    err = usb_setup_descriptor(dev, do_read);
   ALERT(("usb_setup_descriptor -> %ld\n",err));
 
-	if (err)
+    if (err)
   {
     dev->devnum = addr;
-		return err;
+        return err;
   }
-	err = usb_hub_port_reset(dev, parent);
+    err = usb_hub_port_reset(dev, parent);
   ALERT(("usb_hub_port_reset -> %ld\n",err));
 
-	if (err)
-		return err;
+    if (err)
+        return err;
 
   dev->devnum = addr;
 
-	err = usb_set_address(dev); /* set address */
+    err = usb_set_address(dev); /* set address */
   ALERT(("usb_set_address -> %ld\n",err));
 
-	if (err < 0) {
-		ALERT(("\n      USB device not accepting new address " \
-			"(error=%lX)\n", dev->status));
-		return err;
-	}
+    if (err < 0) {
+        ALERT(("\n      USB device not accepting new address " \
+            "(error=%lX)\n", dev->status));
+        return err;
+    }
 
-	mdelay(10);	/* Let the SET_ADDRESS settle */
+    mdelay(10); /* Let the SET_ADDRESS settle */
 
-	/*
-	 * If we haven't read device descriptor before, read it here
-	 * after device is assigned an address. This is only applicable
-	 * to xHCI so far.
-	 */
-	if (!do_read) {
-		err = usb_setup_descriptor(dev, TRUE);
+    /*
+     * If we haven't read device descriptor before, read it here
+     * after device is assigned an address. This is only applicable
+     * to xHCI so far.
+     */
+    if (!do_read) {
+        err = usb_setup_descriptor(dev, TRUE);
     ALERT(("usb_setup_descriptor -> %ld\n",err));
-		if (err)
-			return err;
-	}
+        if (err)
+            return err;
+    }
 
-	return 0;
+    return 0;
 }
 
 long usb_select_config(struct usb_device *dev)
 {
   unsigned char tmpbuf[USB_BUFSIZ];
-	long err;
+    long err;
 
-	err = get_descriptor_len(dev, USB_DT_DEVICE_SIZE, USB_DT_DEVICE_SIZE);
-	if (err)
-		return err;
+    err = get_descriptor_len(dev, USB_DT_DEVICE_SIZE, USB_DT_DEVICE_SIZE);
+    if (err)
+        return err;
 
-	/* correct le values */
-	dev->descriptor.bcdUSB = le2cpu16(dev->descriptor.bcdUSB);
-	dev->descriptor.idVendor = le2cpu16(dev->descriptor.idVendor);
-	dev->descriptor.idProduct = le2cpu16(dev->descriptor.idProduct);
-	dev->descriptor.bcdDevice = le2cpu16(dev->descriptor.bcdDevice);
+    /* correct le values */
+    dev->descriptor.bcdUSB = le2cpu16(dev->descriptor.bcdUSB);
+    dev->descriptor.idVendor = le2cpu16(dev->descriptor.idVendor);
+    dev->descriptor.idProduct = le2cpu16(dev->descriptor.idProduct);
+    dev->descriptor.bcdDevice = le2cpu16(dev->descriptor.bcdDevice);
 
-	/*
-	 * Kingston DT Ultimate 32GB USB 3.0 seems to be extremely sensitive
-	 * about this first Get Descriptor request. If there are any other
-	 * requests in the first microframe, the stick crashes. Wait about
-	 * one microframe duration here (1mS for USB 1.x , 125uS for USB 2.0).
-	 */
-	mdelay(1);
+    /*
+     * Kingston DT Ultimate 32GB USB 3.0 seems to be extremely sensitive
+     * about this first Get Descriptor request. If there are any other
+     * requests in the first microframe, the stick crashes. Wait about
+     * one microframe duration here (1mS for USB 1.x , 125uS for USB 2.0).
+     */
+    mdelay(1);
 
-	/* only support for one config for now */
-	err = usb_get_configuration_len(dev, 0);
-	if (err >= 0) {
-		if (err >= USB_BUFSIZ)
-			err = -1;
-		else
-			err = usb_get_configuration_no(dev, 0, tmpbuf, err);
-	}
-	if (err < 0) {
-		ALERT(("usb_select_config: Cannot read configuration, " \
-		       "skipping device %04x:%04x\n",
-		       dev->descriptor.idVendor, dev->descriptor.idProduct));
-		return err;
-	}
-	usb_parse_config(dev, tmpbuf, 0);
-	usb_set_maxpacket(dev);
-	/*
-	 * we set the default configuration here
-	 * This seems premature. If the driver wants a different configuration
-	 * it will need to select itself.
-	 */
-	err = usb_set_configuration(dev, dev->config.desc.bConfigurationValue);
-	if (err < 0) {
-		ALERT(("failed to set default configuration " \
-			"len %d, status %lX\n", dev->act_len, dev->status));
-		return err;
-	}
+    /* only support for one config for now */
+    err = usb_get_configuration_len(dev, 0);
+    if (err >= 0) {
+        if (err >= USB_BUFSIZ)
+            err = -1;
+        else
+            err = usb_get_configuration_no(dev, 0, tmpbuf, err);
+    }
+    if (err < 0) {
+        ALERT(("usb_select_config: Cannot read configuration, " \
+               "skipping device %04x:%04x\n",
+               dev->descriptor.idVendor, dev->descriptor.idProduct));
+        return err;
+    }
+    usb_parse_config(dev, tmpbuf, 0);
+    usb_set_maxpacket(dev);
+    /*
+     * we set the default configuration here
+     * This seems premature. If the driver wants a different configuration
+     * it will need to select itself.
+     */
+    err = usb_set_configuration(dev, dev->config.desc.bConfigurationValue);
+    if (err < 0) {
+        ALERT(("failed to set default configuration " \
+            "len %d, status %lX\n", dev->act_len, dev->status));
+        return err;
+    }
 
-	/*
-	 * Wait until the Set Configuration request gets processed by the
-	 * device. This is required by at least SanDisk Cruzer Pop USB 2.0
-	 * and Kingston DT Ultimate 32GB USB 3.0 on DWC2 OTG controller.
-	 */
-	mdelay(10);
+    /*
+     * Wait until the Set Configuration request gets processed by the
+     * device. This is required by at least SanDisk Cruzer Pop USB 2.0
+     * and Kingston DT Ultimate 32GB USB 3.0 on DWC2 OTG controller.
+     */
+    mdelay(10);
 
-	KDEBUG(("new device strings: Mfr=%d, Product=%d, SerialNumber=%d\n",
-	      dev->descriptor.iManufacturer, dev->descriptor.iProduct,
-	      dev->descriptor.iSerialNumber));
-	memset(dev->mf, 0, sizeof(dev->mf));
-	memset(dev->prod, 0, sizeof(dev->prod));
-	memset(dev->serial, 0, sizeof(dev->serial));
-	if (dev->descriptor.iManufacturer)
-		usb_string(dev, dev->descriptor.iManufacturer,
-			   dev->mf, sizeof(dev->mf));
-	if (dev->descriptor.iProduct)
-		usb_string(dev, dev->descriptor.iProduct,
-			   dev->prod, sizeof(dev->prod));
-	if (dev->descriptor.iSerialNumber)
-		usb_string(dev, dev->descriptor.iSerialNumber,
-			   dev->serial, sizeof(dev->serial));
-	KDEBUG(("Manufacturer %s\n", dev->mf));
-	KDEBUG(("Product      %s\n", dev->prod));
-	KDEBUG(("SerialNumber %s\n", dev->serial));
+    KDEBUG(("new device strings: Mfr=%d, Product=%d, SerialNumber=%d\n",
+          dev->descriptor.iManufacturer, dev->descriptor.iProduct,
+          dev->descriptor.iSerialNumber));
+    memset(dev->mf, 0, sizeof(dev->mf));
+    memset(dev->prod, 0, sizeof(dev->prod));
+    memset(dev->serial, 0, sizeof(dev->serial));
+    if (dev->descriptor.iManufacturer)
+        usb_string(dev, dev->descriptor.iManufacturer,
+               dev->mf, sizeof(dev->mf));
+    if (dev->descriptor.iProduct)
+        usb_string(dev, dev->descriptor.iProduct,
+               dev->prod, sizeof(dev->prod));
+    if (dev->descriptor.iSerialNumber)
+        usb_string(dev, dev->descriptor.iSerialNumber,
+               dev->serial, sizeof(dev->serial));
+    KDEBUG(("Manufacturer %s\n", dev->mf));
+    KDEBUG(("Product      %s\n", dev->prod));
+    KDEBUG(("SerialNumber %s\n", dev->serial));
 
-	return 0;
+    return 0;
 }
 
 
 long usb_setup_device(struct usb_device *dev, BOOL do_read,
-		     struct usb_device *parent)
+             struct usb_device *parent)
 {
-	long addr;
-	long ret;
+    long addr;
+    long ret;
 
-	/* We still haven't set the Address yet */
-	addr = dev->devnum;
-	dev->devnum = 0;
+    /* We still haven't set the Address yet */
+    addr = dev->devnum;
+    dev->devnum = 0;
 
-	ret = usb_prepare_device(dev, addr, do_read, parent);
+    ret = usb_prepare_device(dev, addr, do_read, parent);
   ALERT(("usb_prepare_device -> %ld\n",ret));
 
-	if (ret)
-		return ret;
-	ret = usb_select_config(dev);
+    if (ret)
+        return ret;
+    ret = usb_select_config(dev);
   ALERT(("usb_select_config -> %ld\n",ret));
 
-	return ret;
+    return ret;
 }
 
 long usb_new_device(struct usb_device *dev)
 {
-	BOOL do_read = TRUE;
-	long err;
+    BOOL do_read = TRUE;
+    long err;
   int idx = 0;
 
-	err = usb_setup_device(dev, do_read, dev->parent);
-	if (err)
+    err = usb_setup_device(dev, do_read, dev->parent);
+    if (err)
   {
     ALERT(("usb_setup_device -> %ld\n",err));
-		return err;
+        return err;
   }
 
   /* now probe if the device is a hub */
@@ -1133,7 +1135,7 @@ long usb_new_device(struct usb_device *dev)
       }
   }
 
-	return 0;
+    return 0;
 }
 
 /********************************************************************

--- a/usb/usb_hub.c
+++ b/usb/usb_hub.c
@@ -488,7 +488,22 @@ usb_hub_events(struct usb_hub_device *hub)
         KDEBUG(("Port %ld Status %x Change %x\n",
                 i + 1, portstatus, portchange));
 
-        if (portchange & USB_PORT_STAT_C_CONNECTION)
+        /*
+         * Normally a newly attached device is caught by the
+         * C_CONNECTION change bit. But the very first scan of a hub
+         * (usb_hub_init(), called once at boot) can observe a port
+         * that is already CONNECTION|ENABLE with no change bit set --
+         * e.g. QEMU's dwc2-usb model reports its downstream hub this
+         * way, since the "connect" already happened as a side effect
+         * of the hub's own enumeration, before this driver ever polled
+         * it. Since there is no periodic re-scan afterwards, missing
+         * this at the one boot-time pass means the device (and
+         * anything behind it, like a keyboard/mouse on a downstream
+         * hub) is never enumerated at all. Treat "connected, enabled,
+         * but we don't have a child for it yet" the same as a change.
+         */
+        if ((portchange & USB_PORT_STAT_C_CONNECTION) ||
+            ((portstatus & USB_PORT_STAT_CONNECTION) && !dev->children[i]))
         {
             changed |= USB_PORT_STAT_C_CONNECTION;
             KDEBUG(("port %ld connection change\n", i + 1));
@@ -533,9 +548,9 @@ usb_hub_events(struct usb_hub_device *hub)
         if (portstatus & USB_PORT_STAT_SUSPEND)
         {
             changed |= USB_PORT_STAT_SUSPEND;
-            KDEBUG(("port %ld suspend change\n", i + 1);
+            KDEBUG(("port %ld suspend change\n", i + 1));
             usb_clear_port_feature(dev, i + 1,
-                        USB_PORT_FEAT_SUSPEND));
+                        USB_PORT_FEAT_SUSPEND);
         }
 
         if (portchange & USB_PORT_STAT_C_OVERCURRENT)

--- a/usb/usb_hub.c
+++ b/usb/usb_hub.c
@@ -503,7 +503,8 @@ usb_hub_events(struct usb_hub_device *hub)
          * but we don't have a child for it yet" the same as a change.
          */
         if ((portchange & USB_PORT_STAT_C_CONNECTION) ||
-            ((portstatus & USB_PORT_STAT_CONNECTION) && !dev->children[i]))
+            ((portstatus & (USB_PORT_STAT_CONNECTION | USB_PORT_STAT_ENABLE)) ==
+                (USB_PORT_STAT_CONNECTION | USB_PORT_STAT_ENABLE) && !dev->children[i]))
         {
             changed |= USB_PORT_STAT_C_CONNECTION;
             KDEBUG(("port %ld connection change\n", i + 1));


### PR DESCRIPTION
Adds a USB keyboard driver (`udd_keyboard.c`) that implements HID boot-protocol keyboard support, complementing the existing mouse driver. The keyboard driver polls the interrupt endpoint via the timer-C tick and translates USB HID usage IDs to Atari IKBD scancodes.

**Key changes:**

- **New USB keyboard driver** (`usb/udd_keyboard.c`): Probes for HID boot-protocol keyboard interfaces, maintains modifier and key state, and generates IKBD scancodes via `kbd_int()` on key press/release events. Includes lookup tables mapping USB HID usage IDs and modifier bits to Atari scancodes.

- **Timer-C integration** (`bios/arch/arm/vectors.c`): Hooks `usb_keyboard_timerc()` into the timer-C interrupt handler alongside the existing mouse polling, enabling periodic keyboard state polling.

- **USB initialization** (`usb/usb.c`): Calls `usb_keyboard_init()` during USB subsystem startup to register the keyboard driver.

- **Hub enumeration fix** (`usb/usb_hub.c`): Corrects a boot-time device enumeration issue where a port already in CONNECTION|ENABLE state (with no change bit set) would be missed. This is particularly important for downstream devices like keyboards on hubs, which may be reported this way by some controllers (e.g., QEMU's dwc2-usb model).

- **Code style cleanup** (`usb/usb.c`): Converts tab indentation to spaces in several functions for consistency.

- **Build configuration** (`usb/build.mk`): Adds `udd_keyboard.o` to the build.

https://claude.ai/code/session_01XEnXdqzZumCBoXPPgWiDbV