### PR TITLE
raspi2: fix Data Abort when hovering/clicking the menu bar

### DIFF
--- a/aes/arch/arm/gemdosif.S
+++ b/aes/arch/arm/gemdosif.S
@@ -183,7 +183,13 @@ _justretf:
 
 _tikcod:
         push_privstack tstack
-        push    {r0-r4,lr}
+        // r5 is otherwise unused here -- included purely to pad this to a
+        // multiple of 8 bytes (7 regs = 28, +4 from push_privstack's own
+        // str = 32), so sp lands 8-byte aligned at the bl's below. tstack
+        // is now explicitly 8-byte aligned (see its .balign 8 above), and
+        // AAPCS requires 8-byte sp alignment at any public interface such
+        // as these calls.
+        push    {r0-r5,lr}
         ldr     r4, =_NUM_TICK
         ldmia   r4, {r1,r2} // r1 <- *NUM_TICK; r2 <- *CMP_TICK
         teq     r2, #0      // if (*CMP_TICK != 0)
@@ -200,7 +206,7 @@ _tikcod:
         mov     r0, #1
         bl      _b_delay    // b_delay(1);
 
-        pop     {r0-r4,lr}
+        pop     {r0-r5,lr}
         pop_privstack
 
         b        _tiksav    // Chain to vector stored in _tiksav

--- a/aes/arch/arm/gemdosif.S
+++ b/aes/arch/arm/gemdosif.S
@@ -138,7 +138,7 @@ trapaes:
 .text
 
 _far_bcha:
-        push_privstack gstksave
+        push_privstack gstack
         push    {r0-r3,lr}
         bl      _b_click
         pop     {r0-r3,lr}
@@ -146,7 +146,7 @@ _far_bcha:
         bx      lr
 
 _far_mcha:
-        push_privstack gstksave
+        push_privstack gstack
         push    {r0-r3,lr}
         ldmfd   sp, {r1,r2} // shift arg 1 and 2 up by one
         ldr     r0, =_mchange
@@ -158,7 +158,7 @@ _far_mcha:
 #if CONF_WITH_VDI_EXTENSIONS
 /* AES mouse wheel handler called by the VDI */
 _aes_wheel:
-        push_privstack gstksave
+        push_privstack gstack
         push    {r0-r3,lr}
         ldmfd   sp, {r1,r2} // shift arg 1 and 2 up by one
         ldr     r0, =_wheel_change
@@ -228,13 +228,19 @@ _CMP_TICK:
 
 /*
  * miscellaneous stacks
+ *
+ * 8-byte aligned (not just 4): these become the live sp for _far_bcha/
+ * _far_mcha/_aes_wheel/_tikcod (see push_privstack above), and GCC's
+ * -mfpu=neon-vfpv4 auto-vectorizer will opportunistically use 8-byte-
+ * aligned NEON loads/stores for stack locals anywhere downstream of
+ * that -- same class of bug as #31/#33.
  */
-        .balign 4
+        .balign 8
 
         .space  0x400
 gstack:                         // gsx stack for mouse
 
-        .balign 4
+        .balign 8
         .space  0x400
 tstack:                         // tick stack
         .space  4

