### PR TITLE
Async USB interrupt transfers for mouse/keyboard

### DIFF
--- a/.claude/skills/ptos-smoketest/SKILL.md
+++ b/.claude/skills/ptos-smoketest/SKILL.md
@@ -197,13 +197,15 @@ copy. Invocations (verified in-tree):
 # Model B machine. Same BCM2835/ARM1176 silicon, boots to the desktop. Requires
 # the FPU-enable fix (#98) — without it the first vldr in _raspi_vcmem_init traps.
 make rpi1_defconfig && make
-qemu-system-arm -M raspi1ap -bios kernel.img -d guest_errors -serial stdio
+qemu-system-arm -M raspi1ap -bios kernel.img -device usb-mouse -device usb-kbd \
+  -d guest_errors -serial stdio
 
 # raspi2 — real video output like raspi1; reads KDEBUG on the serial console.
 # NOTE: the machine is `raspi2b` on QEMU >= 9 (`-M raspi2` is gone). Requires the
 # FPU-enable fix (#98) — without it the first vldr in _raspi_vcmem_init traps.
 make rpi2_defconfig && make
-qemu-system-arm -M raspi2b -bios kernel7.img -d guest_errors -serial stdio
+qemu-system-arm -M raspi2b -bios kernel7.img -device usb-mouse -device usb-kbd \
+  -d guest_errors -serial stdio
 
 # virt-arm (headless, no framebuffer)
 # REQUIRED: -M virt,highmem=off — pTOS has no support for accessing memory or
@@ -228,6 +230,10 @@ make virt-m68k-cli_defconfig && make
 qemu-system-m68k -M virt -m 128 -cpu m68020 -kernel virt-m68k.elf -d guest_errors -serial stdio
 ```
 
+`-device usb-mouse -device usb-kbd` is mandatory when validating USB HID
+input: without these devices, the class drivers register but neither a mouse
+nor keyboard is enumerated.
+
 Device variants (both virt ports; `force-legacy=false` is required on QEMU
 versions that default virtio-mmio to legacy v1):
 
@@ -251,14 +257,19 @@ timeout 5 qemu-system-arm -M virt,highmem=off -cpu cortex-a7 -m 128 -kernel virt
 cat /tmp/qemu.log
 ```
 
-- **raspi1** (booted with `-M raspi1ap`): no `guest_errors`; screen draws.
-- **raspi2** (booted with `-M raspi2b`): no `guest_errors`; screen draws.
+- **raspi1** (booted with `-M raspi1ap`): no `guest_errors`; the screen reaches
+  the normal boot/desktop path; and, with `-device usb-mouse -device usb-kbd`,
+  serial traces confirm both mouse and keyboard HID probes.
+- **raspi2** (booted with `-M raspi2b`): no `guest_errors`; the screen reaches
+  the normal boot/desktop path; and, with `-device usb-mouse -device usb-kbd`,
+  serial traces confirm both mouse and keyboard HID probes.
 - The `vdi_v_opnwk: mode layout=... bpp=...` KDEBUG (and its `backend=selected`
   variant) only prints when the VDI runtime dispatcher is built in (both
   renderers enabled, `CONF_WITH_VDI_BACKEND_DISPATCH`, e.g.
   `rpi2-sparse_defconfig`) — default single-renderer rpi1/rpi2 builds have no
