### PR TITLE
vdi: audit vdi_screen_is_truecolor() call sites, promote palette get/set to backend ops

### DIFF
--- a/vdi/vdi_backend.c
+++ b/vdi/vdi_backend.c
@@ -362,6 +362,7 @@ void vdi_backend_ops_init(vdi_backend_ops *ops)
     if (!ops->search_left) ops->search_left = default_search_left;
 
     if (!ops->get_start_addr || !ops->get_pixel || !ops->put_pixel
-        || !ops->get_raw_pixel || !ops->put_raw_pixel)
+        || !ops->get_raw_pixel || !ops->put_raw_pixel
+        || !ops->set_color || !ops->get_color)
         KDEBUG(("vdi_backend_ops_init: backend is missing a mandatory primitive\n"));
 }

--- a/vdi/vdi_backend.h
+++ b/vdi/vdi_backend.h
@@ -18,8 +18,9 @@
  * never "fall back to another backend." The dispatcher's
  * vdi_backend_ops_init() (see below) fills every NULL slot with a
  * renderer-agnostic default built only on the mandatory primitives
- * (get_start_addr, get_pixel, put_pixel, get_raw_pixel, put_raw_pixel),
- * which must be non-NULL.  open/close default to no-ops.
+ * (get_start_addr, get_pixel, put_pixel, get_raw_pixel, put_raw_pixel,
+ * set_color, get_color), which must be non-NULL.  open/close default to
+ * no-ops.
  */
 typedef struct vdi_backend_ops {
     BOOL (*open)(Vwk *vwk);
@@ -38,6 +39,27 @@ typedef struct vdi_backend_ops {
      */
     UWORD (*get_raw_pixel)(WORD x, WORD y);
     void (*put_raw_pixel)(WORD x, WORD y, UWORD raw);
+
+    /*
+     * Write/read the "actual" hardware or backend palette entry for a VDI
+     * pen (see vdi_vs_color()/vdi_vq_color() in vdi_col.c, issue #171).
+     * pen is the raw pen number as passed by the caller (VDI's INTIN[0]),
+     * not adjusted for TT palette banking -- each backend resolves it
+     * through its own indexing (MAP_COL[] for both current backends).
+     * rgb holds VDI-scale (0-1000) component values; set_color's caller
+     * has already range-clamped them.
+     *
+     * Mandatory, like the raw-pixel pair above: there is no renderer-
+     * agnostic way to write a hardware/backend palette, so there is no
+     * generic default to fall back to.  The separate "last requested"
+     * value cache (REQ_COL/req_col2 vs. a workstation's tc_req_col) is a
+     * backend-specific storage layout, not a primitive -- it stays inline
+     * at the vdi_col.c call site, the same kind of setup/data-layout
+     * decision as cpy_raster()'s packed-MFDB-layout branches.
+     */
+    void (*set_color)(Vwk *vwk, WORD pen, WORD *rgb);
+    void (*get_color)(const Vwk *vwk, WORD pen, WORD *rgb);
+
     void (*fill_rect)(const VwkAttrib *attr, const Rect *rect);
     void (*text_blit)(LOCALVARS *vars);
     void (*raster_copy)(struct raster_t *raster, struct blit_frame *info);

--- a/vdi/vdi_backend_planar.c
+++ b/vdi/vdi_backend_planar.c
@@ -29,6 +29,8 @@ vdi_backend_ops planar_backend_ops = {
     planar_put_pixel,
     planar_get_pixel,       /* get_raw_pixel: a planar pixel's raw value is its composed colour index */
     planar_put_pixel,       /* put_raw_pixel: same for writing */
+    planar_set_color,
+    planar_get_color,
     planar_fill_rect,
     planar_text_blit,
     planar_raster_copy,

--- a/vdi/vdi_backend_truecolor.c
+++ b/vdi/vdi_backend_truecolor.c
@@ -356,6 +356,24 @@ void vdi_truecolor_get_color(const Vwk *vwk, WORD index, WORD *r, WORD *g, WORD 
 }
 
 /*
+ * vdi_backend_ops.set_color/get_color adapters (issue #171): the ops slots
+ * take a raw VDI pen and a 3-element rgb[] array -- see the comment on
+ * those slots in vdi_backend.h -- while vdi_truecolor_set_color()/
+ * vdi_truecolor_get_color() above take an already MAP_COL-mapped index and
+ * three separate components, matching every other index this file takes.
+ * These just bridge the two conventions.
+ */
+static void truecolor_ops_set_color(Vwk *vwk, WORD pen, WORD *rgb)
+{
+    vdi_truecolor_set_color(vwk, MAP_COL[pen], rgb[0], rgb[1], rgb[2]);
+}
+
+static void truecolor_ops_get_color(const Vwk *vwk, WORD pen, WORD *rgb)
+{
+    vdi_truecolor_get_color(vwk, MAP_COL[pen], &rgb[0], &rgb[1], &rgb[2]);
+}
+
+/*
  * Address calculation for a packed 16bpp (2 bytes/pixel) framebuffer.
  * Fixed at 2 bytes/pixel because this backend is only ever selected for
  * SCREEN_PIXEL_RGB565 (see vdi_backend_select()).
@@ -1001,6 +1019,8 @@ vdi_backend_ops packed_truecolor_backend_ops = {
     truecolor_put_pixel,
     truecolor_get_raw_pixel,
     truecolor_put_raw_pixel,
+    truecolor_ops_set_color,
+    truecolor_ops_get_color,
 #if CONF_VDI_SPARSE_TABLE
     /* The optional slots are left NULL so vdi_backend_ops_init() fills them
      * with the generic defaults -- this exercises issue #138's defaults

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -592,6 +592,113 @@ static void set_color(WORD colnum, WORD *rgb)
     Setcolor(hwreg, (r << 8) | (g << 4) | b);
 }
 
+/*
+ * planar_set_color/planar_get_color - vdi_backend_ops.set_color/get_color
+ * for the planar backend (issue #171): hardware colour-register read/write.
+ * vwk is unused -- unlike the truecolor backend's per-workstation pseudo-
+ * palette, this backend writes real hardware colour registers, which are
+ * necessarily shared across every workstation. pen is the raw VDI pen
+ * number; both resolve it to a hardware register through MAP_COL[]
+ * themselves, matching vdi_truecolor_set_color()/vdi_truecolor_get_color()'s
+ * own MAP_COL[]-mapped index convention (see screen_set_color()/
+ * screen_get_color() below).
+ */
+void planar_set_color(Vwk *vwk, WORD pen, WORD *rgb)
+{
+    (void)vwk;
+    set_color(pen, rgb);
+}
+
+void planar_get_color(const Vwk *vwk, WORD pen, WORD *rgb)
+{
+    WORD hwreg = MAP_COL[pen];
+    WORD c;
+
+    (void)vwk;
+
+#if CONF_WITH_VIDEL
+    if (has_videl)
+    {
+        LONG videlrgb;
+
+        VgetRGB(hwreg,1,(LONG)&videlrgb);
+        rgb[0] = videl2vdi(videlrgb >> 16);
+        rgb[1] = videl2vdi(videlrgb >> 8);
+        rgb[2] = videl2vdi(videlrgb);
+        return;
+    }
+#endif
+#if CONF_WITH_TT_SHIFTER
+    if (has_tt_shifter)
+    {
+        query_tt_color(pen,rgb);
+        return;
+    }
+#endif
+#if CONF_WITH_STE_SHIFTER
+    if (has_ste_shifter)
+    {
+        c = Setcolor(hwreg, -1);
+        rgb[0] = ste2vdi(c >> 8);
+        rgb[1] = ste2vdi(c >> 4);
+        rgb[2] = ste2vdi(c);
+        return;
+    }
+#endif
+    /* ST shifter */
+    c = Setcolor(hwreg, -1);
+    rgb[0] = st2vdi(c >> 8);
+    rgb[1] = st2vdi(c >> 4);
+    rgb[2] = st2vdi(c);
+}
+
+/*
+ * screen_set_color/screen_get_color - dispatch a palette write/read to the
+ * current screen's backend (issue #171), the same three-way pattern as
+ * get_start_addr() in vdi_misc.c: through the ops table when more than one
+ * renderer is built in, or straight to the one enabled renderer's function
+ * otherwise, so a single-renderer build pays nothing for dispatch that can
+ * only ever resolve one way.
+ */
+static void screen_set_color(Vwk *vwk, WORD pen, WORD *rgb)
+{
+#if CONF_WITH_VDI_BACKEND_DISPATCH
+    const vdi_backend_ops *backend = vdi_screen_backend();
+
+    /* see the comment in get_start_addr() (vdi_misc.c) */
+    if (!backend)
+        return;
+    backend->set_color(vwk, pen, rgb);
+#elif CONF_WITH_VDI_BACKEND_TRUECOLOR
+    /* see the comment in get_start_addr() (vdi_misc.c) */
+    vdi_truecolor_set_color(vwk, MAP_COL[pen], rgb[0], rgb[1], rgb[2]);
+#else
+    /* see the comment in get_start_addr() (vdi_misc.c) */
+    planar_set_color(vwk, pen, rgb);
+#endif
+}
+
+static void screen_get_color(const Vwk *vwk, WORD pen, WORD *rgb)
+{
+#if CONF_WITH_VDI_BACKEND_DISPATCH
+    const vdi_backend_ops *backend = vdi_screen_backend();
+
+    /* see the comment in get_start_addr() (vdi_misc.c) */
+    if (!backend)
+    {
+        rgb[0] = rgb[1] = rgb[2] = 0;
+        return;
+    }
+    backend->get_color(vwk, pen, rgb);
+#elif CONF_WITH_VDI_BACKEND_TRUECOLOR
+    /* see the comment in get_start_addr() (vdi_misc.c) */
+    vdi_truecolor_get_color(vwk, MAP_COL[pen], &rgb[0], &rgb[1], &rgb[2]);
+#else
+    /* see the comment in get_start_addr() (vdi_misc.c) */
+    planar_get_color(vwk, pen, rgb);
+#endif
+}
+
 
 /*
  * vdi_vs_color - set color index table
@@ -619,17 +726,20 @@ void vdi_vs_color(Vwk *vwk)
     if (vdi_screen_is_truecolor())
     {
         /*
-         * Per-workstation "requested"/"actual" state (issue #89), mirroring
-         * upstream's VwkExt::req_col/palette: unlike the global
-         * REQ_COL/req_col2 below, storing into vwk->tc_req_col here means a
-         * vs_color() on one workstation cannot leak into another
-         * workstation's vq_color(pen,0) answer.
+         * Per-workstation "requested" state (issue #89), mirroring
+         * upstream's VwkExt::req_col: unlike the global REQ_COL/req_col2
+         * below, storing into vwk->tc_req_col here means a vs_color() on
+         * one workstation cannot leak into another workstation's
+         * vq_color(pen,0) answer.
          *
          * Indexed by INTIN[0], the pen as passed in -- not colnum, which
          * may have been bank-adjusted above -- since tc_req_col (unlike
          * REQ_COL/req_col2) is documented as plain pen-indexed. vq_color()
          * reads it back by INTIN[0] too (see below), so a bank adjustment
-         * here would desync the two.
+         * here would desync the two. This is a genuine backend-specific
+         * storage-layout decision (like cpy_raster()'s packed-MFDB-layout
+         * branches in vdi_raster.c), not a primitive, so it stays inline
+         * here rather than moving into screen_set_color() below.
          */
         for (i = 0, intin = INTIN+1, rgbptr = rgb; i < 3; i++, intin++, rgbptr++)
         {
@@ -640,32 +750,39 @@ void vdi_vs_color(Vwk *vwk)
                 *rgbptr = 0;
             else *rgbptr = *intin;
         }
-        vdi_truecolor_set_color(vwk, MAP_COL[INTIN[0]], rgb[0], rgb[1], rgb[2]);
-        return;
     }
+    else
 #endif
+    {
+        /*
+         * Copy raw values to the "requested colour" arrays, then clamp
+         * them to 0-1000 before writing the actual hardware colour below.
+         */
+        for (i = 0, intin = INTIN+1, rgbptr = rgb; i < 3; i++, intin++, rgbptr++)
+        {
+            if (colnum < 16)
+                linea_vars.REQ_COL[colnum][i] = *intin;
+#if EXTENDED_PALETTE
+            else
+                req_col2[colnum-16][i] = *intin;
+#endif
+            if (*intin > 1000)
+                *rgbptr = 1000;
+            else if (*intin < 0)
+                *rgbptr = 0;
+            else *rgbptr = *intin;
+        }
+    }
 
     /*
-     * Copy raw values to the "requested colour" arrays, then clamp
-     * them to 0-1000 before calling set_color()
+     * Write the actual hardware/backend palette entry, dispatched through
+     * the VDI backend ops table (issue #171) the same way the other VDI
+     * drawing primitives are (see vdi_backend.h). Keyed by INTIN[0], the
+     * raw pen as passed in -- not colnum above, which may have been
+     * bank-adjusted for TT REQ_COL storage -- matching vdi_vq_color()'s
+     * read below.
      */
-    for (i = 0, intin = INTIN+1, rgbptr = rgb; i < 3; i++, intin++, rgbptr++)
-    {
-        if (colnum < 16)
-            linea_vars.REQ_COL[colnum][i] = *intin;
-#if EXTENDED_PALETTE
-        else
-            req_col2[colnum-16][i] = *intin;
-#endif
-        if (*intin > 1000)
-            *rgbptr = 1000;
-        else if (*intin < 0)
-            *rgbptr = 0;
-        else *rgbptr = *intin;
-    }
-
-    colnum = INTIN[0];      /* may have been munged on TT system, see above */
-    set_color(colnum, rgb);
+    screen_set_color(vwk, INTIN[0], rgb);
 }
 
 
@@ -769,7 +886,7 @@ void init_colors(void)
  */
 void vdi_vq_color(Vwk *vwk)
 {
-    WORD colnum, c, hwreg;
+    WORD colnum;
 
     colnum = INTIN[0];
 
@@ -790,37 +907,25 @@ void vdi_vq_color(Vwk *vwk)
         colnum = adjust_tt_colnum(colnum);  /* handles palette bank issues */
 #endif
 
-#if CONF_WITH_VDI_BACKEND_TRUECOLOR
-    if (vdi_screen_is_truecolor())
+    if (INTIN[1] == 0)  /* return last-requested value */
     {
-        /*
-         * Both forms come from vwk's own per-workstation state (issue
-         * #89): tc_req_col for "last requested", tc_palette (via
-         * vdi_truecolor_get_color()) for "actual" -- see the tc_req_col
-         * comment on struct Vwk_ in vdi_defs.h for why this doesn't read
-         * the global REQ_COL/req_col2 the way the non-truecolor path
-         * below does.
-         *
-         * Indexed by INTIN[0] rather than colnum, matching how
-         * vdi_vs_color() stores it -- colnum may have been bank-adjusted
-         * above, but tc_req_col is plain pen-indexed.
-         */
-        if (INTIN[1] == 0)  /* return last-requested value */
+#if CONF_WITH_VDI_BACKEND_TRUECOLOR
+        if (vdi_screen_is_truecolor())
         {
+            /*
+             * Per-workstation state (issue #89): unlike the global
+             * REQ_COL/req_col2 below, indexed by INTIN[0] rather than
+             * colnum, matching how vdi_vs_color() stores it -- colnum may
+             * have been bank-adjusted above, but tc_req_col is plain
+             * pen-indexed. Same backend-specific storage-layout exception
+             * as the mirror comment in vdi_vs_color() above.
+             */
             INTOUT[1] = vwk->tc_req_col[INTIN[0]][0];
             INTOUT[2] = vwk->tc_req_col[INTIN[0]][1];
             INTOUT[3] = vwk->tc_req_col[INTIN[0]][2];
         }
-        else                /* return actual current value */
-        {
-            vdi_truecolor_get_color(vwk, MAP_COL[INTIN[0]], &INTOUT[1], &INTOUT[2], &INTOUT[3]);
-        }
-        return;
-    }
+        else
 #endif
-
-    if (INTIN[1] == 0)  /* return last-requested value */
-    {
         if (colnum < 16)
         {
             INTOUT[1] = linea_vars.REQ_COL[colnum][0];
@@ -839,43 +944,17 @@ void vdi_vq_color(Vwk *vwk)
     }
 
     /*
-     * return actual current value
+     * Return the actual current value, dispatched through the VDI backend
+     * ops table (issue #171) the same way vdi_vs_color() writes it above.
+     * Keyed by INTIN[0], the raw pen, not colnum (which may have been
+     * bank-adjusted above for the REQ_COL lookup only).
      */
-    colnum = INTIN[0];          /* may have been munged on TT system, see above */
-    hwreg = MAP_COL[colnum];    /* get hardware register */
+    {
+        WORD rgb[3];
 
-#if CONF_WITH_VIDEL
-    if (has_videl)
-    {
-    LONG rgb;
-
-        VgetRGB(hwreg,1,(LONG)&rgb);
-        INTOUT[1] = videl2vdi(rgb >> 16);
-        INTOUT[2] = videl2vdi(rgb >> 8);
-        INTOUT[3] = videl2vdi(rgb);
-        return;
+        screen_get_color(vwk, INTIN[0], rgb);
+        INTOUT[1] = rgb[0];
+        INTOUT[2] = rgb[1];
+        INTOUT[3] = rgb[2];
     }
-#endif
-#if CONF_WITH_TT_SHIFTER
-    if (has_tt_shifter)
-    {
-        query_tt_color(colnum,&INTOUT[1]);
-        return;
-    }
-#endif
-#if CONF_WITH_STE_SHIFTER
-    if (has_ste_shifter)
-    {
-        c = Setcolor(hwreg, -1);
-        INTOUT[1] = ste2vdi(c >> 8);
-        INTOUT[2] = ste2vdi(c >> 4);
-        INTOUT[3] = ste2vdi(c);
-        return;
-    }
-#endif
-    /* ST shifter */
-    c = Setcolor(hwreg, -1);
-    INTOUT[1] = st2vdi(c >> 8);
-    INTOUT[2] = st2vdi(c >> 4);
-    INTOUT[3] = st2vdi(c);
 }

--- a/vdi/vdi_defs.h
+++ b/vdi/vdi_defs.h
@@ -315,6 +315,11 @@ UWORD *planar_get_start_addr(WORD x, WORD y);
 UWORD planar_get_pixel(WORD x, WORD y);
 void planar_put_pixel(WORD x, WORD y, UWORD color);
 void planar_fill_rect(const VwkAttrib *attr, const Rect *rect);
+/* planar_set_color/planar_get_color (vdi_col.c) -- hardware colour-register
+ * read/write for the planar backend, see the vdi_backend_ops comment on
+ * set_color/get_color in vdi_backend.h */
+void planar_set_color(Vwk *vwk, WORD pen, WORD *rgb);
+void planar_get_color(const Vwk *vwk, WORD pen, WORD *rgb);
 /* truecolor backend primitives (vdi_backend_truecolor.c) -- callable
  * directly in truecolor-only builds, where the dispatcher is compiled out */
 UWORD *truecolor_get_start_addr(WORD x, WORD y);

--- a/vdi/vdi_fill.c
+++ b/vdi/vdi_fill.c
@@ -924,6 +924,11 @@ void contourfill(const VwkAttrib * attr, const VwkClip *clip)
              * covers 1-4 planes and would both read out of bounds and
              * mask search_color down to the point that it could never
              * again match pixelread()'s output.
+             *
+             * Audited under issue #171: this is the palette-index-choice
+             * exception documented on vdi_screen_is_truecolor() itself --
+             * picking which value the already-dispatched search_right()/
+             * search_left() are asked to match, not a primitive.
              */
             search_color = MAP_COL[search_color];
         } else

--- a/vdi/vdi_raster.c
+++ b/vdi/vdi_raster.c
@@ -792,6 +792,11 @@ dont_clip (struct blit_frame * info)
  *  planar backend needs S_OR_D (its data planes are mask-ANDed and
  *  composed over the mask blit).  BM_S_ONLY/BM_S_OR_D are numerically equal
  *  to the AES's S_ONLY/S_OR_D.
+ *
+ *  Audited under issue #171: this picks the write-mode *argument* a later,
+ *  already-dispatched raster_copy() call is made with -- it does not draw
+ *  anything itself -- so it is the same kind of setup/data-layout decision
+ *  as setup_info()'s below, not a leftover pre-dispatch primitive.
  */
 WORD vdi_colour_blit_mode(void)
 {
@@ -804,6 +809,11 @@ WORD vdi_colour_blit_mode(void)
 
 /*
  * setup_info - fill the info structure with MFDB values
+ *
+ * Audited under issue #171: every vdi_screen_is_truecolor() check below is
+ * the packed-MFDB-layout exception documented on that function -- picking
+ * plane strides/counts to feed to the already-dispatched raster_copy(), not
+ * a drawing primitive itself.
  */
 static BOOL
 setup_info (struct raster_t *raster, struct blit_frame * info)

--- a/vdi/vdi_textblit.c
+++ b/vdi/vdi_textblit.c
@@ -886,6 +886,11 @@ void text_blt(void)
      *     rotating AND (skewing OR thickening), OR
      *     skewing AND clipping-is-required,
      *      call pre_blit()
+     *
+     * Audited under issue #171: this is the text_blt() pre-blit-decision
+     * exception documented on vdi_screen_is_truecolor() itself -- deciding
+     * whether to run pre_blit() ahead of the already-dispatched text_blit(),
+     * not a primitive.
      */
 #if CONF_WITH_VDI_BACKEND_TRUECOLOR
     if (vdi_screen_is_truecolor() && (vars.STYLE & (F_SKEW|F_THICKEN|F_OUTLINE)))


### PR DESCRIPTION
Fixes #171

## Summary

- Audited all 13 remaining `vdi_screen_is_truecolor()` call sites (`vdi_raster.c`, `vdi_fill.c`, `vdi_textblit.c`, `vdi_col.c`) against the three documented exceptions on that function.
- The sites in `vdi_raster.c` (`setup_info()`/`cpy_raster()`, plus `vdi_colour_blit_mode()`), `vdi_fill.c` (`contourfill()`), and `vdi_textblit.c` (`text_blt()`'s pre-blit decision) are genuine setup/data-layout decisions feeding an already-dispatched primitive — confirmed legitimate, and given a short comment cross-referencing the rationale documented on `vdi_screen_is_truecolor()` so future readers don't have to re-derive it.
- `vdi_col.c`'s `vdi_vs_color()`/`vdi_vq_color()` didn't fit: they called a backend-specific function (`vdi_truecolor_set_color()`/`get_color()`) directly by name, gated by an inline check — the same shape the other VDI primitives had before being promoted into `vdi_backend_ops`. Promoted palette get/set to new `set_color`/`get_color` slots on `vdi_backend_ops` (mandatory, like the raw-pixel pair, since there's no generic default possible for a hardware palette), backed by:
  - `planar_set_color()`/`planar_get_color()` (new, in `vdi_col.c`) — extracted from the existing hardware colour-register code unchanged.
  - `truecolor_ops_set_color()`/`get_color()` (new, in `vdi_backend_truecolor.c`) — thin adapters over the existing `vdi_truecolor_set_color()`/`get_color()`.
  - `vdi_vs_color()`/`vdi_vq_color()` now dispatch through new `screen_set_color()`/`screen_get_color()` helpers, following the same three-way (dispatch table / truecolor-only / planar-only) pattern already used by `get_start_addr()` and friends.
- The backend-specific "last requested" value cache (`REQ_COL`/`req_col2` vs. a workstation's `tc_req_col`) stays inline at the call site — it's a storage-layout decision, not a primitive, the same category as the three documented exceptions.

No functional/behavioral change intended: the actual index/value computations feeding the hardware/backend palette writes and reads are unchanged, just re-routed through the ops table.

## Test plan

- [x] `make gitready` passes
- [x] Builds clean across all three renderer configurations:
  - `rpi2_defconfig` (truecolor-only, single renderer)
  - `virt-arm_defconfig` (planar-only, single renderer, ARM toolchain — no m68k toolchain available in this environment)
  - `rpi2_defconfig` + forced `CONF_WITH_VDI_BACKEND_PLANAR=y` (dispatch mode, both backends)
  - `rpi2-sparse_defconfig` (dispatch mode + `CONF_VDI_SPARSE_TABLE`)
- [x] QEMU boot smoke test (`raspi2b`) on both the plain rpi2 build and the dispatch-mode build: reaches `AES: EMUDESK: appl_init()` / `evnt_multi()` with no `guest_errors`, confirming palette init/desktop draw still works through the new dispatch path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XEnXdqzZumCBoXPPgWiDbV)_