--- a/aes/arch/arm/gemstart.S
+++ b/aes/arch/arm/gemstart.S
@@ -246,6 +246,18 @@ _dos_exec:
         str     ip, [sp, #+4*5]         // Save rlr->p_uda->u_spsuper where we saved r5 earlier
 
         sub     ip, sp, #0x50           // Adjust the stack (see above)
+
+        // This value stays live in UDA_SPSUPER for as long as the launched
+        // child runs -- for the desktop shell (launched from
+        // _run_accs_and_desktop), that's the entire session, since Pexec
+        // (mode "load and go") doesn't return until the child terminates.
+        // Every re-entrant trap #2 call the desktop makes in the meantime
+        // switches to this stack, so it needs the same AAPCS 8-byte
+        // alignment as every other UDA_SPSUPER site (init_p0_stkptr(),
+        // geminit.c's process-init loop, _accdesk_start above) -- gcc's
+        // NEON/VFP auto-vectorizer Data Aborts otherwise the first time it
+        // vectorizes a stack local deep enough in that call chain.
+        bic     ip, ip, #7
         str     ip, [r7, UDA_SPSUPER]
 
         bl      _enable_interrupts

--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -776,7 +776,10 @@ void gem_main(void)
         /* if not rlr then initialize his stack pointer */
         if (i != 0)
         {
-            ULONG *stack_top = &rlr->p_uda->u_supstk;
+            /* One word past u_supstk, matching init_p0_stkptr()'s stack_top
+             * (same struct, same convention: u_supstk itself is usable
+             * stack space, not just an end-of-array marker). */
+            ULONG *stack_top = &rlr->p_uda->u_supstk + 1;
 
 #if ARCH_ARM
             /* Same reasoning as init_p0_stkptr(): ARM/AAPCS requires the

--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -775,7 +775,22 @@ void gem_main(void)
         rlr->p_appdir[0] = '\0'; /* by default, no application directory */
         /* if not rlr then initialize his stack pointer */
         if (i != 0)
-            rlr->p_uda->u_spsuper = &rlr->p_uda->u_supstk;
+        {
+            ULONG *stack_top = &rlr->p_uda->u_supstk;
+
+#if ARCH_ARM
+            /* Same reasoning as init_p0_stkptr(): ARM/AAPCS requires the
+             * stack pointer to be 8-byte aligned wherever gcc's NEON/VFP
+             * auto-vectorizer might spill a local there, but u_supstk's
+             * offset within UDA isn't a multiple of 8, so this is never
+             * naturally aligned -- round down explicitly. Process 0 gets
+             * this treatment via init_p0_stkptr(); every other internal
+             * process and desk accessory (i != 0) needs it too, since
+             * they all run AES/VDI code on this same private stack. */
+            stack_top = (ULONG *)((ULONG)stack_top & ~7UL);
+#endif
+            rlr->p_uda->u_spsuper = stack_top;
+        }
         rlr->p_pid = i;
         rlr->p_stat = 0;
         rlr->p_msg.action = -1;


### PR DESCRIPTION
Fixes #165 — Data Abort (ARM alignment fault) when hovering/clicking the menu bar on raspi, now that mouse input actually reaches the AES (#163/#164).

## Fix 1: menu-bar hover crash

`gem_main()`'s process-init loop (`aes/geminit.c`) sets up `u_spsuper` — the private AES/VDI supervisor stack — for every internal process and desk accessory except process 0. Process 0 already gets an ARM-specific 8-byte alignment round-down for this (`init_p0_stkptr()`, added by #31/#32/#33), but process 1 never did. `u_supstk`'s offset within `UDA` isn't a multiple of 8, so that stack is *never* naturally aligned without the round-down — deterministic, not occasional. GCC's `-mfpu=neon-vfpv4` auto-vectorizer opportunistically uses 8-byte-aligned NEON loads/stores for stack locals (here, inside `gr_box()`'s `GRECT` copy, reached while inverting a menu title's highlight), faulting with a Data Abort (`fsr=1`) the first time it's hit deep enough on this stack.

Same bug class already tracked in #31/#33 ("ARM VDI/GEM stack-alignment faults"), in a call path those fixes didn't cover — process 1's private stack handles AES event/menu processing once mouse input reaches it, which never happened on raspi until #163/#164 landed.

Also fixed a separately-found bug in `aes/arch/arm/gemdosif.S`: `_far_bcha`/`_far_mcha`/`_aes_wheel` switched to a private stack via `push_privstack gstksave`, but `gstksave` is a 4-byte save-slot variable, not `gstack` (the actual ~1KB reserved buffer) — every push there was corrupting adjacent BSS globals (`_tikaddr`/`_drwaddr`) on every mouse click/move/wheel dispatch. `_tikcod` already used the correct `tstack` symbol; the other three now match.

## Fix 2: menu *selection* crash (found during verification — same PC, different cause)

After fixing the hover crash, clicking any menu entry (not just hovering) still crashed at the exact same `pc=0002c21c`. Root cause: `_dos_exec()` (`aes/arch/arm/gemstart.S`), the Pexec wrapper used to launch a child program, temporarily rewrites `u_spsuper` to `current_sp - 0x50` for the duration of the call, as a reentrancy guard — but never rounds that value to 8-byte alignment, unlike every other `UDA_SPSUPER` site in the file.

This matters because the desktop shell itself is launched this way (`_accdesk_start` → `_run_accs_and_desktop` → `_dos_exec`, Pexec "load and go" mode), and that Pexec call doesn't return until the desktop terminates — so for the desktop, "temporary" means "for the entire session". Every trap #2 call the desktop makes while running (e.g. handling a menu selection) reenters the AES on this unaligned stack. Hovering worked because that runs on a different process; actually selecting an item runs the resulting command on this one.

## Verification

Built and booted in QEMU (raspi1ap and raspi2b, `-device usb-mouse -device usb-kbd`, no accessories loaded):
- Reproduced the exact hover crash (`pc=0002c21c`, `fsr=00000001`) pre-fix-1 on both machines, matching the reporter's dump exactly.
- After fix 1: swept the mouse across the entire menu bar and clicked every title — no crash, menu renders. But clicking an actual menu entry (e.g. "Desktop info...") still crashed at the same PC.
- Root-caused fix 2 via targeted SP/process instrumentation (temporary, not in the final diff), confirming the exact `_dos_exec` reentrancy-guard value was the unaligned stack in use.
- After fix 2: opened the Desk menu and clicked "Desktop info..." — dialog renders, no crash, no `guest_errors`, on both raspi1 and raspi2.
- No regression to mouse/keyboard input from #163/#164.
- `virt-arm` still builds.
- `make gitready` passes.