-  dispatcher and print no such line. The reliable pass signal is no
-  `guest_errors` + the screen drawing.
+  dispatcher and print no such line. For Raspberry Pi HID validation, the
+  reliable pass signal is no `guest_errors`, the screen reaching the normal
+  boot/desktop path, and mouse and keyboard HID probe traces.
 - **virt-arm / virt-m68k**: process survives the full `timeout` window
   (rc=124), no `guest_errors`/`unimp` output beyond ONE benign `Illegal
   Instruction` entry on m68k from `_detect_fpu` (expected, means CPU

--- a/.claude/skills/ptos-smoketest/SKILL.md
+++ b/.claude/skills/ptos-smoketest/SKILL.md
@@ -190,7 +190,7 @@ time; e.g. the 31 s IDE wait polls `_hz_200` at `0x4ba`, `addq.l #1,$4ba` at
 ## QEMU smoke test (raspi1 / raspi2 / virt-arm / virt-m68k)
 
 The pTOS `readme.md` is the user-facing source; this skill is the agent-facing
-copy. Invocations (verified in-tree):
+copy. Required invocations:
 
 ```sh
 # raspi1 — only the A+ exists as a QEMU machine (`raspi1ap`); there is no Pi 1

--- a/.superpowers/sdd/2026-08-12-async-usb-interrupt-transfers/extra-final-fix-report.md
+++ b/.superpowers/sdd/2026-08-12-async-usb-interrupt-transfers/extra-final-fix-report.md
@@ -1,0 +1,64 @@
+# Extra Final Lifecycle Fix Report: #177
+
+## Scope
+
+This wave addresses only the remaining shutdown-lifecycle findings from the
+final re-review.
+
+## Root Cause
+
+`usb_lowlevel_stop()` previously called `dwc2_async_shutdown()` for each slot,
+but the latter logged and returned if its bounded `CHHLTD` wait expired. The
+caller then masked DWC2 interrupts, disconnected the ARM USB IRQ, and reset
+the controller. A retained async slot could therefore still have controller DMA
+ownership when teardown continued.
+
+Teardown also did not mark a controller-wide shutdown state before draining
+slots. An error completion could release its slot and invoke its callback while
+shutdown was in progress. The callback could submit another request using the
+still-connected IRQ/controller, creating a new DMA transfer that the remaining
+teardown did not halt.
+
+## Changes
+
+- Added `dwc2_priv.shutting_down`, set before any async slot is stopped.
+- Reject async submissions while shutdown is active. Cancellation is accepted
+  as a no-op because teardown itself owns every slot until `CHHLTD`.
+- Suppress success/error callbacks and post-callback rearming while shutdown is
+  active. Existing normal error handling is unchanged outside shutdown: a
+  halted error slot is released before its callback, so the callback can retry.
+- Made `dwc2_async_shutdown()` return a status. It waits synchronously for
+  `CHHLTD`; on timeout it logs the channel and returns `ETIMEDOUT`.
+- While shutdown is active, the channel halt interrupt remains masked from the
+  IRQ handler, making the bounded shutdown wait the sole `CHHLTD` observer.
+  This prevents the handler from acknowledging the bit before that wait sees
+  it.
+- Made `usb_lowlevel_stop()` fail closed on that timeout. It leaves global/host
+  interrupts, the ARM IRQ handler, controller registers, and retained slots in
+  place, so a later `CHHLTD` IRQ remains observable and no DMA buffer is reused
+  or reset early.
+- Added contract assertions for shutdown state, guards, and timeout deferral.
+
+The existing `KINFO` trace now records both the intentional suppression of an
+error callback during shutdown and a retained-controller halt timeout.
+
+## Validation
+
+- RED: `sh tools/test-dwc2-async-contract.sh` failed before implementation with
+  `missing async DWC2 contract: controller shutdown state`.
+- GREEN: `sh tools/test-dwc2-async-contract.sh` passed after implementation.
+- `make gitready` passed. The Makefile emitted its existing duplicate `&`
+  target warnings before the check ran.
+- `git diff --check` passed.
+- Targeted `make obj/ucd_dwc2.o` succeeded for `rpi1`, `rpi2`,
+  `rpi2-sparse`, and `rpi3`. `rpi4` uses xHCI and does not compile DWC2.
+- Full `make` / `make -k` image links for all five configurations failed on the
+  pre-existing unresolved `_strcpy` from `bios/bios.tr.c:666`; this is outside
+  the changed driver. No DWC2 compilation errors were reported.
+
+## Residual Concern
+
+No hardware/QEMU lifecycle exercise was possible because the current images do
+not link. A `CHHLTD` timeout now intentionally leaves the USB controller live
+and returns `ETIMEDOUT`; callers must not treat that low-level stop as complete
+or reuse its controller state.

--- a/.superpowers/sdd/2026-08-12-async-usb-interrupt-transfers/final-fix-report.md
+++ b/.superpowers/sdd/2026-08-12-async-usb-interrupt-transfers/final-fix-report.md
@@ -1,0 +1,63 @@
+# Final Fix Report: #177
+
+## Review Findings Addressed
+
+1. `usb/ucd_dwc2.c` now records an eligible `HFNUM` value per async slot.
+   NAKs and successful reports schedule the next poll rather than immediately
+   enabling the channel. The USB SOF interrupt starts only scheduled slots
+   whose interval has elapsed. High-speed endpoint `bInterval` values use the
+   USB 2.0 exponent in microframes. Full/low-speed values use milliseconds,
+   converted to microframes only on a high-speed host port (the split path).
+2. Error handling now records a pending error, halts the channel, releases the
+   slot, and only then calls the UDD callback. A callback can submit its same
+   persistent request immediately; no error status is rearmed.
+3. `usb_lowlevel_stop()` now uses the existing channel-disable path and waits
+   up to 2000 for `CHHLTD` before releasing a slot. A timeout is logged and
+   ownership remains unreleased instead of racing controller teardown.
+4. `.claude/skills/ptos-smoketest/SKILL.md` no longer claims its required QEMU
+   HID invocations were verified in-tree. The mandatory `usb-mouse` and
+   `usb-kbd` commands and HID probe pass criteria remain unchanged.
+
+## Regression Coverage
+
+Added `tools/test-dwc2-async-contract.sh`.
+
+- Red: before the implementation, `sh tools/test-dwc2-async-contract.sh`
+  failed with `missing async DWC2 contract: per-slot next eligible frame`.
+- Green: after the implementation, the same command reports
+  `dwc2 async contract test passed`.
+- The check requires per-slot frame scheduling, USB speed-aware interval
+  conversion, SOF wakeup, post-release error callback support, and a bounded
+  `CHHLTD` shutdown wait.
+
+## Verification Evidence
+
+- `make gitready`: passed (`gitready checks passed.`).
+- `git diff --check`: passed with no output.
+- Legacy HID polling/stub search:
+  `rg 'usb_(mouse|keyboard)_timerc|usb_(mouse|keyboard)_irq|irq_handle =' usb bios/arch/arm/vectors.c`
+  returned no matches.
+- `make <config>_defconfig && make obj/ucd_dwc2.o` completed for `rpi1`,
+  `rpi2`, `rpi2-sparse`, `rpi3`, and `rpi4`. The existing unused `hcd_name`
+  warning remains.
+- Full `make rpi1_defconfig && make` reached the final link and failed on the
+  pre-existing unrelated unresolved symbol `_strcpy` from `bios/bios.tr.c:666`.
+  `usb/ucd_dwc2.c` compiled successfully before that failure.
+
+## HID QEMU Evidence
+
+The required rpi1 command was attempted with the implementation worktree
+output:
+
+```sh
+qemu-system-arm -M raspi1ap -bios kernel.img -device usb-mouse -device usb-kbd \
+  -d guest_errors -D /tmp/ptos-rpi1-hid-qemu.log -display none \
+  -serial file:/tmp/ptos-rpi1-hid-serial.log
+```
+
+It could not start because the failed full link produced no `kernel.img`:
+`qemu-system-arm: Failed to load firmware from kernel.img`. Both capture files
+were empty. No branch-matching CI artifact containing a runnable rpi1/rpi2
+image was available locally, so there is no HID enumeration or guest-error
+evidence to claim. The smoke requirements remain documented as required,
+not verified.

--- a/.superpowers/sdd/2026-08-12-async-usb-interrupt-transfers/last-shutdown-fix-report.md
+++ b/.superpowers/sdd/2026-08-12-async-usb-interrupt-transfers/last-shutdown-fix-report.md
@@ -1,0 +1,31 @@
+# #177 Shutdown IRQ Gate Report
+
+## Change
+
+`dwc2_irq_handler()` returns immediately after recognizing a host-channel or
+SOF interrupt when `priv->shutting_down` is set. It therefore does not read or
+acknowledge async channel interrupts, invoke callbacks, schedule a slot, or
+start DMA while `usb_lowlevel_stop()` is draining slots. The shutdown drain
+remains responsible for observing `CHHLTD` and releasing each slot.
+
+The async contract test now requires this gate to precede async HAINT handling.
+
+## Verification
+
+- `sh tools/test-dwc2-async-contract.sh`: passed (first run failed before the
+  gate was added).
+- `make gitready`: passed.
+- `git diff --check`: passed.
+- `make rpi1_defconfig && make clean && make obj/ucd_dwc2.o`: passed.
+- `make rpi2_defconfig && make clean && make obj/ucd_dwc2.o`: passed.
+- `make rpi2-sparse_defconfig && make clean && make obj/ucd_dwc2.o`: passed.
+- `make rpi3_defconfig && make clean && make obj/ucd_dwc2.o`: passed.
+- `make rpi4_defconfig`: DWC2 excluded by configuration; RPi 4 uses xHCI.
+
+The object builds retain the existing unused `hcd_name` warning. Make commands
+also retain existing target-override warnings.
+
+## Concerns
+
+No emulator boot test was run: this is an IRQ/teardown state gate and the
+requested verification was the contract test plus feasible DWC2 object builds.

--- a/bios/arch/arm/vectors.c
+++ b/bios/arch/arm/vectors.c
@@ -106,11 +106,6 @@ void int_vbl(void)
     vblsem++; // release vbl semaphore (TODO: non-atomic)
 }
 
-#if CONF_WITH_USB
-extern void usb_mouse_timerc (void);
-extern void usb_keyboard_timerc (void);
-#endif
-
 // ==== Timer C interrupt handler ============================================
 // Machine-independent: every ARM machine's periodic tick (raspi's system /
 // generic timer, virt's generic timer) ends up here through vector_5ms.
@@ -124,11 +119,6 @@ void int_timerc(void)
 #       if CONF_WITH_YM2149
             sndirq();   // dosound support
 #       endif
-#       if CONF_WITH_USB
-            usb_mouse_timerc();
-            usb_keyboard_timerc();
-#       endif
-
         // Fake vbl interrupt every 4 timer_c calls (50Hz)
         int_vbl();
     }

--- a/docs/superpowers/plans/2026-08-12-async-usb-interrupt-transfers.md
+++ b/docs/superpowers/plans/2026-08-12-async-usb-interrupt-transfers.md
@@ -1,0 +1,894 @@
+# Async USB HID Interrupt Transfers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Raspberry Pi Timer-C HID polling with DWC2 IRQ-driven asynchronous interrupt-IN transfers for boot mouse and keyboard devices.
+
+**Architecture:** Keep DWC2 host channel 0 and all existing enumeration, control, and bulk transfers synchronous. Add a narrow async interrupt-IN message API and a fixed DWC2 async-slot pool on channels 1–4; the USB IRQ handler re-arms NAKed requests and dispatches completed reports to mouse and keyboard callbacks. Full/low-speed devices behind the LAN951x high-speed hub retain start-split/complete-split handling.
+
+**Tech Stack:** C90 with GNU extensions, pTOS USB UCD/UDD APIs, BCM2835/BCM2836 DWC2 host controller, ARM IRQs, DMA cache maintenance, QEMU Raspberry Pi USB HID devices.
+
+## Global Constraints
+
+- Keep host channel 0 exclusively for the current synchronous `chunk_msg()` path.
+- Use only DWC2 channels 1–4 for a fixed async-slot pool; do not add a dynamic request scheduler.
+- Keep synchronous enumeration, control, and bulk transfers unchanged.
+- Process HID reports in ARM IRQ context; this matches the existing Timer-C report-dispatch context.
+- Re-arm NAKed async IN transfers internally without invoking the UDD callback.
+- Preserve DATA toggles over successful transfers and leave them unchanged for NAKs.
+- Support start-split/complete-split transfers for full/low-speed devices behind a high-speed hub.
+- Stop requests on real transport/protocol errors; never create a persistent error IRQ loop.
+- Preserve boot mouse packet translation, wheel/extra-button behavior, keyboard rollover filtering, and release-before-press ordering.
+- Suppress truly identical mouse reports because some devices send them despite `SET_IDLE(0)`.
+- Remove USB I/O from `bios/arch/arm/vectors.c::int_timerc()`.
+- Update `.claude/skills/ptos-smoketest/SKILL.md` so rpi1/rpi2 QEMU commands require `-device usb-mouse -device usb-kbd`.
+- Keep all C changes C90-compatible and use `/* */` comments.
+
+---
+
+## File Structure
+
+- Modify `usb/usb_api.h`: add async interrupt-IN UCD ioctl opcodes, callback type, and request structure.
+- Modify `usb/usb.h`: declare generic submit/cancel wrappers for persistent async interrupt-IN requests.
+- Modify `usb/usb.c`: route the new wrappers to the owning UCD's ioctl method.
+- Modify `usb/ucd_dwc2.c`: add fixed async slots, USB IRQ setup/handler, DWC2 channel state machine, DMA handling, submit/cancel ioctl cases, and safe low-level teardown.
+- Modify `usb/udd_mouse.c`: replace Timer-C polling and unused legacy irq stub with an async completion callback and probe/disconnect submission lifecycle.
+- Modify `usb/udd_keyboard.c`: replace Timer-C polling and unused legacy irq stub with an async completion callback and probe/disconnect submission lifecycle.
+- Modify `bios/arch/arm/vectors.c`: remove HID polling declarations and calls from Timer-C.
+- Modify `.claude/skills/ptos-smoketest/SKILL.md`: attach QEMU USB mouse and keyboard to rpi1/rpi2 smoke-test commands and require their enumeration as the input-path signal.
+
+## Task 1: Add the Narrow Async Interrupt-IN API
+
+**Files:**
+- Modify: `usb/usb_api.h:39-74`
+- Modify: `usb/usb.h` near the existing `usb_submit_int_msg()` declaration
+- Modify: `usb/usb.c:119-140`
+
+**Interfaces:**
+- Consumes: `struct usb_device`, `struct ucdif`, and the existing UCD ioctl dispatch.
+- Produces:
+  ```c
+  typedef void (*usb_async_int_callback_t)(struct usb_async_int_msg *msg,
+                                           LONG status, LONG actual_length);
+
+  struct usb_async_int_msg {
+      struct usb_device *dev;
+      ULONG pipe;
+      void *buffer;
+      LONG transfer_len;
+      LONG interval;
+      usb_async_int_callback_t callback;
+      void *context;
+  };
+
+  LONG usb_submit_async_int_msg(struct usb_async_int_msg *msg);
+  LONG usb_cancel_async_int_msg(struct usb_async_int_msg *msg);
+  ```
+- The UCD ioctl opcodes are `SUBMIT_ASYNC_INT_MSG` and `CANCEL_ASYNC_INT_MSG`, allocated after `SUBMIT_INT_MSG`.
+
+- [ ] **Step 1: Add the request type and ioctl opcodes**
+
+In `usb/usb_api.h`, add the two opcodes after `SUBMIT_INT_MSG` and define the callback/request structure after `struct int_msg`:
+
+```c
+#define SUBMIT_ASYNC_INT_MSG  (('U' << 8) | 5)
+#define CANCEL_ASYNC_INT_MSG  (('U' << 8) | 6)
+
+struct usb_async_int_msg;
+typedef void (*usb_async_int_callback_t)(struct usb_async_int_msg *msg,
+                                         LONG status, LONG actual_length);
+
+struct usb_async_int_msg
+{
+    struct usb_device *dev;
+    ULONG pipe;
+    void *buffer;
+    LONG transfer_len;
+    LONG interval;
+    usb_async_int_callback_t callback;
+    void *context;
+};
+```
+
+- [ ] **Step 2: Add the generic wrapper declarations**
+
+In `usb/usb.h`, place these declarations beside the existing synchronous interrupt-message API:
+
+```c
+LONG usb_submit_async_int_msg(struct usb_async_int_msg *msg);
+LONG usb_cancel_async_int_msg(struct usb_async_int_msg *msg);
+```
+
+- [ ] **Step 3: Implement thin UCD-routing wrappers**
+
+Add these functions in `usb/usb.c` after `usb_submit_int_msg()`:
+
+```c
+LONG usb_submit_async_int_msg(struct usb_async_int_msg *msg)
+{
+    struct ucdif *ucd;
+
+    if (!msg || !msg->dev || !msg->buffer || msg->transfer_len <= 0
+        || !msg->callback)
+        return -1;
+
+    ucd = msg->dev->controller;
+    return (*ucd->ioctl)(ucd, SUBMIT_ASYNC_INT_MSG, (LONG)msg);
+}
+
+LONG usb_cancel_async_int_msg(struct usb_async_int_msg *msg)
+{
+    struct ucdif *ucd;
+
+    if (!msg || !msg->dev)
+        return -1;
+
+    ucd = msg->dev->controller;
+    return (*ucd->ioctl)(ucd, CANCEL_ASYNC_INT_MSG, (LONG)msg);
+}
+```
+
+- [ ] **Step 4: Build a Raspberry Pi configuration to validate the API is wired without callers**
+
+Run:
+
+```bash
+make rpi2_defconfig && make
+```
+
+Expected: compilation and linking complete; no code outside the new wrappers calls the API yet.
+
+- [ ] **Step 5: Commit the API boundary**
+
+```bash
+git add usb/usb_api.h usb/usb.h usb/usb.c
+git commit -m "Add async USB interrupt message API"
+```
+
+## Task 2: Add DWC2 IRQ-Driven Async Interrupt-IN Slots
+
+**Files:**
+- Modify: `usb/ucd_dwc2.c:18-90,456-478,818-875,1185-1225,1242-1291`
+
+**Interfaces:**
+- Consumes: `struct usb_async_int_msg`, `ARM_IRQ_USB`, `raspi_connect_irq()`, `phys_to_bus()`, cache-maintenance functions, and DWC2 register definitions from `usb/ucd_dwc2.h`.
+- Produces: support for `SUBMIT_ASYNC_INT_MSG` and `CANCEL_ASYNC_INT_MSG` in `dwc2_ioctl()`; callbacks receive `0` and a positive actual length for a successful transfer, or `-1` and `0` for a stopped transport/protocol error.
+
+- [ ] **Step 1: Define slot limits and per-slot state**
+
+Keep `DWC2_HC_CHANNEL` at `0` and add these constants and types near it:
+
+```c
+#define DWC2_ASYNC_FIRST_CHANNEL  1
+#define DWC2_ASYNC_SLOT_COUNT     4
+#define DWC2_ASYNC_DMA_SIZE       8
+
+typedef enum {
+    DWC2_ASYNC_SPLIT_NONE,
+    DWC2_ASYNC_SPLIT_START,
+    DWC2_ASYNC_SPLIT_COMPLETE
+} DWC2_ASYNC_SPLIT_STATE;
+
+struct dwc2_async_slot
+{
+    struct usb_async_int_msg *msg;
+    UBYTE pid;
+    BOOL active;
+    BOOL cancelled;
+    BOOL split;
+    BOOL split_complete;
+    DWC2_ASYNC_SPLIT_STATE split_state;
+    UBYTE hub_addr;
+    UBYTE hub_port;
+    UBYTE *dma_buffer;
+};
+```
+
+Add this standalone storage after `dwc2_local`:
+
+```c
+static UBYTE dwc2_async_dma[DWC2_ASYNC_SLOT_COUNT]
+    [roundup(DWC2_ASYNC_DMA_SIZE, ARCH_DMA_MINALIGN)]
+    __attribute__((aligned(ARCH_DMA_MINALIGN)));
+```
+
+Assign `slot->dma_buffer = dwc2_async_dma[index]` when allocating a slot. Do
+not use the synchronous `aligned_buffer_addr`, because an IRQ transfer may run
+while channel 0 is enumerating a device.
+
+Extend `struct dwc2_priv` with:
+
+```c
+struct dwc2_async_slot async[DWC2_ASYNC_SLOT_COUNT];
+BOOL irq_connected;
+```
+
+- [ ] **Step 2: Add slot lookup, start, stop, and DMA helpers**
+
+Add static helpers with these exact responsibilities:
+
+```c
+static struct dwc2_async_slot *dwc2_async_find(struct dwc2_priv *priv,
+                                                struct usb_async_int_msg *msg);
+static struct dwc2_async_slot *dwc2_async_alloc(struct dwc2_priv *priv,
+                                                 struct usb_async_int_msg *msg);
+static void dwc2_async_start(struct dwc2_priv *priv,
+                             struct dwc2_async_slot *slot);
+static void dwc2_async_stop(struct dwc2_priv *priv,
+                            struct dwc2_async_slot *slot);
+static void dwc2_async_complete(struct dwc2_priv *priv,
+                                struct dwc2_async_slot *slot,
+                                LONG status, LONG actual_length);
+static void dwc2_async_finish_success(struct dwc2_priv *priv,
+                                      struct dwc2_async_slot *slot,
+                                      struct dwc2_hc_regs *hc);
+static void dwc2_async_finish_error(struct dwc2_priv *priv,
+                                    struct dwc2_async_slot *slot);
+```
+
+`dwc2_async_start()` must:
+
+1. Derive the host channel as `DWC2_ASYNC_FIRST_CHANNEL + slot_index`.
+2. Call `dwc_otg_hc_init()` for `slot->msg->dev`, its IN pipe endpoint, and
+   `DWC2_HCCHAR_EPTYPE_INTR`.
+3. Restore hub split information when `slot->split` is true; use
+   `dwc_otg_hc_init_split()` and set `DWC2_HCSPLT_COMPSPLT` only for
+   `DWC2_ASYNC_SPLIT_COMPLETE`.
+4. Program one packet in `HCTSIZ` with `slot->pid`.
+5. Invalidate the DMA buffer, program `HCDMA` with `phys_to_bus()`, clear all
+   pending channel interrupts, and unmask `XFERCOMP`, `CHHLTD`, `STALL`,
+   `AHBERR`, `XACTERR`, `BBLERR`, `DATATGLERR`, `NAK`, `ACK`, and `NYET`.
+6. Set the channel bit in `HAINTMSK`.
+7. Read `HFNUM`; select the opposite parity for `HCCHAR.ODDFRM` when the
+   current frame is even, matching the existing synchronous interrupt path.
+8. Set `HCCHAR.CHENA` with `CHDIS` clear.
+
+`dwc2_async_stop()` must clear the slot's `HAINTMSK` bit, request channel
+disable if `HCCHAR.CHENA` is set, clear its interrupt mask/status, and reset
+`active`, `cancelled`, and `msg` only after no re-arm can occur.
+
+`dwc2_async_complete()` must invoke `msg->callback(msg, status, actual_length)`
+while the slot stays active; it must not call a callback after cancellation.
+
+`dwc2_async_finish_success()` must read `HCTSIZ`, calculate:
+
+```c
+actual_length = slot->msg->transfer_len
+                - ((hctsiz & DWC2_HCTSIZ_XFERSIZE_MASK)
+                   >> DWC2_HCTSIZ_XFERSIZE_OFFSET);
+slot->pid = (hctsiz & DWC2_HCTSIZ_PID_MASK) >> DWC2_HCTSIZ_PID_OFFSET;
+```
+
+It then invalidates `slot->dma_buffer` for
+`roundup(actual_length, ARCH_DMA_MINALIGN)`, copies `actual_length` bytes into
+`slot->msg->buffer`, calls `dwc2_async_complete(priv, slot, 0, actual_length)`,
+and calls `dwc2_async_start(priv, slot)` unless cancellation occurred during
+the callback.
+
+`dwc2_async_finish_error()` must call `dwc2_async_stop(priv, slot)` before
+calling `slot->msg->callback(slot->msg, -1, 0)`. Save `msg` in a local before
+stopping the slot so the callback argument remains valid. It must not re-arm.
+
+- [ ] **Step 3: Implement the DWC2 USB IRQ handler**
+
+Add `static void dwc2_irq_handler(void)` and have it:
+
+```c
+static void dwc2_irq_handler(void)
+{
+    struct dwc2_priv *priv = &dwc2_local;
+    struct dwc2_core_regs *regs = priv->regs;
+    ULONG gintsts;
+    ULONG pending;
+    WORD index;
+
+    gintsts = readl(&regs->gintsts);
+    if (!(gintsts & DWC2_GINTSTS_HCINTR))
+        return;
+
+    pending = readl(&regs->haint) & readl(&regs->haintmsk);
+    for (index = 0; index < DWC2_ASYNC_SLOT_COUNT; index++)
+    {
+        struct dwc2_async_slot *slot = &priv->async[index];
+        WORD channel = DWC2_ASYNC_FIRST_CHANNEL + index;
+        struct dwc2_hc_regs *hc = &regs->hc_regs[channel];
+        ULONG hcint;
+
+        if (!(pending & (1UL << channel)))
+            continue;
+
+        hcint = readl(&hc->hcint);
+        writel(hcint, &hc->hcint);
+
+        if (!slot->active || slot->cancelled)
+        {
+            dwc2_async_stop(priv, slot);
+            continue;
+        }
+
+        if (slot->split)
+        {
+            if (slot->split_state == DWC2_ASYNC_SPLIT_START
+                && (hcint & DWC2_HCINT_ACK))
+            {
+                slot->split_state = DWC2_ASYNC_SPLIT_COMPLETE;
+                dwc2_async_start(priv, slot);
+            }
+            else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE
+                     && (hcint & DWC2_HCINT_NYET))
+            {
+                dwc2_async_start(priv, slot);
+            }
+            else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE
+                     && (hcint & DWC2_HCINT_NAK))
+            {
+                slot->split_state = DWC2_ASYNC_SPLIT_START;
+                dwc2_async_start(priv, slot);
+            }
+            else if (hcint & DWC2_HCINT_XFERCOMP)
+            {
+                slot->split_state = DWC2_ASYNC_SPLIT_START;
+                dwc2_async_finish_success(priv, slot, hc);
+            }
+            else
+            {
+                dwc2_async_finish_error(priv, slot);
+            }
+        }
+        else if (hcint & DWC2_HCINT_XFERCOMP)
+        {
+            dwc2_async_finish_success(priv, slot, hc);
+        }
+        else if ((hcint & DWC2_HCINT_NAK) || hcint == DWC2_HCINT_CHHLTD)
+        {
+            dwc2_async_start(priv, slot);
+        }
+        else
+        {
+            dwc2_async_finish_error(priv, slot);
+        }
+    }
+}
+```
+
+Complete the dispatch with these exact rules:
+
+- For non-split `XFERCOMP`, compute `actual_length` as
+  `msg->transfer_len - remaining_hctsiz_bytes`, update `slot->pid` from
+  `HCTSIZ.PID`, invalidate/copy the DMA bytes to `msg->buffer`, callback with
+  `(0, actual_length)`, then call `dwc2_async_start()` unless cancelled.
+- For non-split `NAK` or bare `CHHLTD`, call `dwc2_async_start()` without a
+  callback or toggle update.
+- For start split `ACK`, set `split_state = DWC2_ASYNC_SPLIT_COMPLETE` and
+  re-arm.
+- For complete split `NYET`, retain complete-split state and re-arm.
+- For complete split `NAK`, set `split_state = DWC2_ASYNC_SPLIT_START` and
+  re-arm.
+- For complete split `XFERCOMP`, copy/callback/re-arm from start-split state.
+- For `STALL`, `AHBERR`, `XACTERR`, `BBLERR`, `DATATGLERR`, or any unhandled
+  channel status, stop the slot then callback with `(-1, 0)`; do not re-arm.
+
+Read and acknowledge `HAINT`/`GINTSTS` after servicing the channels, following
+the write-back-to-clear convention used by DWC2 host interrupt registers.
+
+- [ ] **Step 4: Wire initialization, teardown, and ioctl dispatch**
+
+In `usb_lowlevel_init()` after `dwc2_init_core()` succeeds:
+
+```c
+raspi_connect_irq(ARM_IRQ_USB, dwc2_irq_handler);
+setbits_le32(&regs->gintmsk, DWC2_GINTMSK_HCINTR);
+setbits_le32(&regs->gahbcfg, DWC2_GAHBCFG_GLBLINTRMSK);
+priv->irq_connected = TRUE;
+```
+
+In `usb_lowlevel_stop()`, stop every active async slot, clear
+`DWC2_GINTMSK_HCINTR` and `DWC2_GAHBCFG_GLBLINTRMSK`, disconnect
+`ARM_IRQ_USB`, and set `irq_connected = FALSE` before calling
+`dwc2_uninit_common()`.
+
+Add `dwc2_submit_async_int_msg()` and `dwc2_cancel_async_int_msg()` and route
+the two new ioctl opcodes in `dwc2_ioctl()`. Submission must reject:
+
+```c
+!msg || !msg->dev || !msg->buffer || !msg->callback
+|| msg->transfer_len <= 0 || msg->transfer_len > DWC2_ASYNC_DMA_SIZE
+|| !usb_pipein(msg->pipe)
+|| usb_pipetype(msg->pipe) != PIPE_INTERRUPT
+```
+
+For split detection, copy the existing `chunk_msg()` policy:
+
+```c
+if (msg->dev->speed != USB_SPEED_HIGH
+    && (readl(&priv->regs->hprt0) & DWC2_HPRT0_PRTSPD_MASK)
+        == DWC2_HPRT0_PRTSPD_HIGH)
+    usb_find_usb2_hub_address_port(msg->dev, &slot->hub_addr, &slot->hub_port);
+```
+
+Mark `slot->split` only when that lookup identifies a hub path.
+
+- [ ] **Step 5: Build all DWC2 Raspberry Pi configurations**
+
+Run each command serially, because each rewrites `.config`:
+
+```bash
+make rpi1_defconfig && make
+make rpi2_defconfig && make
+make rpi2-sparse_defconfig && make
+make rpi3_defconfig && make
+```
+
+Expected: all images link. At this stage no UDD submits an async request, so
+the new IRQ path is compiled but inactive.
+
+- [ ] **Step 6: Commit the DWC2 async foundation**
+
+```bash
+git add usb/ucd_dwc2.c
+git commit -m "Add async DWC2 interrupt transfer support"
+```
+
+## Task 3: Convert the USB Mouse UDD to Persistent Async Reports
+
+**Files:**
+- Modify: `usb/udd_mouse.c:25-193,201-290`
+
+**Interfaces:**
+- Consumes: `struct usb_async_int_msg`, `usb_submit_async_int_msg()`, and `usb_cancel_async_int_msg()` from Task 1.
+- Consumes: successful callback signature `void mouse_report_complete(struct usb_async_int_msg *msg, LONG status, LONG actual_length)`.
+- Produces: mouse reports reach `call_mousevec()` from `ARM_IRQ_USB`; `usb_mouse_timerc()` and `usb_mouse_irq()` no longer exist.
+
+- [ ] **Step 1: Make the report buffer and request persistent**
+
+Replace the `char new[8]` field in `struct mse_data` with a `UBYTE report[8]`
+field. Add this static request next to `mse_data`:
+
+```c
+static struct usb_async_int_msg mouse_request;
+```
+
+Remove unused declarations and fields: `mouse_packet` may remain; remove
+`usb_mouse_timerc()`, `usb_mouse_irq()`, `ep_out`, and `irq_handle`.
+
+- [ ] **Step 2: Extract the report decoder into an async callback**
+
+Replace `usb_mouse_timerc()` with:
+
+```c
+static void mouse_report_complete(struct usb_async_int_msg *msg,
+                                  LONG status, LONG actual_length)
+{
+    UBYTE info;
+    UBYTE old_info;
+    BYTE delta_x;
+    BYTE delta_y;
+    UBYTE extra;
+    BOOL changed;
+
+    if (status || actual_length < 3 || actual_length > 8)
+    {
+        KDEBUG(("usb mouse interrupt transfer failed (%ld, %ld)\n",
+                status, actual_length));
+        return;
+    }
+
+    info = mse_data.report[0];
+    old_info = mse_data.data[0];
+    delta_x = mse_data.report[1];
+    delta_y = mse_data.report[2];
+    extra = (actual_length >= 4) ? mse_data.report[3] : 0;
+    changed = (info != old_info) || delta_x || delta_y
+              || ((actual_length >= 4) && (extra != mse_data.data[3]));
+    if (!changed)
+        return;
+
+    mouse_packet[0] = ((info & 1) << 1) | ((info & 2) >> 1) | 0xf8;
+    mouse_packet[1] = delta_x;
+    mouse_packet[2] = delta_y;
+
+    if ((info ^ old_info) & 4)
+        mousexvec((info & 4) ? 0x37 : 0xb7);
+
+    switch (extra & 0x0f)
+    {
+    case 0x1:
+        mousexvec(0x59);
+        break;
+    case 0x2:
+        mousexvec(0x5d);
+        break;
+    case 0xe:
+        mousexvec(0x5c);
+        break;
+    case 0xf:
+        mousexvec(0x5a);
+        break;
+    default:
+        break;
+    }
+
+    call_mousevec(mouse_packet);
+    mse_data.data[0] = info;
+    mse_data.data[1] = delta_x;
+    mse_data.data[2] = delta_y;
+    if (actual_length >= 4)
+        mse_data.data[3] = extra;
+    else
+        mse_data.data[3] = 0;
+    mse_data.data[4] = 0;
+    mse_data.data[5] = 0;
+}
+```
+
+This callback fixes stale wheel bytes noted in the review of PR #168: it
+stores byte 3 only when received and clears bytes 4–5 because boot-protocol
+mouse reports have no defined values there.
+
+Do not resubmit from the callback: Task 2's DWC2 slot re-arms successful
+transfers after the callback returns.
+
+- [ ] **Step 3: Submit at probe and cancel at disconnect**
+
+At the end of successful `mouse_probe()` initialization, after all endpoint
+metadata, report buffers, boot protocol, and idle mode are initialized, fill
+the request:
+
+```c
+mouse_request.dev = dev;
+mouse_request.pipe = mse_data.irqpipe;
+mouse_request.buffer = mse_data.report;
+mouse_request.transfer_len = mse_data.irqmaxp > 8 ? 8 : mse_data.irqmaxp;
+mouse_request.interval = mse_data.irqinterval;
+mouse_request.callback = mouse_report_complete;
+mouse_request.context = &mse_data;
+mse_data.pusb_dev = dev;
+
+if (usb_submit_async_int_msg(&mouse_request))
+{
+    mse_data.pusb_dev = NULL;
+    return -1;
+}
+```
+
+Do not assign `dev->irq_handle`.
+
+In `mouse_disconnect()`, cancel before clearing the device pointer:
+
+```c
+if (dev == mse_data.pusb_dev)
+{
+    usb_cancel_async_int_msg(&mouse_request);
+    mse_data.pusb_dev = NULL;
+}
+```
+
+- [ ] **Step 4: Build and smoke rpi1 with an attached HID mouse**
+
+Run:
+
+```bash
+make rpi1_defconfig && make
+qemu-system-arm -M raspi1ap -bios kernel.img -device usb-mouse -device usb-kbd \
+  -d guest_errors -serial stdio
+```
+
+Expected: pTOS reaches the boot/desktop path without guest errors. Serial
+output shows the USB mouse class driver probes the attached boot mouse; no
+Timer-C mouse poll symbol remains.
+
+- [ ] **Step 5: Commit the mouse migration**
+
+```bash
+git add usb/udd_mouse.c
+git commit -m "Move USB mouse input to DWC2 interrupts"
+```
+
+## Task 4: Convert the USB Keyboard UDD and Remove Timer-C USB Polling
+
+**Files:**
+- Modify: `usb/udd_keyboard.c:7-14,37-48,119-287,289-375`
+- Modify: `bios/arch/arm/vectors.c:109-144`
+
+**Interfaces:**
+- Consumes: the persistent async interrupt-IN API and DWC2 semantics from Tasks 1–2.
+- Produces: keyboard reports reach `kbd_int()` from `ARM_IRQ_USB`; `int_timerc()` no longer references USB HID polling.
+
+- [ ] **Step 1: Add a persistent keyboard report buffer and request**
+
+Extend `struct kbd_data` with:
+
+```c
+UBYTE report[8];
+```
+
+Add next to `kbd_data`:
+
+```c
+static struct usb_async_int_msg keyboard_request;
+```
+
+Remove the top-file wording that says Timer C polls the endpoint. Remove
+`usb_keyboard_timerc()` and the unused `usb_keyboard_irq()` stub.
+
+- [ ] **Step 2: Move keyboard report processing into its callback**
+
+Create:
+
+```c
+static void keyboard_report_complete(struct usb_async_int_msg *msg,
+                                     LONG status, LONG actual_length)
+{
+    UBYTE changed_mod;
+    int i;
+
+    if (status || actual_length < 8)
+    {
+        KDEBUG(("usb keyboard interrupt transfer failed (%ld, %ld)\n",
+                status, actual_length));
+        return;
+    }
+
+    for (i = 0; i < 6; i++)
+    {
+        if (kbd_data.report[2 + i] >= 1 && kbd_data.report[2 + i] <= 3)
+            return;
+    }
+
+    kbd_data.new_modifier = kbd_data.report[0];
+    for (i = 0; i < 6; i++)
+        kbd_data.new_keys[i] = kbd_data.report[2 + i];
+
+    for (i = 0; i < 6; i++)
+    {
+        UBYTE key = kbd_data.keys[i];
+
+        if (key && key < USB_KEYTBL_SIZE
+            && !usb_keyboard_key_in(kbd_data.new_keys, key))
+        {
+            UBYTE scancode = usb_keytbl[key];
+            if (scancode)
+                kbd_int(scancode | KEY_RELEASED);
+        }
+    }
+
+    changed_mod = kbd_data.modifier ^ kbd_data.new_modifier;
+    for (i = 0; i < 8; i++)
+    {
+        if ((changed_mod & (1 << i)) && !(kbd_data.new_modifier & (1 << i)))
+        {
+            UBYTE scancode = usb_modtbl[i];
+            if (scancode)
+                kbd_int(scancode | KEY_RELEASED);
+        }
+    }
+
+    for (i = 0; i < 8; i++)
+    {
+        if ((changed_mod & (1 << i)) && (kbd_data.new_modifier & (1 << i)))
+        {
+            UBYTE scancode = usb_modtbl[i];
+            if (scancode)
+                kbd_int(scancode);
+        }
+    }
+
+    for (i = 0; i < 6; i++)
+    {
+        UBYTE key = kbd_data.new_keys[i];
+
+        if (key && key < USB_KEYTBL_SIZE
+            && !usb_keyboard_key_in(kbd_data.keys, key))
+        {
+            UBYTE scancode = usb_keytbl[key];
+            if (scancode)
+                kbd_int(scancode);
+        }
+    }
+
+    kbd_data.modifier = kbd_data.new_modifier;
+    for (i = 0; i < 6; i++)
+        kbd_data.keys[i] = kbd_data.new_keys[i];
+}
+```
+
+Do not re-submit from the callback.
+
+- [ ] **Step 3: Submit/cancel the keyboard request in lifecycle handlers**
+
+At the end of `keyboard_probe()`, after boot protocol and `SET_IDLE`, set:
+
+```c
+keyboard_request.dev = dev;
+keyboard_request.pipe = kbd_data.irqpipe;
+keyboard_request.buffer = kbd_data.report;
+keyboard_request.transfer_len = kbd_data.irqmaxp > 8 ? 8 : kbd_data.irqmaxp;
+keyboard_request.interval = kbd_data.irqinterval;
+keyboard_request.callback = keyboard_report_complete;
+keyboard_request.context = &kbd_data;
+kbd_data.pusb_dev = dev;
+
+if (usb_submit_async_int_msg(&keyboard_request))
+{
+    kbd_data.pusb_dev = NULL;
+    return -1;
+}
+```
+
+Remove `dev->irq_handle` assignment. In `keyboard_disconnect()`, call
+`usb_cancel_async_int_msg(&keyboard_request)` immediately after confirming
+the device matches and before synthesizing releases.
+
+- [ ] **Step 4: Remove USB work from Timer C**
+
+In `bios/arch/arm/vectors.c`, remove:
+
+```c
+#if CONF_WITH_USB
+extern void usb_mouse_timerc (void);
+extern void usb_keyboard_timerc (void);
+#endif
+```
+
+and remove the entire `#if CONF_WITH_USB` block calling those functions from
+`int_timerc()`. Keep the existing `kb_timerc_int()`, optional `sndirq()`, and
+50 Hz `int_vbl()` structure unchanged.
+
+- [ ] **Step 5: Compile all affected configurations**
+
+Run:
+
+```bash
+make rpi1_defconfig && make
+make rpi2_defconfig && make
+make rpi2-sparse_defconfig && make
+make rpi3_defconfig && make
+make rpi4_defconfig && make
+```
+
+Expected: rpi1–rpi3 compile their DWC2 async path; rpi4 still compiles without
+pulling in DWC2 async behavior.
+
+- [ ] **Step 6: Commit keyboard and Timer-C migration**
+
+```bash
+git add usb/udd_keyboard.c bios/arch/arm/vectors.c
+git commit -m "Move USB keyboard input to DWC2 interrupts"
+```
+
+## Task 5: Require QEMU HID Devices in the Smoke-Test Skill and Validate
+
+**Files:**
+- Modify: `.claude/skills/ptos-smoketest/SKILL.md:195-206,254-255`
+
+**Interfaces:**
+- Consumes: rpi1 `kernel.img`, rpi2 `kernel7.img`, QEMU's `usb-mouse` and `usb-kbd` devices.
+- Produces: documented smoke-test commands that exercise pTOS HID enumeration rather than merely registering the class drivers.
+
+- [ ] **Step 1: Update rpi1 and rpi2 invocation examples**
+
+Replace the rpi1 command with:
+
+```sh
+qemu-system-arm -M raspi1ap -bios kernel.img -device usb-mouse -device usb-kbd \
+  -d guest_errors -serial stdio
+```
+
+Replace the rpi2 command with:
+
+```sh
+qemu-system-arm -M raspi2b -bios kernel7.img -device usb-mouse -device usb-kbd \
+  -d guest_errors -serial stdio
+```
+
+Add an immediately adjacent note that these devices are required whenever
+validating USB HID input; without them the class drivers register but no mouse
+or keyboard is enumerated.
+
+- [ ] **Step 2: Strengthen Raspberry Pi pass criteria**
+
+Change the rpi1/rpi2 pass-signal bullets to require all of:
+
+```text
+- no guest_errors;
+- the screen reaches the normal boot/desktop path; and
+- serial traces confirm mouse and keyboard HID probes after attaching
+  -device usb-mouse -device usb-kbd.
+```
+
+- [ ] **Step 3: Download CI images and run both HID-enabled QEMU smokes**
+
+After pushing the implementation, identify the workflow run for the branch
+and download its rpi artifacts:
+
+```bash
+gh run download <run-id> -D /tmp/ptos-ci-artifacts -p "ptos-rpi*"
+```
+
+Run rpi1:
+
+```bash
+qemu-system-arm -M raspi1ap \
+  -bios /tmp/ptos-ci-artifacts/ptos-rpi1/kernel.img \
+  -device usb-mouse -device usb-kbd -d guest_errors -serial stdio -display none
+```
+
+Run rpi2:
+
+```bash
+qemu-system-arm -M raspi2b \
+  -bios /tmp/ptos-ci-artifacts/ptos-rpi2/kernel7.img \
+  -device usb-mouse -device usb-kbd -d guest_errors -serial stdio -display none
+```
+
+On macOS, stop each emulator after the boot signal with a background PID plus
+`sleep` and `kill`; do not rely on GNU `timeout`.
+
+Expected: both images boot, enumerate the attached HID mouse and keyboard,
+and emit no guest errors. Then test repeated short stationary clicks and rapid
+keyboard input on real Raspberry Pi hardware.
+
+- [ ] **Step 4: Commit smoke-test documentation**
+
+```bash
+git add .claude/skills/ptos-smoketest/SKILL.md
+git commit -m "Document USB HID devices for Raspberry Pi smoke tests"
+```
+
+## Task 6: Final Integration Review
+
+**Files:**
+- Verify: `usb/usb_api.h`
+- Verify: `usb/usb.h`
+- Verify: `usb/usb.c`
+- Verify: `usb/ucd_dwc2.c`
+- Verify: `usb/udd_mouse.c`
+- Verify: `usb/udd_keyboard.c`
+- Verify: `bios/arch/arm/vectors.c`
+- Verify: `.claude/skills/ptos-smoketest/SKILL.md`
+
+**Interfaces:**
+- Verifies the complete #177 contract: UDD submit/cancel lifecycle, DWC2 IRQ ownership, split transfer state handling, and no Timer-C USB polling.
+
+- [ ] **Step 1: Confirm no legacy polling or legacy HID irq stubs remain**
+
+Run:
+
+```bash
+rg "usb_(mouse|keyboard)_timerc|usb_(mouse|keyboard)_irq|irq_handle =" \
+  usb bios/arch/arm/vectors.c
+```
+
+Expected: no mouse/keyboard Timer-C polling functions, no obsolete HID IRQ
+stub assignments, and no USB HID call from `int_timerc()`.
+
+- [ ] **Step 2: Run formatting and final builds**
+
+Run:
+
+```bash
+make gitready
+make rpi1_defconfig && make
+make rpi2_defconfig && make
+```
+
+Expected: formatting checks pass and both images link.
+
+- [ ] **Step 3: Inspect the final diff and status**
+
+Run:
+
+```bash
+git diff master...HEAD --check
+```
+
+Expected: only the planned API, DWC2, HID UDD, Timer-C, skill, and planning
+documentation changes appear.
+
+- [ ] **Step 4: Push the completed implementation**
+
+```bash
+git push
+```
+
+Expected: PR #178 receives the complete async HID implementation and CI runs.

--- a/docs/superpowers/plans/2026-08-13-usb-async-trace-option.md
+++ b/docs/superpowers/plans/2026-08-13-usb-async-trace-option.md
@@ -1,0 +1,172 @@
+# USB Async Trace Option Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in shared USB asynchronous trace macro so normal HID operation does not flood serial debug output.
+
+**Architecture:** `usb/Kconfig` owns a disabled-by-default `CONF_DEBUG_USB_ASYNC` option. `usb/usb.h` exposes `KINFO_USB_ASYNC(args)`, which compiles to `KINFO(args)` when enabled and otherwise to a no-op. DWC2 uses it only for repeated transfer-progress messages.
+
+**Tech Stack:** Kconfig, C90 GNU C, pTOS USB stack, shell contract test.
+
+## Global Constraints
+
+- `CONF_DEBUG_USB_ASYNC` depends on `CONF_WITH_USB` and defaults to `n`.
+- The macro must be reusable by all USB host controllers.
+- Only high-frequency async progress traces are suppressed by default.
+- Errors, cancellation, shutdown, release, and initialization diagnostics remain `KINFO()`.
+- C sources use four spaces and no hard tabs; generated configuration files are not edited.
+
+---
+
+### Task 1: Add the Shared USB Async Trace Gate
+
+**Files:**
+- Modify: `usb/Kconfig`
+- Modify: `usb/usb.h`
+- Modify: `tools/test-dwc2-async-contract.sh`
+
+**Interfaces:**
+- Produces: `CONF_DEBUG_USB_ASYNC`, always defined as `0` or `1` in C.
+- Produces: `KINFO_USB_ASYNC(args)`, accepting the existing double-parenthesized `KINFO` argument convention.
+
+- [ ] **Step 1: Add a failing contract assertion**
+
+Add checks requiring the disabled Kconfig default and both macro branches:
+
+```sh
+require 'config CONF_DEBUG_USB_ASYNC' 'shared USB async trace option'
+require 'default n' 'async trace disabled by default'
+require_multiline '#if CONF_DEBUG_USB_ASYNC[\s\S]*#define KINFO_USB_ASYNC\(a\) KINFO\(a\)[\s\S]*#else[\s\S]*#define KINFO_USB_ASYNC\(a\) \(\(void\)0\)[\s\S]*#endif' \
+    'compile-time USB async trace gate'
+```
+
+- [ ] **Step 2: Run the contract test and verify it fails**
+
+Run: `sh tools/test-dwc2-async-contract.sh`
+
+Expected: failure describing the missing shared USB async trace option.
+
+- [ ] **Step 3: Add the minimal Kconfig symbol and shared macro**
+
+Add to `usb/Kconfig` before `endmenu`:
+
+```kconfig
+config CONF_DEBUG_USB_ASYNC
+    bool "Trace asynchronous USB transfers"
+    depends on CONF_WITH_USB
+    default n
+    help
+      Enable high-frequency progress traces from USB host-controller
+      asynchronous transfers.  This is useful while diagnosing USB transfer
+      scheduling, but can flood serial debug output during normal HID use.
+```
+
+Add to `usb/usb.h` after its includes:
+
+```c
+#if CONF_DEBUG_USB_ASYNC
+#define KINFO_USB_ASYNC(a) KINFO(a)
+#else
+#define KINFO_USB_ASYNC(a) ((void)0)
+#endif
+```
+
+- [ ] **Step 4: Run the contract test and verify it passes**
+
+Run: `sh tools/test-dwc2-async-contract.sh`
+
+Expected: `dwc2 async contract test passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add usb/Kconfig usb/usb.h tools/test-dwc2-async-contract.sh
+git commit -m "Add USB async trace option"
+```
+
+### Task 2: Gate DWC2 High-Frequency Progress Traces
+
+**Files:**
+- Modify: `usb/ucd_dwc2.c:654,802,871-895`
+- Modify: `tools/test-dwc2-async-contract.sh`
+
+**Interfaces:**
+- Consumes: `KINFO_USB_ASYNC(args)` from `usb/usb.h`.
+- Produces: normal DWC2 HID operation without repeated serial output unless `CONF_DEBUG_USB_ASYNC=y`.
+
+- [ ] **Step 1: Add a failing contract assertion for gated trace sites**
+
+Require that all high-frequency trace strings use the shared macro:
+
+```sh
+require_multiline 'KINFO_USB_ASYNC\(\("dwc2_async: start[\s\S]*KINFO_USB_ASYNC\(\("dwc2_async: complete[\s\S]*KINFO_USB_ASYNC\(\("dwc2_async: split-start-ack[\s\S]*KINFO_USB_ASYNC\(\("dwc2_async: split-complete-nyet[\s\S]*KINFO_USB_ASYNC\(\("dwc2_async: split-complete-nak[\s\S]*KINFO_USB_ASYNC\(\("dwc2_async: rearm' \
+    'DWC2 high-frequency async traces use the shared trace gate'
+```
+
+- [ ] **Step 2: Run the contract test and verify it fails**
+
+Run: `sh tools/test-dwc2-async-contract.sh`
+
+Expected: failure describing ungated DWC2 high-frequency traces.
+
+- [ ] **Step 3: Replace only repeated progress logs**
+
+Change these calls in `usb/ucd_dwc2.c` from `KINFO` to
+`KINFO_USB_ASYNC`:
+
+```c
+KINFO_USB_ASYNC(("dwc2_async: start channel=%d generation=%lu split=%d pid=%d\n",
+                 channel, slot->generation, slot->split_state, slot->pid));
+KINFO_USB_ASYNC(("dwc2_async: complete generation=%lu length=%ld\n", generation,
+                 actual_length));
+KINFO_USB_ASYNC(("dwc2_async: split-start-ack generation=%lu\n",
+                 slot->generation));
+KINFO_USB_ASYNC(("dwc2_async: split-complete-nyet generation=%lu\n",
+                 slot->generation));
+KINFO_USB_ASYNC(("dwc2_async: split-complete-nak generation=%lu\n",
+                 slot->generation));
+KINFO_USB_ASYNC(("dwc2_async: rearm generation=%lu reason=%s\n",
+                 slot->generation, (hcint & DWC2_HCINT_NAK) ? "nak" :
+                 "chhltd"));
+```
+
+Do not change stop, release, error, shutdown, submit, cancel, or controller
+initialization messages.
+
+- [ ] **Step 4: Run verification**
+
+Run: `sh tools/test-dwc2-async-contract.sh && make gitready && git diff --check`
+
+Expected: contract and style checks pass with no whitespace errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add usb/ucd_dwc2.c tools/test-dwc2-async-contract.sh
+git commit -m "Gate DWC2 async progress traces"
+```
+
+### Task 3: Build and PR Verification
+
+**Files:**
+- No source changes expected.
+
+**Interfaces:**
+- Verifies: Raspberry Pi configurations compile with the default-disabled option.
+
+- [ ] **Step 1: Run final local verification**
+
+Run: `sh tools/test-dwc2-async-contract.sh && make gitready && git diff --check master...HEAD`
+
+Expected: contract and style checks pass; the diff has no whitespace errors.
+
+- [ ] **Step 2: Push and inspect CI**
+
+Run:
+
+```bash
+git push origin feature/177-async-usb-interrupt-transfers
+gh pr checks 178 --watch
+```
+
+Expected: rpi1, rpi2, rpi2-sparse, rpi3, and rpi4 build successfully.

--- a/docs/superpowers/plans/2026-08-13-usb-async-trace-option.md
+++ b/docs/superpowers/plans/2026-08-13-usb-async-trace-option.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add an opt-in shared USB asynchronous trace macro so normal HID operation does not flood serial debug output.
 
-**Architecture:** `usb/Kconfig` owns a disabled-by-default `CONF_DEBUG_USB_ASYNC` option. `usb/usb.h` exposes `KINFO_USB_ASYNC(args)`, which compiles to `KINFO(args)` when enabled and otherwise to a no-op. DWC2 uses it only for repeated transfer-progress messages.
+**Architecture:** `usb/Kconfig` owns a disabled-by-default `CONF_DEBUG_USB_ASYNC` option. `usb/usb_global.h` exposes `KINFO_USB_ASYNC(args)`, which compiles to `KINFO(args)` when enabled and otherwise to a no-op. DWC2 uses it only for repeated transfer-progress messages.
 
 **Tech Stack:** Kconfig, C90 GNU C, pTOS USB stack, shell contract test.
 

--- a/docs/superpowers/specs/2026-08-12-async-usb-interrupt-transfers-design.md
+++ b/docs/superpowers/specs/2026-08-12-async-usb-interrupt-transfers-design.md
@@ -1,0 +1,203 @@
+# Async USB HID Interrupt Transfers Design
+
+## Context
+
+Issue #167 identified Raspberry Pi mouse clicks that are ignored when a
+button is pressed and released without pointer movement. PR #168 reduced the
+failure window by draining reports from Timer C and increasing polling from
+50 Hz to 200 Hz, but real-hardware testing still loses sufficiently short
+clicks.
+
+The existing DWC2 driver treats HID interrupt endpoints as synchronous,
+one-shot bulk-style transfers. The host sends an IN token only when
+`usb_mouse_timerc()` or `usb_keyboard_timerc()` runs. If a boot mouse changes
+from button-up to button-down and back to button-up between polls, its
+one-report-deep state buffer retains only button-up. The VDI sees no state
+change and cannot reconstruct the lost click.
+
+Circle solves this by submitting an asynchronous transfer to the HID
+interrupt endpoint. Its DWC2 controller IRQ processes each completion and
+immediately re-arms the request. The host therefore polls at USB frame
+cadence rather than at a software timer interval.
+
+The current DWC2 code already contains the prerequisites for a focused
+implementation: 16 host-channel register sets, DMA bounce-buffer support,
+interrupt register definitions, Raspberry Pi IRQ connection support, and a
+commented-out `raspi_connect_irq(ARM_IRQ_USB, ...)` hook. Channel 0 is the
+existing synchronous path. The unused channels can carry persistent HID
+interrupt-IN requests.
+
+## Goal
+
+Replace Timer-C USB HID polling with DWC2 IRQ-driven asynchronous interrupt
+transfers for both boot-protocol mouse and keyboard devices on Raspberry Pi
+1, 2, and 3 targets.
+
+The result must preserve the current mouse packet translation, keyboard
+rollover handling, and existing synchronous USB enumeration/control traffic,
+while reliably capturing fast input transitions that software polling can
+miss.
+
+## Non-Goals
+
+- Do not replace the generic UCD/UDD USB architecture with a general-purpose
+  USB request scheduler.
+- Do not change device enumeration, hub discovery, or synchronous control and
+  bulk transfers.
+- Do not add xHCI support or change Raspberry Pi 4 USB behavior.
+- Do not support more than the existing one boot mouse and one boot keyboard.
+- Do not modify PR #168 as part of this issue; it remains paused.
+
+## Approach
+
+### Narrow Async Interrupt-IN UCD Contract
+
+Add a controller-facing async interrupt-IN message type to `usb/usb_api.h`.
+It contains the USB device, interrupt pipe, persistent caller-owned report
+buffer, transfer length, endpoint interval, callback, and callback context.
+Add submit and cancel operations, then expose small wrappers from the generic
+USB layer. This keeps UDDs independent of DWC2 details and follows the
+existing `usb_bulk_msg()` routing model.
+
+The callback runs in IRQ context. This is compatible with the current path:
+Timer C already invokes the HID report handlers in ARM IRQ context, and the
+mouse path already relies on the AES fork queue's interrupts-masked contract.
+
+### DWC2 Async Request Slots
+
+`usb/ucd_dwc2.c` retains host channel 0 for all synchronous transfers. It
+adds a fixed pool of four async slots using channels 1 through 4. Each slot
+owns:
+
+- its assigned host channel;
+- the submitted async message;
+- cacheline-aligned DMA bounce storage;
+- the endpoint DATA toggle;
+- split-transaction phase when the device is behind a high-speed hub; and
+- active/cancelled state.
+
+Four slots are sufficient for the two current consumers while leaving a
+small margin without implementing a dynamic allocator.
+
+At low-level initialization, the driver connects `ARM_IRQ_USB`, enables the
+DWC2 host-channel interrupt source, and enables the controller's global IRQ
+mask. It only unmasks channel bits for active async slots, so channel 0's
+synchronous polling path remains unaffected.
+
+### Persistent Interrupt-IN State Machine
+
+Submitting a request initializes its host channel, DMA buffer, endpoint
+characteristics, and interrupt mask, then enables the channel on the next
+appropriate USB frame parity.
+
+The USB IRQ handler finds pending active channels and acknowledges their
+channel interrupt status. It applies this state machine:
+
+- **No data / NAK:** do not call the UDD. Re-arm the request on the next
+  frame, keeping the DATA toggle unchanged.
+- **Successful transfer:** derive the actual length and updated DATA toggle
+  from `HCTSIZ`, invalidate/copy the DMA buffer to the UDD report buffer, call
+  the callback, then re-arm the same request unless cancelled.
+- **Start split ACK:** re-arm as complete split.
+- **Complete split NYET:** re-arm complete split.
+- **Complete split NAK:** restart the split sequence on the next frame.
+- **Transfer or protocol error:** call the callback with failure and leave
+  the request stopped. A UDD may explicitly submit again after handling the
+  error; this avoids a persistent error IRQ loop.
+- **Cancellation/disconnect:** disable the host channel, release its slot, and
+  never re-arm it.
+
+Split handling is required: Raspberry Pi external ports commonly sit behind
+the LAN951x high-speed hub, so full- and low-speed HID devices need the same
+start-split/complete-split protocol as the current synchronous DWC2 path.
+
+### HID Device Drivers
+
+After HID boot-protocol setup, mouse and keyboard UDDs submit a persistent
+async request instead of depending on Timer C.
+
+Mouse completion reuses the current boot-report translation:
+
+- compare button state, motion, and available wheel byte to suppress genuine
+  duplicate reports, because some mice send identical reports even after
+  `SET_IDLE(0)`;
+- convert left/right button bits to the IKBD relative-mouse packet;
+- dispatch extra-button and wheel events; and
+- call `call_mousevec()` for changed reports.
+
+The filter does not reintroduce the original race: each edge has its own
+hardware-polled transfer completion, so the filter only removes reports that
+are truly identical to the last processed one.
+
+Keyboard completion retains the current six-key rollover rejection and
+release-before-press ordering. Both UDDs cancel their request on disconnect.
+The legacy `dev->irq_handle` stubs are no longer used.
+
+### Timer C
+
+Remove mouse and keyboard polling calls and their declarations from
+`bios/arch/arm/vectors.c::int_timerc()`. Timer C continues to provide its
+normal 200 Hz OS tick, keyboard repeat handling, sound IRQ work, and 50 Hz
+VBL emulation; it no longer performs USB I/O.
+
+## Data Flow
+
+1. USB enumeration identifies a HID boot mouse or keyboard.
+2. Its UDD configures boot protocol and idle mode, initializes its report
+   state, and submits one async interrupt-IN request.
+3. DWC2 hardware polls the endpoint at USB frame cadence. Empty polls NAK
+   and are re-armed internally without entering the UDD.
+4. A completed report raises `ARM_IRQ_USB`. The DWC2 handler copies the DMA
+   result into the persistent UDD report buffer and invokes its callback.
+5. Mouse converts the report to the existing IKBD/VDI path. Keyboard converts
+   it to existing Atari scancodes. The DWC2 request is then re-armed.
+6. Disconnect cancels the active request and clears the UDD device pointer.
+
+## Validation
+
+### Build
+
+CI must compile all Raspberry Pi configurations: rpi1, rpi2, rpi2-sparse,
+rpi3, and rpi4 (the latter must remain unaffected because it does not use
+DWC2).
+
+### QEMU Smoke Test
+
+Update `.claude/skills/ptos-smoketest/SKILL.md` so both Raspberry Pi QEMU
+commands explicitly attach HID devices:
+
+```sh
+-device usb-mouse -device usb-kbd
+```
+
+This is required for input-driver validation; without those options QEMU
+does not present a boot mouse or keyboard for pTOS to enumerate. Smoke tests
+must run the updated rpi1 and rpi2 commands, confirm the image boots without
+guest errors, and confirm HID devices are enumerated through the driver
+traces.
+
+### Real Hardware
+
+On Raspberry Pi hardware, verify:
+
+- repeated short left-clicks with no pointer movement register;
+- normal drag, movement, wheel, and extra-button behavior remain correct;
+- fast press/release keyboard input and modifier changes are received;
+- rollover reports do not manufacture releases or repeats; and
+- unplugging a supported HID device does not crash or leave a request
+  re-arming.
+
+## Alternatives Rejected
+
+### Faster Timer Polling
+
+Increasing Timer C polling or draining synchronous reports reduces the race
+window but cannot capture a press and release that both happen before the
+next software-initiated IN token.
+
+### Full Circle USB Scheduler Port
+
+Circle has a complete dynamic channel allocator, URB model, frame scheduler,
+and broader USB-device lifecycle support. Porting it would exceed this
+issue's narrow HID requirement. This design adopts only the required IRQ,
+channel, DMA, and persistent-transfer mechanics.

--- a/docs/superpowers/specs/2026-08-13-usb-async-trace-option-design.md
+++ b/docs/superpowers/specs/2026-08-13-usb-async-trace-option-design.md
@@ -1,0 +1,36 @@
+# USB Async Trace Option Design
+
+## Goal
+
+Prevent normal USB HID operation from flooding the selected debug output while
+retaining an opt-in trace for asynchronous USB host-controller scheduling.
+
+## Configuration
+
+Add `CONF_DEBUG_USB_ASYNC` to `usb/Kconfig`.  It depends on
+`CONF_WITH_USB`, defaults to disabled, and is intended for host-controller
+debugging across the USB stack.
+
+## Trace Interface
+
+Define `KINFO_USB_ASYNC(args)` in the shared USB header.  When
+`CONF_DEBUG_USB_ASYNC` is enabled, it expands to `KINFO(args)`; otherwise it
+compiles to a no-op.
+
+## DWC2 Scope
+
+Use the wrapper only for high-frequency DWC2 async progress messages:
+
+- transfer start;
+- successful completion;
+- NAK re-arm;
+- split ACK, NYET, and NAK progress.
+
+Keep errors, cancellation, shutdown, release, and initialization diagnostics
+as regular `KINFO()` output.
+
+## Verification
+
+Confirm the wrapper has both enabled and disabled definitions, all selected
+DWC2 high-frequency traces use it, and the USB config defaults it to disabled.
+Run the async contract test, `make gitready`, and a Raspberry Pi CI build.

--- a/tools/test-dwc2-async-contract.sh
+++ b/tools/test-dwc2-async-contract.sh
@@ -13,6 +13,14 @@ require()
     fi
 }
 
+require_multiline()
+{
+    if ! rg -U -q "$1" "$source"; then
+        echo "missing async DWC2 contract: $2"
+        exit 1
+    fi
+}
+
 require 'next_frame' 'per-slot next eligible frame'
 require 'dwc2_async_interval' 'USB speed-aware interval conversion'
 require 'DWC2_GINTMSK_SOFINTR' 'SOF wakeup for deferred transfers'
@@ -28,5 +36,7 @@ require 'priv->shutting_down' 'shutdown state guards'
 require 'return ETIMEDOUT' 'halt timeout defers controller reset'
 require '!priv->shutting_down' 'callback and rearm shutdown guard'
 require 'if \(!priv->shutting_down\)' 'synchronous shutdown halt observer'
+require_multiline 'gintsts = readl\(&regs->gintsts\);[\s\S]*if \(priv->shutting_down\)[\s\S]*return;[\s\S]*pending = readl\(&regs->host_regs.haint\)' \
+    'IRQ returns during shutdown before handling async channel interrupts'
 
 echo 'dwc2 async contract test passed'

--- a/tools/test-dwc2-async-contract.sh
+++ b/tools/test-dwc2-async-contract.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+source=$repo_root/usb/ucd_dwc2.c
+
+require()
+{
+    if ! rg -q "$1" "$source"; then
+        echo "missing async DWC2 contract: $2"
+        exit 1
+    fi
+}
+
+require 'next_frame' 'per-slot next eligible frame'
+require 'dwc2_async_interval' 'USB speed-aware interval conversion'
+require 'DWC2_GINTMSK_SOFINTR' 'SOF wakeup for deferred transfers'
+require 'dwc2_async_schedule' 'NAK and completion scheduling'
+require 'error_pending' 'post-halt error callback state'
+require 'struct usb_async_int_msg \*msg = slot->msg' \
+    'saved request for post-release error callback'
+require 'msg->callback\(msg, -1, 0\)' 'error callback after slot release'
+require 'wait_for_bit_le32\(&hc->hcint, DWC2_HCINT_CHHLTD' \
+    'shutdown halt wait'
+
+echo 'dwc2 async contract test passed'

--- a/tools/test-dwc2-async-contract.sh
+++ b/tools/test-dwc2-async-contract.sh
@@ -58,6 +58,8 @@ require_multiline 'gintsts = readl\(&regs->gintsts\);[\s\S]*if \(priv->shutting_
     'IRQ acknowledges pending sources during shutdown without channel handling'
 require_multiline 'priv->shutting_down = TRUE;[\s\S]*clrbits_le32\(&priv->regs->gintmsk, DWC2_GINTMSK_SOFINTR\);[\s\S]*clrbits_le32\(&priv->regs->gintmsk, DWC2_GINTMSK_HCINTR\);[\s\S]*for \(index = 0; index < DWC2_ASYNC_SLOT_COUNT; index\+\+\)' \
     'shutdown masks DWC2 IRQ sources before draining async slots'
+require_multiline 'ret = dwc2_async_shutdown\(priv, &priv->async\[index\]\);[\s\S]*if \(ret\)[\s\S]*break;[\s\S]*clrbits_le32\(&priv->regs->gahbcfg, DWC2_GAHBCFG_GLBLINTRMSK\);[\s\S]*raspi_connect_irq\(ARM_IRQ_USB, NULL\);[\s\S]*return ret;' \
+    'shutdown disconnects global IRQ handling after a slot halt failure'
 require_multiline 'actual_length = msg->transfer_len -[\s\S]*if \(actual_length < 0 \|\| actual_length > msg->transfer_len\) \{[\s\S]*dwc2_async_finish_error\(priv, slot\);[\s\S]*return;' \
     'async completion validates DMA length before cache and copy'
 require 'ULONG ssplit_frame' 'per-slot start-split frame'

--- a/tools/test-dwc2-async-contract.sh
+++ b/tools/test-dwc2-async-contract.sh
@@ -4,6 +4,7 @@ set -eu
 
 repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 source=$repo_root/usb/ucd_dwc2.c
+usb_source=$repo_root/usb/usb.c
 
 require()
 {
@@ -38,5 +39,20 @@ require '!priv->shutting_down' 'callback and rearm shutdown guard'
 require 'if \(!priv->shutting_down\)' 'synchronous shutdown halt observer'
 require_multiline 'gintsts = readl\(&regs->gintsts\);[\s\S]*if \(priv->shutting_down\)[\s\S]*return;[\s\S]*pending = readl\(&regs->host_regs.haint\)' \
     'IRQ returns during shutdown before handling async channel interrupts'
+require 'ULONG ssplit_frame' 'per-slot start-split frame'
+require 'dwc2_async_schedule_split_complete' 'deferred complete-split scheduling'
+require_multiline 'slot->ssplit_frame = readl\(&regs->host_regs.hfnum\)[\s\S]*DWC2_ASYNC_SPLIT_COMPLETE[\s\S]*dwc2_async_schedule_split_complete' \
+    'start-split ACK records its frame before scheduling the complete split'
+require_multiline '\(frame - slot->ssplit_frame\)[\s\S]*> 4[\s\S]*slot->split_state = DWC2_ASYNC_SPLIT_START[\s\S]*dwc2_async_schedule' \
+    'complete-split NYET retry window is limited to four microframes'
+
+if ! rg -U -q 'for \(i = 0; i < USB_MAX_DEVICE; i\+\+\)[\s\S]*usb_disconnect\(dev\);[\s\S]*for \(a = allucdifs' "$usb_source"; then
+    echo 'missing USB teardown contract: disconnect devices before stopping controller'
+    exit 1
+fi
+if ! rg -q 'if \(dev->children\[i\]\)' "$usb_source"; then
+    echo 'missing USB teardown contract: ignore empty child slots'
+    exit 1
+fi
 
 echo 'dwc2 async contract test passed'

--- a/tools/test-dwc2-async-contract.sh
+++ b/tools/test-dwc2-async-contract.sh
@@ -5,11 +5,21 @@ set -eu
 repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 source=$repo_root/usb/ucd_dwc2.c
 usb_source=$repo_root/usb/usb.c
+usb_header=$repo_root/usb/usb_global.h
+usb_kconfig=$repo_root/usb/Kconfig
 
 require()
 {
     if ! rg -q "$1" "$source"; then
         echo "missing async DWC2 contract: $2"
+        exit 1
+    fi
+}
+
+require_file()
+{
+    if ! rg -q "$1" "$2"; then
+        echo "missing async DWC2 contract: $3"
         exit 1
     fi
 }
@@ -45,6 +55,15 @@ require_multiline 'slot->ssplit_frame = readl\(&regs->host_regs.hfnum\)[\s\S]*DW
     'start-split ACK records its frame before scheduling the complete split'
 require_multiline '\(frame - slot->ssplit_frame\)[\s\S]*> 4[\s\S]*slot->split_state = DWC2_ASYNC_SPLIT_START[\s\S]*dwc2_async_schedule' \
     'complete-split NYET retry window is limited to four microframes'
+require_file 'config CONF_DEBUG_USB_ASYNC' "$usb_kconfig" \
+    'shared USB async trace option'
+require_file 'default n' "$usb_kconfig" 'async trace disabled by default'
+if ! rg -U -q '#if CONF_DEBUG_USB_ASYNC[\s\S]*#define KINFO_USB_ASYNC\(a\) KINFO\(a\)[\s\S]*#else[\s\S]*#define KINFO_USB_ASYNC\(a\) \(\(void\)0\)[\s\S]*#endif' "$usb_header"; then
+    echo 'missing async DWC2 contract: compile-time USB async trace gate'
+    exit 1
+fi
+require_multiline 'KINFO_USB_ASYNC\(\("dwc2_async: start[\s\S]*KINFO_USB_ASYNC\(\("dwc2_async: complete[\s\S]*KINFO_USB_ASYNC\(\("dwc2_async: split-start-ack[\s\S]*KINFO_USB_ASYNC\(\("dwc2_async: split-complete-nyet[\s\S]*KINFO_USB_ASYNC\(\("dwc2_async: split-complete-nak[\s\S]*KINFO_USB_ASYNC\(\("dwc2_async: rearm' \
+    'DWC2 high-frequency async traces use the shared trace gate'
 
 if ! rg -U -q 'for \(i = 0; i < USB_MAX_DEVICE; i\+\+\)[\s\S]*usb_disconnect\(dev\);[\s\S]*for \(a = allucdifs' "$usb_source"; then
     echo 'missing USB teardown contract: disconnect devices before stopping controller'

--- a/tools/test-dwc2-async-contract.sh
+++ b/tools/test-dwc2-async-contract.sh
@@ -2,6 +2,11 @@
 
 set -eu
 
+if ! command -v rg >/dev/null 2>&1; then
+    echo 'tools/test-dwc2-async-contract.sh requires ripgrep (rg)'
+    exit 1
+fi
+
 repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 source=$repo_root/usb/ucd_dwc2.c
 usb_source=$repo_root/usb/usb.c
@@ -47,8 +52,12 @@ require 'priv->shutting_down' 'shutdown state guards'
 require 'return ETIMEDOUT' 'halt timeout defers controller reset'
 require '!priv->shutting_down' 'callback and rearm shutdown guard'
 require 'if \(!priv->shutting_down\)' 'synchronous shutdown halt observer'
-require_multiline 'gintsts = readl\(&regs->gintsts\);[\s\S]*if \(priv->shutting_down\)[\s\S]*return;[\s\S]*pending = readl\(&regs->host_regs.haint\)' \
-    'IRQ returns during shutdown before handling async channel interrupts'
+require_multiline 'gintsts = readl\(&regs->gintsts\);[\s\S]*if \(priv->shutting_down\) \{[\s\S]*writel\(gintsts & \(DWC2_GINTSTS_HCINTR \| DWC2_GINTSTS_SOFINTR\),[\s\S]*return;' \
+    'IRQ acknowledges pending sources during shutdown without channel handling'
+require_multiline 'priv->shutting_down = TRUE;[\s\S]*clrbits_le32\(&priv->regs->gintmsk, DWC2_GINTMSK_SOFINTR\);[\s\S]*clrbits_le32\(&priv->regs->gintmsk, DWC2_GINTMSK_HCINTR\);[\s\S]*for \(index = 0; index < DWC2_ASYNC_SLOT_COUNT; index\+\+\)' \
+    'shutdown masks DWC2 IRQ sources before draining async slots'
+require_multiline 'actual_length = msg->transfer_len -[\s\S]*if \(actual_length < 0 \|\| actual_length > msg->transfer_len\) \{[\s\S]*dwc2_async_finish_error\(priv, slot\);[\s\S]*return;' \
+    'async completion validates DMA length before cache and copy'
 require 'ULONG ssplit_frame' 'per-slot start-split frame'
 require 'dwc2_async_schedule_split_complete' 'deferred complete-split scheduling'
 require_multiline 'slot->ssplit_frame = readl\(&regs->host_regs.hfnum\)[\s\S]*DWC2_ASYNC_SPLIT_COMPLETE[\s\S]*dwc2_async_schedule_split_complete' \

--- a/tools/test-dwc2-async-contract.sh
+++ b/tools/test-dwc2-async-contract.sh
@@ -12,6 +12,8 @@ source=$repo_root/usb/ucd_dwc2.c
 usb_source=$repo_root/usb/usb.c
 usb_header=$repo_root/usb/usb_global.h
 usb_kconfig=$repo_root/usb/Kconfig
+mouse_source=$repo_root/usb/udd_mouse.c
+keyboard_source=$repo_root/usb/udd_keyboard.c
 
 require()
 {
@@ -83,6 +85,14 @@ if ! rg -U -q 'for \(i = 0; i < USB_MAX_DEVICE; i\+\+\)[\s\S]*usb_disconnect\(de
 fi
 if ! rg -q 'if \(dev->children\[i\]\)' "$usb_source"; then
     echo 'missing USB teardown contract: ignore empty child slots'
+    exit 1
+fi
+if ! rg -U -q 'static void mouse_report_complete\([\s\S]*\{[\s\S]*\(void\)msg;' "$mouse_source"; then
+    echo 'missing async DWC2 contract: mouse callback marks request unused'
+    exit 1
+fi
+if ! rg -U -q 'static void keyboard_report_complete\([\s\S]*\{[\s\S]*\(void\)msg;' "$keyboard_source"; then
+    echo 'missing async DWC2 contract: keyboard callback marks request unused'
     exit 1
 fi
 

--- a/tools/test-dwc2-async-contract.sh
+++ b/tools/test-dwc2-async-contract.sh
@@ -66,7 +66,10 @@ require_multiline '\(frame - slot->ssplit_frame\)[\s\S]*> 4[\s\S]*slot->split_st
     'complete-split NYET retry window is limited to four microframes'
 require_file 'config CONF_DEBUG_USB_ASYNC' "$usb_kconfig" \
     'shared USB async trace option'
-require_file 'default n' "$usb_kconfig" 'async trace disabled by default'
+if ! rg -U -q 'config CONF_DEBUG_USB_ASYNC[\s\S]*default n[\s\S]*help' "$usb_kconfig"; then
+    echo 'missing async DWC2 contract: async trace disabled by default'
+    exit 1
+fi
 if ! rg -U -q '#if CONF_DEBUG_USB_ASYNC[\s\S]*#define KINFO_USB_ASYNC\(a\) KINFO\(a\)[\s\S]*#else[\s\S]*#define KINFO_USB_ASYNC\(a\) \(\(void\)0\)[\s\S]*#endif' "$usb_header"; then
     echo 'missing async DWC2 contract: compile-time USB async trace gate'
     exit 1

--- a/tools/test-dwc2-async-contract.sh
+++ b/tools/test-dwc2-async-contract.sh
@@ -23,5 +23,10 @@ require 'struct usb_async_int_msg \*msg = slot->msg' \
 require 'msg->callback\(msg, -1, 0\)' 'error callback after slot release'
 require 'wait_for_bit_le32\(&hc->hcint, DWC2_HCINT_CHHLTD' \
     'shutdown halt wait'
+require 'BOOL shutting_down' 'controller shutdown state'
+require 'priv->shutting_down' 'shutdown state guards'
+require 'return ETIMEDOUT' 'halt timeout defers controller reset'
+require '!priv->shutting_down' 'callback and rearm shutdown guard'
+require 'if \(!priv->shutting_down\)' 'synchronous shutdown halt observer'
 
 echo 'dwc2 async contract test passed'

--- a/usb/Kconfig
+++ b/usb/Kconfig
@@ -34,4 +34,13 @@ config CONF_WITH_USB_XHCI
 	  The xHCI host controller used for the Raspberry Pi 4/400 external
 	  USB ports through the VL805 PCIe bridge.
 
+config CONF_DEBUG_USB_ASYNC
+	bool "Trace asynchronous USB transfers"
+	depends on CONF_WITH_USB
+	default n
+	help
+	  Enable high-frequency progress traces from USB host-controller
+	  asynchronous transfers.  This is useful while diagnosing USB transfer
+	  scheduling, but can flood serial debug output during normal HID use.
+
 endmenu

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -795,6 +795,12 @@ static void dwc2_async_finish_success(struct dwc2_priv *priv,
     actual_length = msg->transfer_len -
                     ((hctsiz & DWC2_HCTSIZ_XFERSIZE_MASK) >>
                      DWC2_HCTSIZ_XFERSIZE_OFFSET);
+    if (actual_length < 0 || actual_length > msg->transfer_len) {
+        KINFO(("dwc2_async: invalid completion length=%ld generation=%lu\n",
+               actual_length, generation));
+        dwc2_async_finish_error(priv, slot);
+        return;
+    }
     slot->pid = (hctsiz & DWC2_HCTSIZ_PID_MASK) >> DWC2_HCTSIZ_PID_OFFSET;
     invalidate_data_cache(slot->dma_buffer,
                           roundup(actual_length, ARCH_DMA_MINALIGN));
@@ -835,8 +841,11 @@ static void dwc2_irq_handler(void)
     gintsts = readl(&regs->gintsts);
     if (!(gintsts & (DWC2_GINTSTS_HCINTR | DWC2_GINTSTS_SOFINTR)))
         return;
-    if (priv->shutting_down)
+    if (priv->shutting_down) {
+        writel(gintsts & (DWC2_GINTSTS_HCINTR | DWC2_GINTSTS_SOFINTR),
+               &regs->gintsts);
         return;
+    }
 
     pending = readl(&regs->host_regs.haint) &
               readl(&regs->host_regs.haintmsk);
@@ -1719,13 +1728,13 @@ long usb_lowlevel_stop(void *ucd_priv)
     LONG ret;
 
     priv->shutting_down = TRUE;
+    clrbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_SOFINTR);
+    clrbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_HCINTR);
     for (index = 0; index < DWC2_ASYNC_SLOT_COUNT; index++) {
         ret = dwc2_async_shutdown(priv, &priv->async[index]);
         if (ret)
             return ret;
     }
-    clrbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_SOFINTR);
-    clrbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_HCINTR);
     clrbits_le32(&priv->regs->gahbcfg, DWC2_GAHBCFG_GLBLINTRMSK);
     if (priv->irq_connected)
         raspi_connect_irq(ARM_IRQ_USB, NULL);

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -42,12 +42,14 @@ struct dwc2_async_slot
     UBYTE pid;
     BOOL active;
     BOOL cancelled;
+    BOOL stopping;
     BOOL split;
     BOOL split_complete;
     DWC2_ASYNC_SPLIT_STATE split_state;
     UBYTE hub_addr;
     UBYTE hub_port;
     UBYTE *dma_buffer;
+    ULONG generation;
 };
 
 struct dwc2_priv {
@@ -65,6 +67,7 @@ struct dwc2_priv {
     BOOL hnp_srp_disable;
     BOOL oc_disable;
     struct dwc2_async_slot async[DWC2_ASYNC_SLOT_COUNT];
+    ULONG async_generation;
     BOOL irq_connected;
 };
 
@@ -102,6 +105,7 @@ static void dwc2_async_start(struct dwc2_priv *priv,
                              struct dwc2_async_slot *slot);
 static void dwc2_async_stop(struct dwc2_priv *priv,
                             struct dwc2_async_slot *slot);
+static void dwc2_async_release(struct dwc2_async_slot *slot);
 static void dwc2_async_complete(struct dwc2_priv *priv,
                                 struct dwc2_async_slot *slot,
                                 LONG status, LONG actual_length);
@@ -565,6 +569,7 @@ static struct dwc2_async_slot *dwc2_async_alloc(struct dwc2_priv *priv,
             slot->msg = msg;
             slot->pid = DWC2_HC_PID_DATA0;
             slot->dma_buffer = dwc2_async_dma[index];
+            slot->generation = ++priv->async_generation;
             return slot;
         }
     }
@@ -582,7 +587,7 @@ static void dwc2_async_start(struct dwc2_priv *priv,
     ULONG hcintmsk;
     ULONG hfnum;
 
-    if (!slot->active || slot->cancelled)
+    if (!slot->active || slot->cancelled || slot->stopping)
         return;
 
     dwc_otg_hc_init(regs, channel, slot->msg->dev,
@@ -625,13 +630,33 @@ static void dwc2_async_stop(struct dwc2_priv *priv,
     WORD channel = DWC2_ASYNC_FIRST_CHANNEL + index;
     struct dwc2_hc_regs *hc = &priv->regs->hc_regs[channel];
 
+    if (slot->stopping)
+        return;
+
+    slot->active = FALSE;
+    slot->cancelled = TRUE;
+    slot->stopping = TRUE;
+    KDEBUG(("%s: channel %d generation %lu\n", __func__, channel,
+            slot->generation));
     clrbits_le32(&priv->regs->host_regs.haintmsk, 1UL << channel);
-    if (readl(&hc->hcchar) & DWC2_HCCHAR_CHEN)
+    if (readl(&hc->hcchar) & DWC2_HCCHAR_CHEN) {
+        writel(DWC2_HCINT_CHHLTD, &hc->hcint);
+        writel(DWC2_HCINTMSK_CHHLTD, &hc->hcintmsk);
         setbits_le32(&hc->hcchar, DWC2_HCCHAR_CHEN | DWC2_HCCHAR_CHDIS);
+        setbits_le32(&priv->regs->host_regs.haintmsk, 1UL << channel);
+        return;
+    }
     writel(0, &hc->hcintmsk);
     writel(0x3fff, &hc->hcint);
+    dwc2_async_release(slot);
+}
+
+static void dwc2_async_release(struct dwc2_async_slot *slot)
+{
+    KDEBUG(("%s: generation %lu\n", __func__, slot->generation));
     slot->active = FALSE;
     slot->cancelled = FALSE;
+    slot->stopping = FALSE;
     slot->msg = NULL;
 }
 
@@ -651,18 +676,26 @@ static void dwc2_async_finish_success(struct dwc2_priv *priv,
 {
     ULONG hctsiz;
     LONG actual_length;
+    struct usb_async_int_msg *msg;
+    ULONG generation;
 
+    msg = slot->msg;
+    generation = slot->generation;
     hctsiz = readl(&hc->hctsiz);
-    actual_length = slot->msg->transfer_len -
+    actual_length = msg->transfer_len -
                     ((hctsiz & DWC2_HCTSIZ_XFERSIZE_MASK) >>
                      DWC2_HCTSIZ_XFERSIZE_OFFSET);
     slot->pid = (hctsiz & DWC2_HCTSIZ_PID_MASK) >> DWC2_HCTSIZ_PID_OFFSET;
     invalidate_data_cache(slot->dma_buffer,
                           roundup(actual_length, ARCH_DMA_MINALIGN));
-    memcpy(slot->msg->buffer, slot->dma_buffer, actual_length);
+    memcpy(msg->buffer, slot->dma_buffer, actual_length);
     dwc2_async_complete(priv, slot, 0, actual_length);
-    if (slot->active && !slot->cancelled)
+    if (slot->active && !slot->cancelled && !slot->stopping &&
+        slot->msg == msg && slot->generation == generation)
         dwc2_async_start(priv, slot);
+    else
+        KDEBUG(("%s: completion generation %lu not rearmed\n", __func__,
+                generation));
 }
 
 static void dwc2_async_finish_error(struct dwc2_priv *priv,
@@ -700,8 +733,16 @@ static void dwc2_irq_handler(void)
         hcint = readl(&hc->hcint);
         writel(hcint, &hc->hcint);
 
+        if (slot->stopping) {
+            if (hcint & DWC2_HCINT_CHHLTD) {
+                writel(0, &hc->hcintmsk);
+                clrbits_le32(&regs->host_regs.haintmsk, 1UL << channel);
+                dwc2_async_release(slot);
+            }
+            continue;
+        }
+
         if (!slot->active || slot->cancelled) {
-            dwc2_async_stop(priv, slot);
             continue;
         }
 
@@ -717,7 +758,8 @@ static void dwc2_irq_handler(void)
                        (hcint & DWC2_HCINT_NAK)) {
                 slot->split_state = DWC2_ASYNC_SPLIT_START;
                 dwc2_async_start(priv, slot);
-            } else if (hcint & DWC2_HCINT_XFERCOMP) {
+            } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
+                       (hcint & DWC2_HCINT_XFERCOMP)) {
                 slot->split_state = DWC2_ASYNC_SPLIT_START;
                 dwc2_async_finish_success(priv, slot, hc);
             } else {
@@ -731,8 +773,7 @@ static void dwc2_irq_handler(void)
             dwc2_async_finish_error(priv, slot);
         }
     }
-    writel(pending, &regs->host_regs.haint);
-    writel(gintsts, &regs->gintsts);
+    writel(DWC2_GINTSTS_HCINTR, &regs->gintsts);
 }
 
 /*
@@ -1353,6 +1394,7 @@ static LONG dwc2_submit_async_int_msg(struct dwc2_priv *priv,
     struct dwc2_async_slot *slot;
 
     if (!msg || !msg->dev || !msg->buffer || !msg->callback ||
+        !priv->irq_connected ||
         msg->transfer_len <= 0 || msg->transfer_len > DWC2_ASYNC_DMA_SIZE ||
         !usb_pipein(msg->pipe) || usb_pipetype(msg->pipe) != PIPE_INTERRUPT)
         return EINVAL;

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -589,8 +589,8 @@ static void dwc2_async_start(struct dwc2_priv *priv,
     if (!slot->active || slot->cancelled || slot->stopping)
         return;
 
-    KDEBUG(("dwc2_async: start channel=%d generation=%lu split=%d pid=%d\n",
-            channel, slot->generation, slot->split_state, slot->pid));
+    KINFO(("dwc2_async: start channel=%d generation=%lu split=%d pid=%d\n",
+           channel, slot->generation, slot->split_state, slot->pid));
     dwc_otg_hc_init(regs, channel, slot->msg->dev,
                     usb_pipedevice(slot->msg->pipe),
                     usb_pipeendpoint(slot->msg->pipe), TRUE,
@@ -637,8 +637,8 @@ static void dwc2_async_stop(struct dwc2_priv *priv,
     slot->active = FALSE;
     slot->cancelled = TRUE;
     slot->stopping = TRUE;
-    KDEBUG(("dwc2_async: stop channel=%d generation=%lu\n", channel,
-            slot->generation));
+    KINFO(("dwc2_async: stop channel=%d generation=%lu\n", channel,
+           slot->generation));
     clrbits_le32(&priv->regs->host_regs.haintmsk, 1UL << channel);
     if (readl(&hc->hcchar) & DWC2_HCCHAR_CHEN) {
         writel(DWC2_HCINT_CHHLTD, &hc->hcint);
@@ -654,7 +654,7 @@ static void dwc2_async_stop(struct dwc2_priv *priv,
 
 static void dwc2_async_release(struct dwc2_async_slot *slot)
 {
-    KDEBUG(("dwc2_async: release generation=%lu\n", slot->generation));
+    KINFO(("dwc2_async: release generation=%lu\n", slot->generation));
     slot->active = FALSE;
     slot->cancelled = FALSE;
     slot->stopping = FALSE;
@@ -690,14 +690,14 @@ static void dwc2_async_finish_success(struct dwc2_priv *priv,
     invalidate_data_cache(slot->dma_buffer,
                           roundup(actual_length, ARCH_DMA_MINALIGN));
     memcpy(msg->buffer, slot->dma_buffer, actual_length);
-    KDEBUG(("dwc2_async: complete generation=%lu length=%ld\n", generation,
-            actual_length));
+    KINFO(("dwc2_async: complete generation=%lu length=%ld\n", generation,
+           actual_length));
     dwc2_async_complete(priv, slot, 0, actual_length);
     if (slot->active && !slot->cancelled && !slot->stopping &&
         slot->msg == msg && slot->generation == generation)
         dwc2_async_start(priv, slot);
     else
-        KDEBUG(("dwc2_async: no-rearm generation=%lu\n", generation));
+        KINFO(("dwc2_async: no-rearm generation=%lu\n", generation));
 }
 
 static void dwc2_async_finish_error(struct dwc2_priv *priv,
@@ -734,9 +734,6 @@ static void dwc2_irq_handler(void)
 
         hcint = readl(&hc->hcint);
         writel(hcint, &hc->hcint);
-        KDEBUG(("dwc2_async: irq channel=%d generation=%lu hcint=%08lx split=%d\n",
-                channel, slot->generation, hcint, slot->split_state));
-
         if (slot->stopping) {
             if (hcint & DWC2_HCINT_CHHLTD) {
                 writel(0, &hc->hcintmsk);
@@ -754,19 +751,19 @@ static void dwc2_irq_handler(void)
             if (slot->split_state == DWC2_ASYNC_SPLIT_START &&
                 (hcint & DWC2_HCINT_ACK)) {
                 slot->split_state = DWC2_ASYNC_SPLIT_COMPLETE;
-                KDEBUG(("dwc2_async: split-start-ack generation=%lu\n",
-                        slot->generation));
+                KINFO(("dwc2_async: split-start-ack generation=%lu\n",
+                       slot->generation));
                 dwc2_async_start(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_NYET)) {
-                KDEBUG(("dwc2_async: split-complete-nyet generation=%lu\n",
-                        slot->generation));
+                KINFO(("dwc2_async: split-complete-nyet generation=%lu\n",
+                       slot->generation));
                 dwc2_async_start(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_NAK)) {
                 slot->split_state = DWC2_ASYNC_SPLIT_START;
-                KDEBUG(("dwc2_async: split-complete-nak generation=%lu\n",
-                        slot->generation));
+                KINFO(("dwc2_async: split-complete-nak generation=%lu\n",
+                       slot->generation));
                 dwc2_async_start(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_XFERCOMP)) {
@@ -778,9 +775,9 @@ static void dwc2_irq_handler(void)
         } else if (hcint & DWC2_HCINT_XFERCOMP) {
             dwc2_async_finish_success(priv, slot, hc);
         } else if ((hcint & DWC2_HCINT_NAK) || hcint == DWC2_HCINT_CHHLTD) {
-            KDEBUG(("dwc2_async: rearm generation=%lu reason=%s\n",
-                    slot->generation, (hcint & DWC2_HCINT_NAK) ? "nak" :
-                    "chhltd"));
+            KINFO(("dwc2_async: rearm generation=%lu reason=%s\n",
+                   slot->generation, (hcint & DWC2_HCINT_NAK) ? "nak" :
+                   "chhltd"));
             dwc2_async_start(priv, slot);
         } else {
             dwc2_async_finish_error(priv, slot);
@@ -1430,8 +1427,8 @@ static LONG dwc2_submit_async_int_msg(struct dwc2_priv *priv,
     slot->split_state = slot->split ? DWC2_ASYNC_SPLIT_START :
                         DWC2_ASYNC_SPLIT_NONE;
     slot->active = TRUE;
-    KDEBUG(("dwc2_async: submit generation=%lu split=%d\n",
-            slot->generation, slot->split_state));
+    KINFO(("dwc2_async: submit generation=%lu split=%d\n",
+           slot->generation, slot->split_state));
     dwc2_async_start(priv, slot);
 
     return E_OK;

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -651,8 +651,8 @@ static void dwc2_async_start(struct dwc2_priv *priv,
         return;
     slot->scheduled = FALSE;
 
-    KINFO(("dwc2_async: start channel=%d generation=%lu split=%d pid=%d\n",
-           channel, slot->generation, slot->split_state, slot->pid));
+    KINFO_USB_ASYNC(("dwc2_async: start channel=%d generation=%lu split=%d pid=%d\n",
+                     channel, slot->generation, slot->split_state, slot->pid));
     dwc_otg_hc_init(regs, channel, slot->msg->dev,
                     usb_pipedevice(slot->msg->pipe),
                     usb_pipeendpoint(slot->msg->pipe), TRUE,
@@ -799,8 +799,8 @@ static void dwc2_async_finish_success(struct dwc2_priv *priv,
     invalidate_data_cache(slot->dma_buffer,
                           roundup(actual_length, ARCH_DMA_MINALIGN));
     memcpy(msg->buffer, slot->dma_buffer, actual_length);
-    KINFO(("dwc2_async: complete generation=%lu length=%ld\n", generation,
-           actual_length));
+    KINFO_USB_ASYNC(("dwc2_async: complete generation=%lu length=%ld\n", generation,
+                     actual_length));
     dwc2_async_complete(priv, slot, 0, actual_length);
     if (slot->active && !slot->cancelled && !slot->stopping &&
         !priv->shutting_down &&
@@ -868,19 +868,19 @@ static void dwc2_irq_handler(void)
                 slot->ssplit_frame = readl(&regs->host_regs.hfnum) &
                                      DWC2_HFNUM_MAX_FRNUM;
                 slot->split_state = DWC2_ASYNC_SPLIT_COMPLETE;
-                KINFO(("dwc2_async: split-start-ack generation=%lu\n",
-                       slot->generation));
+                KINFO_USB_ASYNC(("dwc2_async: split-start-ack generation=%lu\n",
+                                 slot->generation));
                 dwc2_async_schedule_split_complete(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_NYET)) {
-                KINFO(("dwc2_async: split-complete-nyet generation=%lu\n",
-                       slot->generation));
+                KINFO_USB_ASYNC(("dwc2_async: split-complete-nyet generation=%lu\n",
+                                 slot->generation));
                 dwc2_async_schedule_split_complete(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_NAK)) {
                 slot->split_state = DWC2_ASYNC_SPLIT_START;
-                KINFO(("dwc2_async: split-complete-nak generation=%lu\n",
-                       slot->generation));
+                KINFO_USB_ASYNC(("dwc2_async: split-complete-nak generation=%lu\n",
+                                 slot->generation));
                 dwc2_async_schedule(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_XFERCOMP)) {
@@ -892,9 +892,9 @@ static void dwc2_irq_handler(void)
         } else if (hcint & DWC2_HCINT_XFERCOMP) {
             dwc2_async_finish_success(priv, slot, hc);
         } else if ((hcint & DWC2_HCINT_NAK) || hcint == DWC2_HCINT_CHHLTD) {
-            KINFO(("dwc2_async: rearm generation=%lu reason=%s\n",
-                   slot->generation, (hcint & DWC2_HCINT_NAK) ? "nak" :
-                   "chhltd"));
+            KINFO_USB_ASYNC(("dwc2_async: rearm generation=%lu reason=%s\n",
+                             slot->generation, (hcint & DWC2_HCINT_NAK) ? "nak" :
+                             "chhltd"));
             dwc2_async_schedule(priv, slot);
         } else {
             dwc2_async_finish_error(priv, slot);

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -49,6 +49,9 @@ struct dwc2_async_slot
     UBYTE hub_port;
     UBYTE *dma_buffer;
     ULONG generation;
+    ULONG next_frame;
+    BOOL scheduled;
+    BOOL error_pending;
 };
 
 struct dwc2_priv {
@@ -102,9 +105,13 @@ static struct dwc2_async_slot *dwc2_async_alloc(struct dwc2_priv *priv,
                                                  struct usb_async_int_msg *msg);
 static void dwc2_async_start(struct dwc2_priv *priv,
                              struct dwc2_async_slot *slot);
+static void dwc2_async_schedule(struct dwc2_priv *priv,
+                                 struct dwc2_async_slot *slot);
 static void dwc2_async_stop(struct dwc2_priv *priv,
                             struct dwc2_async_slot *slot);
 static void dwc2_async_release(struct dwc2_async_slot *slot);
+static void dwc2_async_halted(struct dwc2_priv *priv,
+                               struct dwc2_async_slot *slot);
 static void dwc2_async_complete(struct dwc2_priv *priv,
                                 struct dwc2_async_slot *slot,
                                 LONG status, LONG actual_length);
@@ -576,6 +583,39 @@ static struct dwc2_async_slot *dwc2_async_alloc(struct dwc2_priv *priv,
     return NULL;
 }
 
+static ULONG dwc2_async_interval(struct dwc2_priv *priv,
+                                  struct usb_async_int_msg *msg)
+{
+    ULONG interval;
+
+    interval = msg->interval;
+    if (!interval)
+        interval = 1;
+    if (msg->dev->speed == USB_SPEED_HIGH) {
+        if (interval > 16)
+            interval = 16;
+        return 1UL << (interval - 1);
+    }
+
+    if ((readl(&priv->regs->hprt0) & DWC2_HPRT0_PRTSPD_MASK) ==
+        DWC2_HPRT0_PRTSPD_HIGH)
+        return interval * 8;
+
+    return interval;
+}
+
+static void dwc2_async_schedule(struct dwc2_priv *priv,
+                                 struct dwc2_async_slot *slot)
+{
+    ULONG frame;
+
+    frame = readl(&priv->regs->host_regs.hfnum) & DWC2_HFNUM_MAX_FRNUM;
+    slot->next_frame = (frame + dwc2_async_interval(priv, slot->msg)) &
+                       DWC2_HFNUM_MAX_FRNUM;
+    slot->scheduled = TRUE;
+    setbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_SOFINTR);
+}
+
 static void dwc2_async_start(struct dwc2_priv *priv,
                              struct dwc2_async_slot *slot)
 {
@@ -586,8 +626,10 @@ static void dwc2_async_start(struct dwc2_priv *priv,
     ULONG hcintmsk;
     ULONG hfnum;
 
-    if (!slot->active || slot->cancelled || slot->stopping)
+    if (!slot->active || slot->cancelled || slot->stopping ||
+        slot->error_pending)
         return;
+    slot->scheduled = FALSE;
 
     KINFO(("dwc2_async: start channel=%d generation=%lu split=%d pid=%d\n",
            channel, slot->generation, slot->split_state, slot->pid));
@@ -649,7 +691,7 @@ static void dwc2_async_stop(struct dwc2_priv *priv,
     }
     writel(0, &hc->hcintmsk);
     writel(0x3fff, &hc->hcint);
-    dwc2_async_release(slot);
+    dwc2_async_halted(priv, slot);
 }
 
 static void dwc2_async_release(struct dwc2_async_slot *slot)
@@ -659,6 +701,47 @@ static void dwc2_async_release(struct dwc2_async_slot *slot)
     slot->cancelled = FALSE;
     slot->stopping = FALSE;
     slot->msg = NULL;
+}
+
+static void dwc2_async_halted(struct dwc2_priv *priv,
+                               struct dwc2_async_slot *slot)
+{
+    WORD index = slot - priv->async;
+    WORD channel = DWC2_ASYNC_FIRST_CHANNEL + index;
+    struct dwc2_hc_regs *hc = &priv->regs->hc_regs[channel];
+
+    writel(0, &hc->hcintmsk);
+    clrbits_le32(&priv->regs->host_regs.haintmsk, 1UL << channel);
+    if (slot->error_pending) {
+        struct usb_async_int_msg *msg = slot->msg;
+
+        slot->error_pending = FALSE;
+        dwc2_async_release(slot);
+        msg->callback(msg, -1, 0);
+    } else
+        dwc2_async_release(slot);
+}
+
+static void dwc2_async_shutdown(struct dwc2_priv *priv,
+                                struct dwc2_async_slot *slot)
+{
+    WORD index = slot - priv->async;
+    WORD channel = DWC2_ASYNC_FIRST_CHANNEL + index;
+    struct dwc2_hc_regs *hc = &priv->regs->hc_regs[channel];
+    int ret;
+
+    if (!slot->msg)
+        return;
+    dwc2_async_stop(priv, slot);
+    if (!slot->stopping)
+        return;
+    ret = wait_for_bit_le32(&hc->hcint, DWC2_HCINT_CHHLTD, TRUE, 2000);
+    if (ret) {
+        KINFO(("dwc2_async: halt timeout channel=%d\n", channel));
+        return;
+    }
+    writel(readl(&hc->hcint), &hc->hcint);
+    dwc2_async_halted(priv, slot);
 }
 
 static void dwc2_async_complete(struct dwc2_priv *priv,
@@ -695,7 +778,7 @@ static void dwc2_async_finish_success(struct dwc2_priv *priv,
     dwc2_async_complete(priv, slot, 0, actual_length);
     if (slot->active && !slot->cancelled && !slot->stopping &&
         slot->msg == msg && slot->generation == generation)
-        dwc2_async_start(priv, slot);
+        dwc2_async_schedule(priv, slot);
     else
         KINFO(("dwc2_async: no-rearm generation=%lu\n", generation));
 }
@@ -703,10 +786,14 @@ static void dwc2_async_finish_success(struct dwc2_priv *priv,
 static void dwc2_async_finish_error(struct dwc2_priv *priv,
                                     struct dwc2_async_slot *slot)
 {
-    struct usb_async_int_msg *msg = slot->msg;
-
+    slot->error_pending = TRUE;
     dwc2_async_stop(priv, slot);
-    msg->callback(msg, -1, 0);
+}
+
+static BOOL dwc2_async_frame_due(ULONG frame, ULONG next_frame)
+{
+    return ((frame - next_frame) & DWC2_HFNUM_MAX_FRNUM) <
+           (DWC2_HFNUM_MAX_FRNUM / 2);
 }
 
 static void dwc2_irq_handler(void)
@@ -715,10 +802,11 @@ static void dwc2_irq_handler(void)
     struct dwc2_core_regs *regs = priv->regs;
     ULONG gintsts;
     ULONG pending;
+    ULONG frame;
     WORD index;
 
     gintsts = readl(&regs->gintsts);
-    if (!(gintsts & DWC2_GINTSTS_HCINTR))
+    if (!(gintsts & (DWC2_GINTSTS_HCINTR | DWC2_GINTSTS_SOFINTR)))
         return;
 
     pending = readl(&regs->host_regs.haint) &
@@ -736,9 +824,7 @@ static void dwc2_irq_handler(void)
         writel(hcint, &hc->hcint);
         if (slot->stopping) {
             if (hcint & DWC2_HCINT_CHHLTD) {
-                writel(0, &hc->hcintmsk);
-                clrbits_le32(&regs->host_regs.haintmsk, 1UL << channel);
-                dwc2_async_release(slot);
+                dwc2_async_halted(priv, slot);
             }
             continue;
         }
@@ -764,7 +850,7 @@ static void dwc2_irq_handler(void)
                 slot->split_state = DWC2_ASYNC_SPLIT_START;
                 KINFO(("dwc2_async: split-complete-nak generation=%lu\n",
                        slot->generation));
-                dwc2_async_start(priv, slot);
+                dwc2_async_schedule(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_XFERCOMP)) {
                 slot->split_state = DWC2_ASYNC_SPLIT_START;
@@ -778,12 +864,31 @@ static void dwc2_irq_handler(void)
             KINFO(("dwc2_async: rearm generation=%lu reason=%s\n",
                    slot->generation, (hcint & DWC2_HCINT_NAK) ? "nak" :
                    "chhltd"));
-            dwc2_async_start(priv, slot);
+            dwc2_async_schedule(priv, slot);
         } else {
             dwc2_async_finish_error(priv, slot);
         }
     }
-    writel(DWC2_GINTSTS_HCINTR, &regs->gintsts);
+    if (gintsts & DWC2_GINTSTS_SOFINTR) {
+        BOOL waiting = FALSE;
+
+        frame = readl(&regs->host_regs.hfnum) & DWC2_HFNUM_MAX_FRNUM;
+        for (index = 0; index < DWC2_ASYNC_SLOT_COUNT; index++) {
+            struct dwc2_async_slot *slot = &priv->async[index];
+
+            if (!slot->active || slot->cancelled || slot->stopping ||
+                slot->error_pending || !slot->scheduled)
+                continue;
+            if (dwc2_async_frame_due(frame, slot->next_frame))
+                dwc2_async_start(priv, slot);
+            else
+                waiting = TRUE;
+        }
+        if (!waiting)
+            clrbits_le32(&regs->gintmsk, DWC2_GINTMSK_SOFINTR);
+    }
+    writel(gintsts & (DWC2_GINTSTS_HCINTR | DWC2_GINTSTS_SOFINTR),
+           &regs->gintsts);
 }
 
 /*
@@ -1576,9 +1681,9 @@ long usb_lowlevel_stop(void *ucd_priv)
     WORD index;
 
     for (index = 0; index < DWC2_ASYNC_SLOT_COUNT; index++) {
-        if (priv->async[index].active)
-            dwc2_async_stop(priv, &priv->async[index]);
+        dwc2_async_shutdown(priv, &priv->async[index]);
     }
+    clrbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_SOFINTR);
     clrbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_HCINTR);
     clrbits_le32(&priv->regs->gahbcfg, DWC2_GAHBCFG_GLBLINTRMSK);
     if (priv->irq_connected)

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -44,7 +44,6 @@ struct dwc2_async_slot
     BOOL cancelled;
     BOOL stopping;
     BOOL split;
-    BOOL split_complete;
     DWC2_ASYNC_SPLIT_STATE split_state;
     UBYTE hub_addr;
     UBYTE hub_port;
@@ -590,6 +589,8 @@ static void dwc2_async_start(struct dwc2_priv *priv,
     if (!slot->active || slot->cancelled || slot->stopping)
         return;
 
+    KDEBUG(("dwc2_async: start channel=%d generation=%lu split=%d pid=%d\n",
+            channel, slot->generation, slot->split_state, slot->pid));
     dwc_otg_hc_init(regs, channel, slot->msg->dev,
                     usb_pipedevice(slot->msg->pipe),
                     usb_pipeendpoint(slot->msg->pipe), TRUE,
@@ -636,7 +637,7 @@ static void dwc2_async_stop(struct dwc2_priv *priv,
     slot->active = FALSE;
     slot->cancelled = TRUE;
     slot->stopping = TRUE;
-    KDEBUG(("%s: channel %d generation %lu\n", __func__, channel,
+    KDEBUG(("dwc2_async: stop channel=%d generation=%lu\n", channel,
             slot->generation));
     clrbits_le32(&priv->regs->host_regs.haintmsk, 1UL << channel);
     if (readl(&hc->hcchar) & DWC2_HCCHAR_CHEN) {
@@ -653,7 +654,7 @@ static void dwc2_async_stop(struct dwc2_priv *priv,
 
 static void dwc2_async_release(struct dwc2_async_slot *slot)
 {
-    KDEBUG(("%s: generation %lu\n", __func__, slot->generation));
+    KDEBUG(("dwc2_async: release generation=%lu\n", slot->generation));
     slot->active = FALSE;
     slot->cancelled = FALSE;
     slot->stopping = FALSE;
@@ -689,13 +690,14 @@ static void dwc2_async_finish_success(struct dwc2_priv *priv,
     invalidate_data_cache(slot->dma_buffer,
                           roundup(actual_length, ARCH_DMA_MINALIGN));
     memcpy(msg->buffer, slot->dma_buffer, actual_length);
+    KDEBUG(("dwc2_async: complete generation=%lu length=%ld\n", generation,
+            actual_length));
     dwc2_async_complete(priv, slot, 0, actual_length);
     if (slot->active && !slot->cancelled && !slot->stopping &&
         slot->msg == msg && slot->generation == generation)
         dwc2_async_start(priv, slot);
     else
-        KDEBUG(("%s: completion generation %lu not rearmed\n", __func__,
-                generation));
+        KDEBUG(("dwc2_async: no-rearm generation=%lu\n", generation));
 }
 
 static void dwc2_async_finish_error(struct dwc2_priv *priv,
@@ -732,6 +734,8 @@ static void dwc2_irq_handler(void)
 
         hcint = readl(&hc->hcint);
         writel(hcint, &hc->hcint);
+        KDEBUG(("dwc2_async: irq channel=%d generation=%lu hcint=%08lx split=%d\n",
+                channel, slot->generation, hcint, slot->split_state));
 
         if (slot->stopping) {
             if (hcint & DWC2_HCINT_CHHLTD) {
@@ -750,13 +754,19 @@ static void dwc2_irq_handler(void)
             if (slot->split_state == DWC2_ASYNC_SPLIT_START &&
                 (hcint & DWC2_HCINT_ACK)) {
                 slot->split_state = DWC2_ASYNC_SPLIT_COMPLETE;
+                KDEBUG(("dwc2_async: split-start-ack generation=%lu\n",
+                        slot->generation));
                 dwc2_async_start(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_NYET)) {
+                KDEBUG(("dwc2_async: split-complete-nyet generation=%lu\n",
+                        slot->generation));
                 dwc2_async_start(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_NAK)) {
                 slot->split_state = DWC2_ASYNC_SPLIT_START;
+                KDEBUG(("dwc2_async: split-complete-nak generation=%lu\n",
+                        slot->generation));
                 dwc2_async_start(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_XFERCOMP)) {
@@ -768,6 +778,9 @@ static void dwc2_irq_handler(void)
         } else if (hcint & DWC2_HCINT_XFERCOMP) {
             dwc2_async_finish_success(priv, slot, hc);
         } else if ((hcint & DWC2_HCINT_NAK) || hcint == DWC2_HCINT_CHHLTD) {
+            KDEBUG(("dwc2_async: rearm generation=%lu reason=%s\n",
+                    slot->generation, (hcint & DWC2_HCINT_NAK) ? "nak" :
+                    "chhltd"));
             dwc2_async_start(priv, slot);
         } else {
             dwc2_async_finish_error(priv, slot);
@@ -1417,6 +1430,8 @@ static LONG dwc2_submit_async_int_msg(struct dwc2_priv *priv,
     slot->split_state = slot->split ? DWC2_ASYNC_SPLIT_START :
                         DWC2_ASYNC_SPLIT_NONE;
     slot->active = TRUE;
+    KDEBUG(("dwc2_async: submit generation=%lu split=%d\n",
+            slot->generation, slot->split_state));
     dwc2_async_start(priv, slot);
 
     return E_OK;

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -49,6 +49,7 @@ struct dwc2_async_slot
     UBYTE hub_port;
     UBYTE *dma_buffer;
     ULONG generation;
+    ULONG ssplit_frame;
     ULONG next_frame;
     BOOL scheduled;
     BOOL error_pending;
@@ -107,7 +108,9 @@ static struct dwc2_async_slot *dwc2_async_alloc(struct dwc2_priv *priv,
 static void dwc2_async_start(struct dwc2_priv *priv,
                              struct dwc2_async_slot *slot);
 static void dwc2_async_schedule(struct dwc2_priv *priv,
-                                 struct dwc2_async_slot *slot);
+                                  struct dwc2_async_slot *slot);
+static void dwc2_async_schedule_split_complete(struct dwc2_priv *priv,
+                                                struct dwc2_async_slot *slot);
 static void dwc2_async_stop(struct dwc2_priv *priv,
                             struct dwc2_async_slot *slot);
 static void dwc2_async_release(struct dwc2_async_slot *slot);
@@ -606,13 +609,29 @@ static ULONG dwc2_async_interval(struct dwc2_priv *priv,
 }
 
 static void dwc2_async_schedule(struct dwc2_priv *priv,
-                                 struct dwc2_async_slot *slot)
+                                  struct dwc2_async_slot *slot)
 {
     ULONG frame;
 
     frame = readl(&priv->regs->host_regs.hfnum) & DWC2_HFNUM_MAX_FRNUM;
     slot->next_frame = (frame + dwc2_async_interval(priv, slot->msg)) &
                        DWC2_HFNUM_MAX_FRNUM;
+    slot->scheduled = TRUE;
+    setbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_SOFINTR);
+}
+
+static void dwc2_async_schedule_split_complete(struct dwc2_priv *priv,
+                                                struct dwc2_async_slot *slot)
+{
+    ULONG frame;
+
+    frame = readl(&priv->regs->host_regs.hfnum) & DWC2_HFNUM_MAX_FRNUM;
+    if (((frame - slot->ssplit_frame) & DWC2_HFNUM_MAX_FRNUM) > 4) {
+        slot->split_state = DWC2_ASYNC_SPLIT_START;
+        dwc2_async_schedule(priv, slot);
+        return;
+    }
+    slot->next_frame = (frame + 1) & DWC2_HFNUM_MAX_FRNUM;
     slot->scheduled = TRUE;
     setbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_SOFINTR);
 }
@@ -846,15 +865,17 @@ static void dwc2_irq_handler(void)
         if (slot->split) {
             if (slot->split_state == DWC2_ASYNC_SPLIT_START &&
                 (hcint & DWC2_HCINT_ACK)) {
+                slot->ssplit_frame = readl(&regs->host_regs.hfnum) &
+                                     DWC2_HFNUM_MAX_FRNUM;
                 slot->split_state = DWC2_ASYNC_SPLIT_COMPLETE;
                 KINFO(("dwc2_async: split-start-ack generation=%lu\n",
                        slot->generation));
-                dwc2_async_start(priv, slot);
+                dwc2_async_schedule_split_complete(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_NYET)) {
                 KINFO(("dwc2_async: split-complete-nyet generation=%lu\n",
                        slot->generation));
-                dwc2_async_start(priv, slot);
+                dwc2_async_schedule_split_complete(priv, slot);
             } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
                        (hcint & DWC2_HCINT_NAK)) {
                 slot->split_state = DWC2_ASYNC_SPLIT_START;

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -71,6 +71,7 @@ struct dwc2_priv {
     struct dwc2_async_slot async[DWC2_ASYNC_SLOT_COUNT];
     ULONG async_generation;
     BOOL irq_connected;
+    BOOL shutting_down;
 };
 
 /* We need cacheline-aligned buffers for DMA transfers and dcache support */
@@ -686,7 +687,8 @@ static void dwc2_async_stop(struct dwc2_priv *priv,
         writel(DWC2_HCINT_CHHLTD, &hc->hcint);
         writel(DWC2_HCINTMSK_CHHLTD, &hc->hcintmsk);
         setbits_le32(&hc->hcchar, DWC2_HCCHAR_CHEN | DWC2_HCCHAR_CHDIS);
-        setbits_le32(&priv->regs->host_regs.haintmsk, 1UL << channel);
+        if (!priv->shutting_down)
+            setbits_le32(&priv->regs->host_regs.haintmsk, 1UL << channel);
         return;
     }
     writel(0, &hc->hcintmsk);
@@ -712,17 +714,20 @@ static void dwc2_async_halted(struct dwc2_priv *priv,
 
     writel(0, &hc->hcintmsk);
     clrbits_le32(&priv->regs->host_regs.haintmsk, 1UL << channel);
-    if (slot->error_pending) {
+    if (slot->error_pending && !priv->shutting_down) {
         struct usb_async_int_msg *msg = slot->msg;
 
         slot->error_pending = FALSE;
         dwc2_async_release(slot);
         msg->callback(msg, -1, 0);
-    } else
+    } else {
+        if (slot->error_pending)
+            KINFO(("dwc2_async: suppress error callback during shutdown\n"));
         dwc2_async_release(slot);
+    }
 }
 
-static void dwc2_async_shutdown(struct dwc2_priv *priv,
+static LONG dwc2_async_shutdown(struct dwc2_priv *priv,
                                 struct dwc2_async_slot *slot)
 {
     WORD index = slot - priv->async;
@@ -731,17 +736,19 @@ static void dwc2_async_shutdown(struct dwc2_priv *priv,
     int ret;
 
     if (!slot->msg)
-        return;
+        return E_OK;
     dwc2_async_stop(priv, slot);
     if (!slot->stopping)
-        return;
+        return E_OK;
     ret = wait_for_bit_le32(&hc->hcint, DWC2_HCINT_CHHLTD, TRUE, 2000);
     if (ret) {
-        KINFO(("dwc2_async: halt timeout channel=%d\n", channel));
-        return;
+        KINFO(("dwc2_async: halt timeout channel=%d; controller retained\n",
+               channel));
+        return ETIMEDOUT;
     }
     writel(readl(&hc->hcint), &hc->hcint);
     dwc2_async_halted(priv, slot);
+    return E_OK;
 }
 
 static void dwc2_async_complete(struct dwc2_priv *priv,
@@ -750,7 +757,7 @@ static void dwc2_async_complete(struct dwc2_priv *priv,
 {
     (void)priv;
 
-    if (slot->active && !slot->cancelled)
+    if (slot->active && !slot->cancelled && !priv->shutting_down)
         slot->msg->callback(slot->msg, status, actual_length);
 }
 
@@ -777,6 +784,7 @@ static void dwc2_async_finish_success(struct dwc2_priv *priv,
            actual_length));
     dwc2_async_complete(priv, slot, 0, actual_length);
     if (slot->active && !slot->cancelled && !slot->stopping &&
+        !priv->shutting_down &&
         slot->msg == msg && slot->generation == generation)
         dwc2_async_schedule(priv, slot);
     else
@@ -1509,6 +1517,7 @@ static LONG dwc2_submit_async_int_msg(struct dwc2_priv *priv,
     struct dwc2_async_slot *slot;
 
     if (!msg || !msg->dev || !msg->buffer || !msg->callback ||
+        priv->shutting_down ||
         !priv->irq_connected ||
         msg->transfer_len <= 0 || msg->transfer_len > DWC2_ASYNC_DMA_SIZE ||
         !usb_pipein(msg->pipe) || usb_pipetype(msg->pipe) != PIPE_INTERRUPT)
@@ -1546,6 +1555,11 @@ static LONG dwc2_cancel_async_int_msg(struct dwc2_priv *priv,
 
     if (!msg)
         return EINVAL;
+
+    if (priv->shutting_down) {
+        KINFO(("dwc2_async: cancel ignored during shutdown\n"));
+        return E_OK;
+    }
 
     slot = dwc2_async_find(priv, msg);
     if (!slot)
@@ -1679,9 +1693,13 @@ long usb_lowlevel_stop(void *ucd_priv)
 {
     struct dwc2_priv *priv = ucd_priv;
     WORD index;
+    LONG ret;
 
+    priv->shutting_down = TRUE;
     for (index = 0; index < DWC2_ASYNC_SLOT_COUNT; index++) {
-        dwc2_async_shutdown(priv, &priv->async[index]);
+        ret = dwc2_async_shutdown(priv, &priv->async[index]);
+        if (ret)
+            return ret;
     }
     clrbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_SOFINTR);
     clrbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_HCINTR);

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -108,7 +108,7 @@ static struct dwc2_async_slot *dwc2_async_alloc(struct dwc2_priv *priv,
 static void dwc2_async_start(struct dwc2_priv *priv,
                              struct dwc2_async_slot *slot);
 static void dwc2_async_schedule(struct dwc2_priv *priv,
-                                  struct dwc2_async_slot *slot);
+                                 struct dwc2_async_slot *slot);
 static void dwc2_async_schedule_split_complete(struct dwc2_priv *priv,
                                                 struct dwc2_async_slot *slot);
 static void dwc2_async_stop(struct dwc2_priv *priv,
@@ -609,7 +609,7 @@ static ULONG dwc2_async_interval(struct dwc2_priv *priv,
 }
 
 static void dwc2_async_schedule(struct dwc2_priv *priv,
-                                  struct dwc2_async_slot *slot)
+                                 struct dwc2_async_slot *slot)
 {
     ULONG frame;
 

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -816,6 +816,8 @@ static void dwc2_irq_handler(void)
     gintsts = readl(&regs->gintsts);
     if (!(gintsts & (DWC2_GINTSTS_HCINTR | DWC2_GINTSTS_SOFINTR)))
         return;
+    if (priv->shutting_down)
+        return;
 
     pending = readl(&regs->host_regs.haint) &
               readl(&regs->host_regs.haintmsk);

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -1733,15 +1733,16 @@ long usb_lowlevel_stop(void *ucd_priv)
     for (index = 0; index < DWC2_ASYNC_SLOT_COUNT; index++) {
         ret = dwc2_async_shutdown(priv, &priv->async[index]);
         if (ret)
-            return ret;
+            break;
     }
     clrbits_le32(&priv->regs->gahbcfg, DWC2_GAHBCFG_GLBLINTRMSK);
     if (priv->irq_connected)
         raspi_connect_irq(ARM_IRQ_USB, NULL);
     priv->irq_connected = FALSE;
-    dwc2_uninit_common(priv->regs);
+    if (!ret)
+        dwc2_uninit_common(priv->regs);
 
-    return 0;
+    return ret;
 }
 
 /*

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -17,6 +17,9 @@
 
 /* Use only HC channel 0. */
 #define DWC2_HC_CHANNEL            0
+#define DWC2_ASYNC_FIRST_CHANNEL    1
+#define DWC2_ASYNC_SLOT_COUNT       4
+#define DWC2_ASYNC_DMA_SIZE         8
 
 #define DWC2_STATUS_BUF_SIZE        64
 #define DWC2_DATA_BUF_SIZE        (CONFIG_USB_DWC2_BUFFER_SIZE * 1024)
@@ -26,6 +29,26 @@
 
 #define CONFIG_DWC2_DMA_ENABLE
 #define CONFIG_DWC2_ULPI_FS_LS
+
+typedef enum {
+    DWC2_ASYNC_SPLIT_NONE,
+    DWC2_ASYNC_SPLIT_START,
+    DWC2_ASYNC_SPLIT_COMPLETE
+} DWC2_ASYNC_SPLIT_STATE;
+
+struct dwc2_async_slot
+{
+    struct usb_async_int_msg *msg;
+    UBYTE pid;
+    BOOL active;
+    BOOL cancelled;
+    BOOL split;
+    BOOL split_complete;
+    DWC2_ASYNC_SPLIT_STATE split_state;
+    UBYTE hub_addr;
+    UBYTE hub_port;
+    UBYTE *dma_buffer;
+};
 
 struct dwc2_priv {
     uint8_t *aligned_buffer;
@@ -41,6 +64,8 @@ struct dwc2_priv {
      */
     BOOL hnp_srp_disable;
     BOOL oc_disable;
+    struct dwc2_async_slot async[DWC2_ASYNC_SLOT_COUNT];
+    BOOL irq_connected;
 };
 
 /* We need cacheline-aligned buffers for DMA transfers and dcache support */
@@ -48,6 +73,9 @@ DEFINE_ALIGN_BUFFER(uint8_t, aligned_buffer_addr, DWC2_DATA_BUF_SIZE,
         ARCH_DMA_MINALIGN);
 DEFINE_ALIGN_BUFFER(uint8_t, status_buffer_addr, DWC2_STATUS_BUF_SIZE,
         ARCH_DMA_MINALIGN);
+static UBYTE dwc2_async_dma[DWC2_ASYNC_SLOT_COUNT]
+    [roundup(DWC2_ASYNC_DMA_SIZE, ARCH_DMA_MINALIGN)]
+    __attribute__((aligned(ARCH_DMA_MINALIGN)));
 
 /* Forward declarations */
 
@@ -66,6 +94,27 @@ static long dwc2_ioctl(struct ucdif *u, short cmd, long arg);
 static long dwc2_power_on(void);
 static int dwc2_init_core(struct dwc2_priv *priv);
 static void dwc_otg_core_host_init(struct dwc2_core_regs *regs);
+static struct dwc2_async_slot *dwc2_async_find(struct dwc2_priv *priv,
+                                                struct usb_async_int_msg *msg);
+static struct dwc2_async_slot *dwc2_async_alloc(struct dwc2_priv *priv,
+                                                 struct usb_async_int_msg *msg);
+static void dwc2_async_start(struct dwc2_priv *priv,
+                             struct dwc2_async_slot *slot);
+static void dwc2_async_stop(struct dwc2_priv *priv,
+                            struct dwc2_async_slot *slot);
+static void dwc2_async_complete(struct dwc2_priv *priv,
+                                struct dwc2_async_slot *slot,
+                                LONG status, LONG actual_length);
+static void dwc2_async_finish_success(struct dwc2_priv *priv,
+                                      struct dwc2_async_slot *slot,
+                                      struct dwc2_hc_regs *hc);
+static void dwc2_async_finish_error(struct dwc2_priv *priv,
+                                    struct dwc2_async_slot *slot);
+static void dwc2_irq_handler(void);
+static LONG dwc2_submit_async_int_msg(struct dwc2_priv *priv,
+                                      struct usb_async_int_msg *msg);
+static LONG dwc2_cancel_async_int_msg(struct dwc2_priv *priv,
+                                      struct usb_async_int_msg *msg);
 
 /*--- Global variables ---*/
 static const char hcd_name[] = "dwc2";
@@ -488,6 +537,202 @@ static void dwc_otg_hc_init_split(struct dwc2_hc_regs *hc_regs,
 
     /* Program the HCSPLIT register for SPLITs */
     writel(hcsplt, &hc_regs->hcsplt);
+}
+
+static struct dwc2_async_slot *dwc2_async_find(struct dwc2_priv *priv,
+                                                struct usb_async_int_msg *msg)
+{
+    WORD index;
+
+    for (index = 0; index < DWC2_ASYNC_SLOT_COUNT; index++) {
+        if (priv->async[index].msg == msg)
+            return &priv->async[index];
+    }
+
+    return NULL;
+}
+
+static struct dwc2_async_slot *dwc2_async_alloc(struct dwc2_priv *priv,
+                                                 struct usb_async_int_msg *msg)
+{
+    WORD index;
+
+    for (index = 0; index < DWC2_ASYNC_SLOT_COUNT; index++) {
+        struct dwc2_async_slot *slot = &priv->async[index];
+
+        if (!slot->msg) {
+            memset(slot, 0, sizeof(*slot));
+            slot->msg = msg;
+            slot->pid = DWC2_HC_PID_DATA0;
+            slot->dma_buffer = dwc2_async_dma[index];
+            return slot;
+        }
+    }
+
+    return NULL;
+}
+
+static void dwc2_async_start(struct dwc2_priv *priv,
+                             struct dwc2_async_slot *slot)
+{
+    struct dwc2_core_regs *regs = priv->regs;
+    WORD index = slot - priv->async;
+    WORD channel = DWC2_ASYNC_FIRST_CHANNEL + index;
+    struct dwc2_hc_regs *hc = &regs->hc_regs[channel];
+    ULONG hcintmsk;
+    ULONG hfnum;
+
+    if (!slot->active || slot->cancelled)
+        return;
+
+    dwc_otg_hc_init(regs, channel, slot->msg->dev,
+                    usb_pipedevice(slot->msg->pipe),
+                    usb_pipeendpoint(slot->msg->pipe), TRUE,
+                    DWC2_HCCHAR_EPTYPE_INTR,
+                    usb_maxpacket(slot->msg->dev, slot->msg->pipe));
+    if (slot->split) {
+        dwc_otg_hc_init_split(hc, slot->hub_addr, slot->hub_port);
+        if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE)
+            setbits_le32(&hc->hcsplt, DWC2_HCSPLT_COMPSPLT);
+    }
+
+    writel((slot->msg->transfer_len << DWC2_HCTSIZ_XFERSIZE_OFFSET) |
+           (1UL << DWC2_HCTSIZ_PKTCNT_OFFSET) |
+           (slot->pid << DWC2_HCTSIZ_PID_OFFSET), &hc->hctsiz);
+    invalidate_data_cache(slot->dma_buffer,
+                          roundup(slot->msg->transfer_len, ARCH_DMA_MINALIGN));
+    writel(phys_to_bus((unsigned long)slot->dma_buffer), &hc->hcdma);
+    writel(0x3fff, &hc->hcint);
+    hcintmsk = DWC2_HCINTMSK_XFERCOMPL | DWC2_HCINTMSK_CHHLTD |
+               DWC2_HCINTMSK_STALL | DWC2_HCINTMSK_AHBERR |
+               DWC2_HCINTMSK_XACTERR | DWC2_HCINTMSK_BBLERR |
+               DWC2_HCINTMSK_DATATGLERR | DWC2_HCINTMSK_NAK |
+               DWC2_HCINTMSK_ACK | DWC2_HCINTMSK_NYET;
+    writel(hcintmsk, &hc->hcintmsk);
+    setbits_le32(&regs->host_regs.haintmsk, 1UL << channel);
+
+    hfnum = readl(&regs->host_regs.hfnum);
+    clrsetbits_le32(&hc->hcchar, DWC2_HCCHAR_CHEN | DWC2_HCCHAR_CHDIS |
+                    DWC2_HCCHAR_ODDFRM,
+                    (!(hfnum & 1) << DWC2_HCCHAR_ODDFRM_OFFSET) |
+                    DWC2_HCCHAR_CHEN);
+}
+
+static void dwc2_async_stop(struct dwc2_priv *priv,
+                            struct dwc2_async_slot *slot)
+{
+    WORD index = slot - priv->async;
+    WORD channel = DWC2_ASYNC_FIRST_CHANNEL + index;
+    struct dwc2_hc_regs *hc = &priv->regs->hc_regs[channel];
+
+    clrbits_le32(&priv->regs->host_regs.haintmsk, 1UL << channel);
+    if (readl(&hc->hcchar) & DWC2_HCCHAR_CHEN)
+        setbits_le32(&hc->hcchar, DWC2_HCCHAR_CHEN | DWC2_HCCHAR_CHDIS);
+    writel(0, &hc->hcintmsk);
+    writel(0x3fff, &hc->hcint);
+    slot->active = FALSE;
+    slot->cancelled = FALSE;
+    slot->msg = NULL;
+}
+
+static void dwc2_async_complete(struct dwc2_priv *priv,
+                                struct dwc2_async_slot *slot,
+                                LONG status, LONG actual_length)
+{
+    (void)priv;
+
+    if (slot->active && !slot->cancelled)
+        slot->msg->callback(slot->msg, status, actual_length);
+}
+
+static void dwc2_async_finish_success(struct dwc2_priv *priv,
+                                      struct dwc2_async_slot *slot,
+                                      struct dwc2_hc_regs *hc)
+{
+    ULONG hctsiz;
+    LONG actual_length;
+
+    hctsiz = readl(&hc->hctsiz);
+    actual_length = slot->msg->transfer_len -
+                    ((hctsiz & DWC2_HCTSIZ_XFERSIZE_MASK) >>
+                     DWC2_HCTSIZ_XFERSIZE_OFFSET);
+    slot->pid = (hctsiz & DWC2_HCTSIZ_PID_MASK) >> DWC2_HCTSIZ_PID_OFFSET;
+    invalidate_data_cache(slot->dma_buffer,
+                          roundup(actual_length, ARCH_DMA_MINALIGN));
+    memcpy(slot->msg->buffer, slot->dma_buffer, actual_length);
+    dwc2_async_complete(priv, slot, 0, actual_length);
+    if (slot->active && !slot->cancelled)
+        dwc2_async_start(priv, slot);
+}
+
+static void dwc2_async_finish_error(struct dwc2_priv *priv,
+                                    struct dwc2_async_slot *slot)
+{
+    struct usb_async_int_msg *msg = slot->msg;
+
+    dwc2_async_stop(priv, slot);
+    msg->callback(msg, -1, 0);
+}
+
+static void dwc2_irq_handler(void)
+{
+    struct dwc2_priv *priv = &dwc2_local;
+    struct dwc2_core_regs *regs = priv->regs;
+    ULONG gintsts;
+    ULONG pending;
+    WORD index;
+
+    gintsts = readl(&regs->gintsts);
+    if (!(gintsts & DWC2_GINTSTS_HCINTR))
+        return;
+
+    pending = readl(&regs->host_regs.haint) &
+              readl(&regs->host_regs.haintmsk);
+    for (index = 0; index < DWC2_ASYNC_SLOT_COUNT; index++) {
+        struct dwc2_async_slot *slot = &priv->async[index];
+        WORD channel = DWC2_ASYNC_FIRST_CHANNEL + index;
+        struct dwc2_hc_regs *hc = &regs->hc_regs[channel];
+        ULONG hcint;
+
+        if (!(pending & (1UL << channel)))
+            continue;
+
+        hcint = readl(&hc->hcint);
+        writel(hcint, &hc->hcint);
+
+        if (!slot->active || slot->cancelled) {
+            dwc2_async_stop(priv, slot);
+            continue;
+        }
+
+        if (slot->split) {
+            if (slot->split_state == DWC2_ASYNC_SPLIT_START &&
+                (hcint & DWC2_HCINT_ACK)) {
+                slot->split_state = DWC2_ASYNC_SPLIT_COMPLETE;
+                dwc2_async_start(priv, slot);
+            } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
+                       (hcint & DWC2_HCINT_NYET)) {
+                dwc2_async_start(priv, slot);
+            } else if (slot->split_state == DWC2_ASYNC_SPLIT_COMPLETE &&
+                       (hcint & DWC2_HCINT_NAK)) {
+                slot->split_state = DWC2_ASYNC_SPLIT_START;
+                dwc2_async_start(priv, slot);
+            } else if (hcint & DWC2_HCINT_XFERCOMP) {
+                slot->split_state = DWC2_ASYNC_SPLIT_START;
+                dwc2_async_finish_success(priv, slot, hc);
+            } else {
+                dwc2_async_finish_error(priv, slot);
+            }
+        } else if (hcint & DWC2_HCINT_XFERCOMP) {
+            dwc2_async_finish_success(priv, slot, hc);
+        } else if ((hcint & DWC2_HCINT_NAK) || hcint == DWC2_HCINT_CHHLTD) {
+            dwc2_async_start(priv, slot);
+        } else {
+            dwc2_async_finish_error(priv, slot);
+        }
+    }
+    writel(pending, &regs->host_regs.haint);
+    writel(gintsts, &regs->gintsts);
 }
 
 /*
@@ -1102,6 +1347,57 @@ static int submit_int_msg(struct usb_device *dev, unsigned long pipe,
     }
 }
 
+static LONG dwc2_submit_async_int_msg(struct dwc2_priv *priv,
+                                      struct usb_async_int_msg *msg)
+{
+    struct dwc2_async_slot *slot;
+
+    if (!msg || !msg->dev || !msg->buffer || !msg->callback ||
+        msg->transfer_len <= 0 || msg->transfer_len > DWC2_ASYNC_DMA_SIZE ||
+        !usb_pipein(msg->pipe) || usb_pipetype(msg->pipe) != PIPE_INTERRUPT)
+        return EINVAL;
+
+    if (dwc2_async_find(priv, msg))
+        return EINVAL;
+
+    slot = dwc2_async_alloc(priv, msg);
+    if (!slot)
+        return EAGAIN;
+
+    if (msg->dev->speed != USB_SPEED_HIGH &&
+        (readl(&priv->regs->hprt0) & DWC2_HPRT0_PRTSPD_MASK) ==
+        DWC2_HPRT0_PRTSPD_HIGH) {
+        usb_find_usb2_hub_address_port(msg->dev, &slot->hub_addr,
+                                       &slot->hub_port);
+        if (slot->hub_addr && slot->hub_port)
+            slot->split = TRUE;
+    }
+    slot->split_state = slot->split ? DWC2_ASYNC_SPLIT_START :
+                        DWC2_ASYNC_SPLIT_NONE;
+    slot->active = TRUE;
+    dwc2_async_start(priv, slot);
+
+    return E_OK;
+}
+
+static LONG dwc2_cancel_async_int_msg(struct dwc2_priv *priv,
+                                      struct usb_async_int_msg *msg)
+{
+    struct dwc2_async_slot *slot;
+
+    if (!msg)
+        return EINVAL;
+
+    slot = dwc2_async_find(priv, msg);
+    if (!slot)
+        return EINVAL;
+
+    slot->cancelled = TRUE;
+    dwc2_async_stop(priv, slot);
+
+    return E_OK;
+}
+
 static int dwc2_init_core(struct dwc2_priv *priv)
 {
     struct dwc2_core_regs *regs = priv->regs;
@@ -1212,7 +1508,10 @@ long usb_lowlevel_init(void *ucd_priv)
         return err;
     }
 
-    //raspi_connect_irq (ARM_IRQ_USB, dwc2_irq_handler);
+    raspi_connect_irq(ARM_IRQ_USB, dwc2_irq_handler);
+    setbits_le32(&regs->gintmsk, DWC2_GINTMSK_HCINTR);
+    setbits_le32(&regs->gahbcfg, DWC2_GAHBCFG_GLBLINTRMSK);
+    priv->irq_connected = TRUE;
 
     return 0;
 }
@@ -1220,6 +1519,17 @@ long usb_lowlevel_init(void *ucd_priv)
 long usb_lowlevel_stop(void *ucd_priv)
 {
     struct dwc2_priv *priv = ucd_priv;
+    WORD index;
+
+    for (index = 0; index < DWC2_ASYNC_SLOT_COUNT; index++) {
+        if (priv->async[index].active)
+            dwc2_async_stop(priv, &priv->async[index]);
+    }
+    clrbits_le32(&priv->regs->gintmsk, DWC2_GINTMSK_HCINTR);
+    clrbits_le32(&priv->regs->gahbcfg, DWC2_GAHBCFG_GLBLINTRMSK);
+    if (priv->irq_connected)
+        raspi_connect_irq(ARM_IRQ_USB, NULL);
+    priv->irq_connected = FALSE;
     dwc2_uninit_common(priv->regs);
 
     return 0;
@@ -1281,6 +1591,18 @@ static long dwc2_ioctl(struct ucdif *u, short cmd, long arg)
                                  int_msg->buffer, int_msg->transfer_len,
                                  int_msg->interval);
 
+            break;
+        }
+        case SUBMIT_ASYNC_INT_MSG :
+        {
+            ret = dwc2_submit_async_int_msg((struct dwc2_priv *)u->ucd_priv,
+                                             (struct usb_async_int_msg *)arg);
+            break;
+        }
+        case CANCEL_ASYNC_INT_MSG :
+        {
+            ret = dwc2_cancel_async_int_msg((struct dwc2_priv *)u->ucd_priv,
+                                             (struct usb_async_int_msg *)arg);
             break;
         }
         default:

--- a/usb/udd_keyboard.c
+++ b/usb/udd_keyboard.c
@@ -186,6 +186,8 @@ static void keyboard_report_complete(struct usb_async_int_msg *msg,
     UBYTE changed_mod;
     int i;
 
+    (void)msg;
+
     if (status || actual_length < 8)
     {
         KDEBUG(("usb keyboard interrupt transfer failed (%ld, %ld)\n",

--- a/usb/udd_keyboard.c
+++ b/usb/udd_keyboard.c
@@ -7,10 +7,8 @@
 /*
  * USB HID boot-keyboard class driver.
  *
- * Modeled on udd_mouse.c: probes for a HID boot-protocol keyboard
- * interface, then polls its interrupt endpoint from the raspi timer-C
- * tick (see usb_keyboard_timerc() below, hooked up next to
- * usb_mouse_timerc() in bios/arch/arm/vectors.c).
+ * Probes for a HID boot-protocol keyboard interface and receives reports
+ * through its interrupt endpoint.
  */
 
 static long keyboard_ioctl (struct uddif *, short, long);
@@ -45,9 +43,11 @@ struct kbd_data
     UBYTE keys[6];                /* last set of up to 6 pressed key usages */
     UBYTE new_modifier;
     UBYTE new_keys[6];
+    UBYTE report[8];
 };
 
 static struct kbd_data kbd_data;
+static struct usb_async_int_msg keyboard_request;
 
 /*
  * USB HID keyboard usage ID (Usage Page 0x07) -> Atari IKBD scancode.
@@ -126,12 +126,9 @@ keyboard_disconnect (struct usb_device *dev)
 {
     if (dev == kbd_data.pusb_dev)
     {
-        /* Clear pusb_dev first: usb_keyboard_timerc() (called from the
-         * Timer-C interrupt) gates purely on pusb_dev != NULL, so this
-         * stops it from polling a device that's being torn down before
-         * touching anything else in kbd_data. */
         int i;
 
+        usb_cancel_async_int_msg(&keyboard_request);
         kbd_data.pusb_dev = NULL;
 
         /* Synthesize releases for anything still held, so an unplug
@@ -166,12 +163,6 @@ keyboard_disconnect (struct usb_device *dev)
     return 0;
 }
 
-static long
-usb_keyboard_irq (struct usb_device *dev)
-{
-    return 0;
-}
-
 /* TRUE if usage 'key' (nonzero) is present anywhere in the 6-entry array */
 static BOOL
 usb_keyboard_key_in(const UBYTE *keys, UBYTE key)
@@ -189,47 +180,32 @@ usb_keyboard_key_in(const UBYTE *keys, UBYTE key)
     return FALSE;
 }
 
-void usb_keyboard_timerc (void);
-void usb_keyboard_timerc (void)
+static void keyboard_report_complete(struct usb_async_int_msg *msg,
+                                     LONG status, LONG actual_length)
 {
-    long actlen = 0;
-    long r;
     UBYTE changed_mod;
     int i;
 
-    if (kbd_data.pusb_dev == NULL)
-        return;
-
+    if (status || actual_length < 8)
     {
-        UBYTE report[8];
-
-        r = usb_bulk_msg (kbd_data.pusb_dev,
-                          kbd_data.irqpipe,
-                          report,
-                          kbd_data.irqmaxp > 8 ? 8 : kbd_data.irqmaxp,
-                          &actlen, USB_CNTL_TIMEOUT * 5, 1);
-
-        if ((r != 0) || (actlen < 8))
-            return;
-
-        /* Usages 0x01-0x03 (ErrorRollOver/POSTFail/ErrorUndefined) mean
-         * the device can't report its actual key state this poll (e.g.
-         * more than 6 keys held at once) -- every array slot is filled
-         * with one of these instead of real usages. Treating them as
-         * real keycodes would make every currently-held key look
-         * released (it won't be found in this bogus array) and then
-         * "pressed" again once real reports resume. Skip the report
-         * instead, leaving the last known-good state in place. */
-        for (i = 0; i < 6; i++)
-        {
-            if (report[2 + i] >= 1 && report[2 + i] <= 3)
-                return;
-        }
-
-        kbd_data.new_modifier = report[0];
-        for (i = 0; i < 6; i++)
-            kbd_data.new_keys[i] = report[2 + i];
+        KDEBUG(("usb keyboard interrupt transfer failed (%ld, %ld)\n",
+                status, actual_length));
+        return;
     }
+
+    /* Usages 0x01-0x03 (ErrorRollOver/POSTFail/ErrorUndefined) mean
+     * the device can't report its actual key state this report (e.g.
+     * more than 6 keys held at once). Skip it, leaving the last known-good
+     * state in place. */
+    for (i = 0; i < 6; i++)
+    {
+        if (kbd_data.report[2 + i] >= 1 && kbd_data.report[2 + i] <= 3)
+            return;
+    }
+
+    kbd_data.new_modifier = kbd_data.report[0];
+    for (i = 0; i < 6; i++)
+        kbd_data.new_keys[i] = kbd_data.report[2 + i];
 
     /* Released keys first, so a key that vanishes from one slot and
      * reappears in another in the same report doesn't get treated as
@@ -357,7 +333,6 @@ keyboard_probe (struct usb_device *dev, unsigned int ifnum)
     kbd_data.irqpipe =
         usb_rcvintpipe (dev, (long) kbd_data.ep_int);
     kbd_data.irqmaxp = usb_maxpacket (dev, kbd_data.irqpipe);
-    dev->irq_handle = usb_keyboard_irq;
     kbd_data.modifier = 0;
     memset (kbd_data.keys, 0, sizeof (kbd_data.keys));
     memset (kbd_data.new_keys, 0, sizeof (kbd_data.new_keys));
@@ -365,10 +340,20 @@ keyboard_probe (struct usb_device *dev, unsigned int ifnum)
     usb_set_protocol (dev, iface->desc.bInterfaceNumber, 0); /* boot */
     usb_set_idle (dev, iface->desc.bInterfaceNumber, 0, 0);
 
-    /* Publish pusb_dev last: usb_keyboard_timerc() (Timer-C interrupt)
-     * gates purely on pusb_dev != NULL, so everything else above must
-     * already be valid by the time this becomes visible to it. */
+    keyboard_request.dev = dev;
+    keyboard_request.pipe = kbd_data.irqpipe;
+    keyboard_request.buffer = kbd_data.report;
+    keyboard_request.transfer_len = kbd_data.irqmaxp > 8 ? 8 : kbd_data.irqmaxp;
+    keyboard_request.interval = kbd_data.irqinterval;
+    keyboard_request.callback = keyboard_report_complete;
+    keyboard_request.context = &kbd_data;
     kbd_data.pusb_dev = dev;
+
+    if (usb_submit_async_int_msg(&keyboard_request))
+    {
+        kbd_data.pusb_dev = NULL;
+        return -1;
+    }
 
     KINFO (("%s: exit keyboard_probe success\n", __FILE__));
 

--- a/usb/udd_mouse.c
+++ b/usb/udd_mouse.c
@@ -121,6 +121,10 @@ static void mouse_report_complete(struct usb_async_int_msg *msg,
 	delta_x = mse_data.report[1];
 	delta_y = mse_data.report[2];
 	extra = (actual_length >= 4) ? mse_data.report[3] : 0;
+	if (actual_length < 4)
+		mse_data.data[3] = 0;
+	mse_data.data[4] = 0;
+	mse_data.data[5] = 0;
 	changed = (info != old_info) || delta_x || delta_y
 		|| ((actual_length >= 4) && (extra != mse_data.data[3]));
 	if (!changed)
@@ -157,10 +161,6 @@ static void mouse_report_complete(struct usb_async_int_msg *msg,
 	mse_data.data[2] = delta_y;
 	if (actual_length >= 4)
 		mse_data.data[3] = extra;
-	else
-		mse_data.data[3] = 0;
-	mse_data.data[4] = 0;
-	mse_data.data[5] = 0;
 }
 
 /*******************************************************************************

--- a/usb/udd_mouse.c
+++ b/usb/udd_mouse.c
@@ -40,30 +40,30 @@ static long mouse_probe (struct usb_device *dev, unsigned int ifnum);
 static char lname[] = "USB mouse class driver\0";
 
 static struct uddif mouse_uif = {
-	0,                          /* *next */
-	USB_API_VERSION,            /* API */
-	USB_DEVICE,                 /* class */
-	lname,                      /* lname */
-	"mouse",                    /* name */
-	0,                          /* unit */
-	0,                          /* flags */
-	mouse_probe,                /* probe */
-	mouse_disconnect,           /* disconnect */
-	0,                          /* resrvd1 */
-	mouse_ioctl,                /* ioctl */
-	0,                          /* resrvd2 */
+    0,                          /* *next */
+    USB_API_VERSION,            /* API */
+    USB_DEVICE,                 /* class */
+    lname,                      /* lname */
+    "mouse",                    /* name */
+    0,                          /* unit */
+    0,                          /* flags */
+    mouse_probe,                /* probe */
+    mouse_disconnect,           /* disconnect */
+    0,                          /* resrvd1 */
+    mouse_ioctl,                /* ioctl */
+    0,                          /* resrvd2 */
 };
 
 struct mse_data
 {
-	struct usb_device *pusb_dev;        /* this usb_device */
-	unsigned char ep_in;        /* in endpoint */
-	unsigned char ep_int;       /* interrupt . */
-	unsigned long irqpipe;      /* pipe for release_irq */
-	unsigned char irqmaxp;      /* max packed for irq Pipe */
-	unsigned char irqinterval;  /* Intervall for IRQ Pipe */
-	char data[8];
-	UBYTE report[8];
+    struct usb_device *pusb_dev;        /* this usb_device */
+    unsigned char ep_in;        /* in endpoint */
+    unsigned char ep_int;       /* interrupt . */
+    unsigned long irqpipe;      /* pipe for release_irq */
+    unsigned char irqmaxp;      /* max packed for irq Pipe */
+    unsigned char irqinterval;  /* Intervall for IRQ Pipe */
+    char data[8];
+    UBYTE report[8];
 };
 
 static struct mse_data mse_data;
@@ -76,7 +76,7 @@ static struct usb_async_int_msg mouse_request;
 
 static long mouse_ioctl (struct uddif *u, short cmd, long arg)
 {
-	return E_OK;
+    return E_OK;
 }
 
 /*
@@ -90,77 +90,79 @@ static long mouse_ioctl (struct uddif *u, short cmd, long arg)
 static long
 mouse_disconnect (struct usb_device *dev)
 {
-	if (dev == mse_data.pusb_dev)
-	{
-		usb_cancel_async_int_msg(&mouse_request);
-		mse_data.pusb_dev = NULL;
-	}
+    if (dev == mse_data.pusb_dev)
+    {
+        usb_cancel_async_int_msg(&mouse_request);
+        mse_data.pusb_dev = NULL;
+    }
 
-	return 0;
+    return 0;
 }
 
 static void mouse_report_complete(struct usb_async_int_msg *msg,
                                   LONG status, LONG actual_length)
 {
-	UBYTE info;
-	UBYTE old_info;
-	BYTE delta_x;
-	BYTE delta_y;
-	UBYTE extra;
-	BOOL changed;
+    UBYTE info;
+    UBYTE old_info;
+    BYTE delta_x;
+    BYTE delta_y;
+    UBYTE extra;
+    BOOL changed;
 
-	if (status || actual_length < 3 || actual_length > 8)
-	{
-		KDEBUG(("usb mouse interrupt transfer failed (%ld, %ld)\n",
-			status, actual_length));
-		return;
-	}
+    (void)msg;
 
-	info = mse_data.report[0];
-	old_info = mse_data.data[0];
-	delta_x = mse_data.report[1];
-	delta_y = mse_data.report[2];
-	extra = (actual_length >= 4) ? mse_data.report[3] : 0;
-	if (actual_length < 4)
-		mse_data.data[3] = 0;
-	mse_data.data[4] = 0;
-	mse_data.data[5] = 0;
-	changed = (info != old_info) || delta_x || delta_y
-		|| ((actual_length >= 4) && (extra != mse_data.data[3]));
-	if (!changed)
-		return;
+    if (status || actual_length < 3 || actual_length > 8)
+    {
+        KDEBUG(("usb mouse interrupt transfer failed (%ld, %ld)\n",
+            status, actual_length));
+        return;
+    }
 
-	mouse_packet[0] = ((info & 1) << 1) | ((info & 2) >> 1) | 0xf8;
-	mouse_packet[1] = delta_x;
-	mouse_packet[2] = delta_y;
+    info = mse_data.report[0];
+    old_info = mse_data.data[0];
+    delta_x = mse_data.report[1];
+    delta_y = mse_data.report[2];
+    extra = (actual_length >= 4) ? mse_data.report[3] : 0;
+    if (actual_length < 4)
+        mse_data.data[3] = 0;
+    mse_data.data[4] = 0;
+    mse_data.data[5] = 0;
+    changed = (info != old_info) || delta_x || delta_y
+        || ((actual_length >= 4) && (extra != mse_data.data[3]));
+    if (!changed)
+        return;
 
-	if ((info ^ old_info) & 4)
-		mousexvec((info & 4) ? 0x37 : 0xb7);
+    mouse_packet[0] = ((info & 1) << 1) | ((info & 2) >> 1) | 0xf8;
+    mouse_packet[1] = delta_x;
+    mouse_packet[2] = delta_y;
 
-	switch (extra & 0x0f)
-	{
-	case 0x1:
-		mousexvec(0x59);
-		break;
-	case 0x2:
-		mousexvec(0x5d);
-		break;
-	case 0xe:
-		mousexvec(0x5c);
-		break;
-	case 0xf:
-		mousexvec(0x5a);
-		break;
-	default:
-		break;
-	}
+    if ((info ^ old_info) & 4)
+        mousexvec((info & 4) ? 0x37 : 0xb7);
 
-	call_mousevec(mouse_packet);
-	mse_data.data[0] = info;
-	mse_data.data[1] = delta_x;
-	mse_data.data[2] = delta_y;
-	if (actual_length >= 4)
-		mse_data.data[3] = extra;
+    switch (extra & 0x0f)
+    {
+    case 0x1:
+        mousexvec(0x59);
+        break;
+    case 0x2:
+        mousexvec(0x5d);
+        break;
+    case 0xe:
+        mousexvec(0x5c);
+        break;
+    case 0xf:
+        mousexvec(0x5a);
+        break;
+    default:
+        break;
+    }
+
+    call_mousevec(mouse_packet);
+    mse_data.data[0] = info;
+    mse_data.data[1] = delta_x;
+    mse_data.data[2] = delta_y;
+    if (actual_length >= 4)
+        mse_data.data[3] = extra;
 }
 
 /*******************************************************************************
@@ -170,122 +172,122 @@ static void mouse_report_complete(struct usb_async_int_msg *msg,
 static long
 mouse_probe (struct usb_device *dev, unsigned int ifnum)
 {
-	struct usb_interface *iface;
-	struct usb_endpoint_descriptor *ep_desc;
+    struct usb_interface *iface;
+    struct usb_endpoint_descriptor *ep_desc;
 
-	/*
-	 * Only one mouse at time
-	 */
-	if (mse_data.pusb_dev)
-	{
-		return -1;
-	}
+    /*
+     * Only one mouse at time
+     */
+    if (mse_data.pusb_dev)
+    {
+        return -1;
+    }
 
-	if (dev == NULL)
-	{
-		return -1;
-	}
+    if (dev == NULL)
+    {
+        return -1;
+    }
 
-	usb_disable_asynch (1);     /* asynch transfer not allowed */
+    usb_disable_asynch (1);     /* asynch transfer not allowed */
 
-	/*
-	 * let's examine the device now
-	 */
-	iface = &dev->config.if_desc[ifnum];
-	if (!iface)
-	{
-		return -1;
-	}
+    /*
+     * let's examine the device now
+     */
+    iface = &dev->config.if_desc[ifnum];
+    if (!iface)
+    {
+        return -1;
+    }
 
-	if (iface->desc.bInterfaceClass != USB_CLASS_HID)
-	{
-		return -1;
-	}
+    if (iface->desc.bInterfaceClass != USB_CLASS_HID)
+    {
+        return -1;
+    }
 
-	if (iface->desc.bInterfaceSubClass != USB_SUB_HID_BOOT)
-	{
-		return -1;
-	}
+    if (iface->desc.bInterfaceSubClass != USB_SUB_HID_BOOT)
+    {
+        return -1;
+    }
 
-	if (iface->desc.bInterfaceProtocol != 2)
-	{
-		return -1;
-	}
+    if (iface->desc.bInterfaceProtocol != 2)
+    {
+        return -1;
+    }
 
-	if (iface->desc.bNumEndpoints != 1)
-	{
-		return -1;
-	}
+    if (iface->desc.bNumEndpoints != 1)
+    {
+        return -1;
+    }
 
-	ep_desc = &iface->ep_desc[0];
-	if (!ep_desc)
-	{
-		return -1;
-	}
+    ep_desc = &iface->ep_desc[0];
+    if (!ep_desc)
+    {
+        return -1;
+    }
 
-	if ((ep_desc->bmAttributes &
-		 USB_ENDPOINT_XFERTYPE_MASK) == USB_ENDPOINT_XFER_INT)
-	{
-		mse_data.ep_int =
-			ep_desc->bEndpointAddress & USB_ENDPOINT_NUMBER_MASK;
-		mse_data.irqinterval = ep_desc->bInterval;
-	}
-	else
-	{
-		return -1;
-	}
+    if ((ep_desc->bmAttributes &
+         USB_ENDPOINT_XFERTYPE_MASK) == USB_ENDPOINT_XFER_INT)
+    {
+        mse_data.ep_int =
+            ep_desc->bEndpointAddress & USB_ENDPOINT_NUMBER_MASK;
+        mse_data.irqinterval = ep_desc->bInterval;
+    }
+    else
+    {
+        return -1;
+    }
 
-	mse_data.irqinterval =
-		(mse_data.irqinterval > 0) ? mse_data.irqinterval : 255;
-	mse_data.irqpipe =
-		usb_rcvintpipe (dev, (long) mse_data.ep_int);
-	mse_data.irqmaxp = usb_maxpacket (dev, mse_data.irqpipe);
-	memset (mse_data.data, 0, 8);
-	memset (mse_data.report, 0, 8);
+    mse_data.irqinterval =
+        (mse_data.irqinterval > 0) ? mse_data.irqinterval : 255;
+    mse_data.irqpipe =
+        usb_rcvintpipe (dev, (long) mse_data.ep_int);
+    mse_data.irqmaxp = usb_maxpacket (dev, mse_data.irqpipe);
+    memset (mse_data.data, 0, 8);
+    memset (mse_data.report, 0, 8);
 
-	// if(mse_data.irqmaxp < 6)
-	usb_set_protocol(dev, iface->desc.bInterfaceNumber, 0); /* boot */
-	// else
-	//usb_set_protocol (dev, iface->desc.bInterfaceNumber, 1);    /* report */
+    // if(mse_data.irqmaxp < 6)
+    usb_set_protocol(dev, iface->desc.bInterfaceNumber, 0); /* boot */
+    // else
+    //usb_set_protocol (dev, iface->desc.bInterfaceNumber, 1);    /* report */
 
-	usb_set_idle (dev, iface->desc.bInterfaceNumber, 0, 0);     /* report
-	                                                              * infinite
-	                                                              */
-	mouse_request.dev = dev;
-	mouse_request.pipe = mse_data.irqpipe;
-	mouse_request.buffer = mse_data.report;
-	mouse_request.transfer_len = mse_data.irqmaxp > 8 ? 8 : mse_data.irqmaxp;
-	mouse_request.interval = mse_data.irqinterval;
-	mouse_request.callback = mouse_report_complete;
-	mouse_request.context = &mse_data;
-	mse_data.pusb_dev = dev;
+    usb_set_idle (dev, iface->desc.bInterfaceNumber, 0, 0);     /* report
+                                                                  * infinite
+                                                                  */
+    mouse_request.dev = dev;
+    mouse_request.pipe = mse_data.irqpipe;
+    mouse_request.buffer = mse_data.report;
+    mouse_request.transfer_len = mse_data.irqmaxp > 8 ? 8 : mse_data.irqmaxp;
+    mouse_request.interval = mse_data.irqinterval;
+    mouse_request.callback = mouse_report_complete;
+    mouse_request.context = &mse_data;
+    mse_data.pusb_dev = dev;
 
-	if (usb_submit_async_int_msg(&mouse_request))
-	{
-		mse_data.pusb_dev = NULL;
-		return -1;
-	}
+    if (usb_submit_async_int_msg(&mouse_request))
+    {
+        mse_data.pusb_dev = NULL;
+        return -1;
+    }
 
 KINFO (("%s: exit mouse_probe success\n", __FILE__));
 
-	return 0;
+    return 0;
 }
 
 int usb_mouse_init (void);
 int usb_mouse_init (void)
 {
-	long ret;
+    long ret;
 
-	KINFO (("%s: enter init\n", __FILE__));
+    KINFO (("%s: enter init\n", __FILE__));
 
-	ret = udd_register (&mouse_uif);
+    ret = udd_register (&mouse_uif);
 
-	if (ret)
-	{
-		KINFO (("%s: udd register failed! %ld\n", __FILE__, ret));
-		return 1;
-	}
+    if (ret)
+    {
+        KINFO (("%s: udd register failed! %ld\n", __FILE__, ret));
+        return 1;
+    }
 
-	KINFO(("%s: udd register ok\n", __FILE__));
-	return 0;
+    KINFO(("%s: udd register ok\n", __FILE__));
+    return 0;
 }

--- a/usb/udd_mouse.c
+++ b/usb/udd_mouse.c
@@ -23,7 +23,6 @@ extern void (*old_ikbd_int) (void);
 extern void interrupt_ikbd (void);
 
 static UBYTE mouse_packet[6];
-void usb_mouse_timerc (void);
 
 /*
  * END kernel interface
@@ -59,17 +58,16 @@ struct mse_data
 {
 	struct usb_device *pusb_dev;        /* this usb_device */
 	unsigned char ep_in;        /* in endpoint */
-	unsigned char ep_out;       /* out ....... */
 	unsigned char ep_int;       /* interrupt . */
-	long *irq_handle;            /* for USB int requests */
 	unsigned long irqpipe;      /* pipe for release_irq */
 	unsigned char irqmaxp;      /* max packed for irq Pipe */
 	unsigned char irqinterval;  /* Intervall for IRQ Pipe */
 	char data[8];
-	char new[8];
+	UBYTE report[8];
 };
 
 static struct mse_data mse_data;
+static struct usb_async_int_msg mouse_request;
 
 /*
  * --- Inteface functions
@@ -94,103 +92,75 @@ mouse_disconnect (struct usb_device *dev)
 {
 	if (dev == mse_data.pusb_dev)
 	{
+		usb_cancel_async_int_msg(&mouse_request);
 		mse_data.pusb_dev = NULL;
 	}
 
 	return 0;
 }
 
-static long
-usb_mouse_irq (struct usb_device *dev)
+static void mouse_report_complete(struct usb_async_int_msg *msg,
+                                  LONG status, LONG actual_length)
 {
-	return 0;
-}
+	UBYTE info;
+	UBYTE old_info;
+	BYTE delta_x;
+	BYTE delta_y;
+	UBYTE extra;
+	BOOL changed;
 
-void usb_mouse_timerc (void)
-{
-	long actlen = 0;
-	long r;
-
-	if (mse_data.pusb_dev == NULL)
-		return;
-
-	r = usb_bulk_msg (mse_data.pusb_dev,
-					  mse_data.irqpipe,
-					  mse_data.new,
-					  mse_data.irqmaxp > 8 ? 8 : mse_data.irqmaxp,
-					  &actlen, USB_CNTL_TIMEOUT * 5, 1);
-
-	if ((r != 0) || (actlen < 3) || (actlen > 8))
+	if (status || actual_length < 3 || actual_length > 8)
 	{
+		KDEBUG(("usb mouse interrupt transfer failed (%ld, %ld)\n",
+			status, actual_length));
 		return;
 	}
 
+	info = mse_data.report[0];
+	old_info = mse_data.data[0];
+	delta_x = mse_data.report[1];
+	delta_y = mse_data.report[2];
+	extra = (actual_length >= 4) ? mse_data.report[3] : 0;
+	changed = (info != old_info) || delta_x || delta_y
+		|| ((actual_length >= 4) && (extra != mse_data.data[3]));
+	if (!changed)
+		return;
+
+	mouse_packet[0] = ((info & 1) << 1) | ((info & 2) >> 1) | 0xf8;
+	mouse_packet[1] = delta_x;
+	mouse_packet[2] = delta_y;
+
+	if ((info ^ old_info) & 4)
+		mousexvec((info & 4) ? 0x37 : 0xb7);
+
+	switch (extra & 0x0f)
 	{
-		char info, old_info;
-		char delta_x, delta_y;
-		char extra, old_extra;
-		BOOL change = FALSE;
-
-		(void)old_extra;
-		{					   /* boot report */
-			info = mse_data.new[0];
-			old_info = mse_data.data[0];
-			change |= info != old_info;
-			delta_x = mse_data.new[1];
-			delta_y = mse_data.new[2];
-			change |= !!delta_x || !!delta_y;
-			if (actlen >= 3)
-			{
-				extra = mse_data.new[3];
-				old_extra = mse_data.data[3];
-				change |= extra != old_extra;
-			}
-		}
-		if(!change)
-		{
-			return;
-		}
-
-		// Build ikbd mouse packet
-		mouse_packet[0] =
-			((info & 1) << 1) |
-			((info & 2) >> 1) | 0xF8;
-		mouse_packet[1] = delta_x;
-		mouse_packet[2] = delta_y;
-
-		if ((info ^ old_info) & 4)
-		{					   /* 3rd button */
-			mousexvec ((info & 4)?0x37:0xb7);
-		}
-
-		// Mouse wheel is stored in the low nybble of the extra byte
-		switch (extra & 0xf)
-		{
-			case 0x1:		/* Wheel up */
-			mousexvec (0x59);
-			break;
-			case 0x2:		/* Wheel right */
-			mousexvec (0x5d);
-			break;
-			case 0xe:		/* Wheel left */
-			mousexvec (0x5c);
-			break;
-			case 0xf:		/* Wheel down */
-			mousexvec (0x5a);
-			break;
-			case 0:
-			default:
-			break; // Default is no movement
-		}
-
-		call_mousevec(mouse_packet);
-		mse_data.data[0] = mse_data.new[0];
-		mse_data.data[1] = mse_data.new[1];
-		mse_data.data[2] = mse_data.new[2];
-		mse_data.data[3] = mse_data.new[3];
-		mse_data.data[4] = mse_data.new[4];
-		mse_data.data[5] = mse_data.new[5];
+	case 0x1:
+		mousexvec(0x59);
+		break;
+	case 0x2:
+		mousexvec(0x5d);
+		break;
+	case 0xe:
+		mousexvec(0x5c);
+		break;
+	case 0xf:
+		mousexvec(0x5a);
+		break;
+	default:
+		break;
 	}
+
+	call_mousevec(mouse_packet);
+	mse_data.data[0] = info;
+	mse_data.data[1] = delta_x;
+	mse_data.data[2] = delta_y;
+	if (actual_length >= 4)
+		mse_data.data[3] = extra;
+	else
+		mse_data.data[3] = 0;
+	mse_data.data[4] = 0;
+	mse_data.data[5] = 0;
 }
 
 /*******************************************************************************
@@ -265,16 +235,13 @@ mouse_probe (struct usb_device *dev, unsigned int ifnum)
 		return -1;
 	}
 
-	mse_data.pusb_dev = dev;
-
 	mse_data.irqinterval =
 		(mse_data.irqinterval > 0) ? mse_data.irqinterval : 255;
 	mse_data.irqpipe =
-		usb_rcvintpipe (mse_data.pusb_dev, (long) mse_data.ep_int);
+		usb_rcvintpipe (dev, (long) mse_data.ep_int);
 	mse_data.irqmaxp = usb_maxpacket (dev, mse_data.irqpipe);
-	dev->irq_handle = usb_mouse_irq;
 	memset (mse_data.data, 0, 8);
-	memset (mse_data.new, 0, 8);
+	memset (mse_data.report, 0, 8);
 
 	// if(mse_data.irqmaxp < 6)
 	usb_set_protocol(dev, iface->desc.bInterfaceNumber, 0); /* boot */
@@ -282,8 +249,22 @@ mouse_probe (struct usb_device *dev, unsigned int ifnum)
 	//usb_set_protocol (dev, iface->desc.bInterfaceNumber, 1);    /* report */
 
 	usb_set_idle (dev, iface->desc.bInterfaceNumber, 0, 0);     /* report
-                                                                 * infinite
-                                                                 */
+	                                                              * infinite
+	                                                              */
+	mouse_request.dev = dev;
+	mouse_request.pipe = mse_data.irqpipe;
+	mouse_request.buffer = mse_data.report;
+	mouse_request.transfer_len = mse_data.irqmaxp > 8 ? 8 : mse_data.irqmaxp;
+	mouse_request.interval = mse_data.irqinterval;
+	mouse_request.callback = mouse_report_complete;
+	mouse_request.context = &mse_data;
+	mse_data.pusb_dev = dev;
+
+	if (usb_submit_async_int_msg(&mouse_request))
+	{
+		mse_data.pusb_dev = NULL;
+		return -1;
+	}
 
 KINFO (("%s: exit mouse_probe success\n", __FILE__));
 

--- a/usb/usb.c
+++ b/usb/usb.c
@@ -94,8 +94,16 @@ extern long ucd_unregister(struct ucdif *a);
 void usb_stop(void)
 {
     struct ucdif *a;
+    struct usb_device *dev;
+    long i;
 
     asynch_allowed = 1;
+
+    for (i = 0; i < USB_MAX_DEVICE; i++) {
+        dev = usb_get_dev_index(i);
+        if (dev && !dev->parent)
+            usb_disconnect(dev);
+    }
 
     for (a = allucdifs; a; a = a->next) {
         ucd_unregister(a);
@@ -795,8 +803,10 @@ usb_disconnect(struct usb_device *dev)
     {
         long i;
 
-        ALERT(("USB disconnect on device %ld", dev->parent->devnum));
-        KDEBUG(("USB device disconnect on device %s\n", dev->parent->prod));
+        if (dev->parent) {
+            ALERT(("USB disconnect on device %ld", dev->parent->devnum));
+            KDEBUG(("USB device disconnect on device %s\n", dev->parent->prod));
+        }
 
         KDEBUG(("USB disconnected, device number %ld\n", dev->devnum));
         KDEBUG(("USB device disconnected, device %s\n", dev->prod));
@@ -810,11 +820,14 @@ usb_disconnect(struct usb_device *dev)
         /* Free up all the children.. */
         for (i = 0; i < dev->maxchild; i++)
         {
-            KDEBUG(("Disconnect children %ld\n", dev->children[i]->devnum));
-            struct usb_device *child = dev->children[i];
-            KDEBUG(("child %lx\n", child));
-            usb_disconnect(child);
-            dev->children[i] = NULL;
+            if (dev->children[i]) {
+                struct usb_device *child = dev->children[i];
+
+                KDEBUG(("Disconnect children %ld\n", child->devnum));
+                KDEBUG(("child %lx\n", child));
+                usb_disconnect(child);
+                dev->children[i] = NULL;
+            }
         }
 
         /* See if it's a hub */

--- a/usb/usb.c
+++ b/usb/usb.c
@@ -139,6 +139,29 @@ long usb_submit_int_msg(struct usb_device *dev, unsigned long pipe,
     return (*ucd->ioctl)(ucd, SUBMIT_INT_MSG, (long)&arg);
 }
 
+LONG usb_submit_async_int_msg(struct usb_async_int_msg *msg)
+{
+    struct ucdif *ucd;
+
+    if (!msg || !msg->dev || !msg->buffer || msg->transfer_len <= 0
+        || !msg->callback)
+        return -1;
+
+    ucd = msg->dev->controller;
+    return (*ucd->ioctl)(ucd, SUBMIT_ASYNC_INT_MSG, (LONG)msg);
+}
+
+LONG usb_cancel_async_int_msg(struct usb_async_int_msg *msg)
+{
+    struct ucdif *ucd;
+
+    if (!msg || !msg->dev)
+        return -1;
+
+    ucd = msg->dev->controller;
+    return (*ucd->ioctl)(ucd, CANCEL_ASYNC_INT_MSG, (LONG)msg);
+}
+
 /*
  * submits a control message and waits for completion (at least timeout * 1ms)
  * If timeout is 0, we don't wait for completion (used as example to set and

--- a/usb/usb.h
+++ b/usb/usb.h
@@ -177,6 +177,7 @@ enum {
 };
 
 struct usb_device;
+struct usb_async_int_msg;
 
 struct usb_device
 {
@@ -251,6 +252,8 @@ long usb_bulk_msg            (struct usb_device *dev, unsigned long pipe,
                               long flags);
 long usb_submit_int_msg      (struct usb_device *dev, unsigned long pipe,
                               void *buffer, long transfer_len, long interval);
+LONG usb_submit_async_int_msg(struct usb_async_int_msg *msg);
+LONG usb_cancel_async_int_msg(struct usb_async_int_msg *msg);
 long usb_disable_asynch      (long disable);
 long usb_maxpacket           (struct usb_device *dev, unsigned long pipe);
 long usb_get_configuration_no(struct usb_device *dev, long cfgno,

--- a/usb/usb_api.h
+++ b/usb/usb_api.h
@@ -44,6 +44,8 @@
 #define SUBMIT_CONTROL_MSG    (('U'<< 8) | 2)
 #define SUBMIT_BULK_MSG        (('U'<< 8) | 3)
 #define SUBMIT_INT_MSG        (('U'<< 8) | 4)
+#define SUBMIT_ASYNC_INT_MSG  (('U' << 8) | 5)
+#define CANCEL_ASYNC_INT_MSG  (('U' << 8) | 6)
 
 struct bulk_msg
 {
@@ -71,6 +73,21 @@ struct int_msg
     void             *buffer;
     long             transfer_len;
     long             interval;
+};
+
+struct usb_async_int_msg;
+typedef void (*usb_async_int_callback_t)(struct usb_async_int_msg *msg,
+                                         LONG status, LONG actual_length);
+
+struct usb_async_int_msg
+{
+    struct usb_device *dev;
+    ULONG pipe;
+    void *buffer;
+    LONG transfer_len;
+    LONG interval;
+    usb_async_int_callback_t callback;
+    void *context;
 };
 
 struct ucdif

--- a/usb/usb_global.h
+++ b/usb/usb_global.h
@@ -42,12 +42,12 @@
 #ifndef MACHINE_RPI
 static inline ULONG phys_to_bus(ULONG phys)
 {
-	return phys;
+    return phys;
 }
 
 static inline ULONG bus_to_phys(ULONG bus)
 {
-	return bus;
+    return bus;
 }
 #endif
 
@@ -60,9 +60,15 @@ typedef char Path[MAXPATHLEN];
 # define ALERT(x)       KINFO(x)
 # define DEBUG(x)       KDEBUG(x)
 
+#if CONF_DEBUG_USB_ASYNC
+#define KINFO_USB_ASYNC(a) KINFO(a)
+#else
+#define KINFO_USB_ASYNC(a) ((void)0)
+#endif
+
 #ifdef MACHINE_RPI
-#define mdelay(x) 	raspi_delay_ms(x)
-#define udelay(x) 	raspi_delay_us(x)
+#define mdelay(x)     raspi_delay_ms(x)
+#define udelay(x)     raspi_delay_us(x)
 #define get_timer(x) raspi_get_timer(x)
 #else
 #error "The USB driver can currently only be compiled on RPI"


### PR DESCRIPTION
Fixes #177

## Summary
- Replace Raspberry Pi USB HID Timer-C polling with persistent DWC2 IRQ-driven interrupt-IN transfers.
- Add generic async USB interrupt-message APIs and DWC2 lifecycle handling for intervals, NAKs, errors, cancellation, split transactions, and shutdown.
- Move boot-protocol mouse and keyboard report handling to async completions.
- Add `CONF_DEBUG_USB_ASYNC` (default off) and `KINFO_USB_ASYNC()` to enable high-frequency USB async traces only when diagnosing host-controller scheduling.

## Verification
- `sh tools/test-dwc2-async-contract.sh`
- `make gitready`
- `git diff --check master...HEAD`
- Default rpi1 configuration generates `#define CONF_DEBUG_USB_ASYNC 0`.
- CI builds passed for rpi1, rpi2, rpi2-sparse, rpi3, and rpi4 before the trace-option update.
- QEMU smoke: rpi1 and rpi2 artifacts ran 15 seconds with `-device usb-mouse -device usb-kbd`, initialized both async HID requests, and reported no guest errors.

## Remaining Hardware Validation
- Validate rapid mouse clicks and rapid keyboard input on physical Raspberry Pi hardware, especially full-/low-speed HID devices behind a hub.