### PR TITLE
Split planar palette get/set into per-shifter variants

### DIFF
--- a/bios/raspi_screen.c
+++ b/bios/raspi_screen.c
@@ -251,6 +251,7 @@ void raspi_get_current_mode_desc(SCREEN_MODE_DESC *desc)
     desc->layout = SCREEN_LAYOUT_PACKED;
     desc->color_model = SCREEN_COLOR_TRUECOLOR;
     desc->pixel_format = SCREEN_PIXEL_RGB565;
+    desc->shifter = SCREEN_SHIFTER_NONE;
 }
 
 void raspi_setphys(const UBYTE *addr)

--- a/bios/screen.c
+++ b/bios/screen.c
@@ -765,6 +765,26 @@ static void planar_mode_desc(SCREEN_MODE_DESC *desc, UWORD planes, UWORD hz_rez,
     desc->color_model = SCREEN_COLOR_INDEXED;
     desc->pixel_format = SCREEN_PIXEL_NONE;
     desc->pitch = (ULONG)hz_rez / 8 * planes;
+
+    /*
+     * Which hardware palette family drives this screen (issue #173) -- a
+     * boot-time constant, like has_videl/has_tt_shifter/has_ste_shifter
+     * themselves (see detect_video(), machine.c), so this only needs
+     * computing once per workstation open, not on every vs_color()/
+     * vq_color() call. HAS_VIDEL/HAS_TT_SHIFTER/HAS_STE_SHIFTER (machine.h)
+     * are always-defined macros (0 when the corresponding CONF_WITH_* is
+     * off), so no #if is needed here; on machines with none of these
+     * chips (e.g. Amiga), every branch reads 0 and shifter falls through
+     * to the single generic hardware-palette family, SCREEN_SHIFTER_ST.
+     */
+    if (HAS_VIDEL)
+        desc->shifter = SCREEN_SHIFTER_VIDEL;
+    else if (HAS_TT_SHIFTER)
+        desc->shifter = SCREEN_SHIFTER_TT;
+    else if (HAS_STE_SHIFTER)
+        desc->shifter = SCREEN_SHIFTER_STE;
+    else
+        desc->shifter = SCREEN_SHIFTER_ST;
 }
 
 void screen_get_current_mode_desc(SCREEN_MODE_DESC *desc)

--- a/bios/screen_mode.c
+++ b/bios/screen_mode.c
@@ -22,7 +22,20 @@ BOOL screen_mode_desc_valid(const SCREEN_MODE_DESC *desc)
 
     switch (desc->layout) {
     case SCREEN_LAYOUT_PLANAR:
+        switch (desc->shifter) {
+        case SCREEN_SHIFTER_ST:
+        case SCREEN_SHIFTER_STE:
+        case SCREEN_SHIFTER_TT:
+        case SCREEN_SHIFTER_VIDEL:
+            break;
+        default:
+            return FALSE;
+        }
+        break;
     case SCREEN_LAYOUT_PACKED:
+        /* shifter is meaningless for a packed layout (see screen_mode.h) */
+        if (desc->shifter != SCREEN_SHIFTER_NONE)
+            return FALSE;
         break;
     default:
         return FALSE;

--- a/include/screen_mode.h
+++ b/include/screen_mode.h
@@ -18,6 +18,14 @@
 #define SCREEN_PIXEL_NONE      0   /* not applicable: indexed color */
 #define SCREEN_PIXEL_RGB565    1   /* 5 red / 6 green / 5 blue bits, packed into a UWORD */
 
+#define SCREEN_SHIFTER_NONE    0   /* not applicable: SCREEN_LAYOUT_PACKED */
+#define SCREEN_SHIFTER_ST      1   /* plain ST shifter, or an equivalent single
+                                     * hardware palette with no ST/STE/TT/Videl
+                                     * distinction (e.g. Amiga) */
+#define SCREEN_SHIFTER_STE     2   /* STe shifter */
+#define SCREEN_SHIFTER_TT      3   /* TT shifter */
+#define SCREEN_SHIFTER_VIDEL   4   /* Falcon Videl */
+
 typedef struct {
     UWORD width;          /* visible width, in pixels */
     UWORD height;         /* visible height, in pixels */
@@ -26,6 +34,10 @@ typedef struct {
     UBYTE layout;          /* SCREEN_LAYOUT_* */
     UBYTE color_model;     /* SCREEN_COLOR_* */
     UBYTE pixel_format;    /* SCREEN_PIXEL_*, meaningful only for SCREEN_COLOR_TRUECOLOR */
+    UBYTE shifter;         /* SCREEN_SHIFTER_*, meaningful only for SCREEN_LAYOUT_PLANAR:
+                             * which hardware palette family drives vs_color()/vq_color()
+                             * (issue #173), so vdi_backend_select() can resolve it once
+                             * per workstation instead of every palette read/write */
 } SCREEN_MODE_DESC;
 
 /*

--- a/vdi/vdi_backend.c
+++ b/vdi/vdi_backend.c
@@ -20,8 +20,40 @@ const vdi_backend_ops *vdi_backend_select(const SCREEN_MODE_DESC *mode)
         return NULL;
 
     if (mode->layout == SCREEN_LAYOUT_PLANAR && mode->color_model == SCREEN_COLOR_INDEXED) {
-        vdi_backend_ops_init(&planar_backend_ops);
-        return &planar_backend_ops;
+        vdi_backend_ops *ops;
+
+        /*
+         * Which hardware palette family (issue #173): mode->shifter was
+         * resolved once, at mode-descriptor time, by planar_mode_desc()
+         * (bios/screen.c) from has_videl/has_tt_shifter/has_ste_shifter.
+         * Falls back to the ST variant for any shifter this build didn't
+         * configure in (can't happen for a valid descriptor -- see
+         * screen_mode_desc_valid() -- but a build lacking, say,
+         * CONF_WITH_VIDEL has no planar_videl_backend_ops to select).
+         */
+        switch (mode->shifter) {
+#if CONF_WITH_VIDEL
+        case SCREEN_SHIFTER_VIDEL:
+            ops = &planar_videl_backend_ops;
+            break;
+#endif
+#if CONF_WITH_TT_SHIFTER
+        case SCREEN_SHIFTER_TT:
+            ops = &planar_tt_backend_ops;
+            break;
+#endif
+#if CONF_WITH_STE_SHIFTER
+        case SCREEN_SHIFTER_STE:
+            ops = &planar_ste_backend_ops;
+            break;
+#endif
+        default:
+            ops = &planar_st_backend_ops;
+            break;
+        }
+
+        vdi_backend_ops_init(ops);
+        return ops;
     }
 
 #if CONF_WITH_VDI_BACKEND_TRUECOLOR

--- a/vdi/vdi_backend.c
+++ b/vdi/vdi_backend.c
@@ -13,6 +13,7 @@
 #include "../bios/lineavars.h"  /* linea_vars */
 #include "asm.h"                /* rolw1/rorw1 */
 #include "kprint.h"             /* KDEBUG */
+#include "string.h"             /* memcpy */
 
 const vdi_backend_ops *vdi_backend_select(const SCREEN_MODE_DESC *mode)
 {
@@ -20,45 +21,52 @@ const vdi_backend_ops *vdi_backend_select(const SCREEN_MODE_DESC *mode)
         return NULL;
 
     if (mode->layout == SCREEN_LAYOUT_PLANAR && mode->color_model == SCREEN_COLOR_INDEXED) {
-        const vdi_backend_ops *ops;
-
         /*
-         * Which hardware palette family (issue #173): mode->shifter was
-         * resolved once, at mode-descriptor time, by planar_mode_desc()
-         * (bios/screen.c) from has_videl/has_tt_shifter/has_ste_shifter.
-         * Falls back to the ST variant for any shifter this build didn't
-         * configure in (can't happen for a valid descriptor -- see
-         * screen_mode_desc_valid() -- but a build lacking, say,
-         * CONF_WITH_VIDEL has no planar_videl_backend_ops to select).
+         * Copy the ST-shifter defaults in, then patch set_color/get_color
+         * for the actual hardware palette family (issue #173 follow-up;
+         * see the comment on default_planar_backend_ops/planar_backend_ops
+         * in vdi_backend.h for why this is a runtime copy-and-patch rather
+         * than one const table per family). mode->shifter was resolved
+         * once, at mode-descriptor time, by planar_mode_desc() (bios/
+         * screen.c) from has_videl/has_tt_shifter/has_ste_shifter.
+         *
+         * The default case (SCREEN_SHIFTER_ST, or any shifter this build
+         * didn't configure in -- can't happen for a valid descriptor, see
+         * screen_mode_desc_valid()) needs no patch: the copied defaults are
+         * already the ST-shifter pair.
          */
+        memcpy(&planar_backend_ops, &default_planar_backend_ops, sizeof(planar_backend_ops));
+
         switch (mode->shifter) {
 #if CONF_WITH_VIDEL
         case SCREEN_SHIFTER_VIDEL:
-            ops = &planar_videl_backend_ops;
+            planar_backend_ops.set_color = planar_set_videl_color;
+            planar_backend_ops.get_color = planar_get_videl_color;
             break;
 #endif
 #if CONF_WITH_TT_SHIFTER
         case SCREEN_SHIFTER_TT:
-            ops = &planar_tt_backend_ops;
+            planar_backend_ops.set_color = planar_set_tt_color;
+            planar_backend_ops.get_color = planar_get_tt_color;
             break;
 #endif
 #if CONF_WITH_STE_SHIFTER
         case SCREEN_SHIFTER_STE:
-            ops = &planar_ste_backend_ops;
+            planar_backend_ops.set_color = planar_set_ste_color;
+            planar_backend_ops.get_color = planar_get_ste_color;
             break;
 #endif
         default:
-            ops = &planar_st_backend_ops;
             break;
         }
 
         /*
-         * Not vdi_backend_ops_init(): the planar_*_backend_ops variants are
-         * const (see vdi_backend.h) and never have a NULL slot to fill in,
-         * so only the read-only mandatory-primitive check applies.
+         * Not vdi_backend_ops_init(): planar_backend_ops is always fully
+         * populated by the copy-and-patch above, with no NULL slot to fill
+         * in, so only the read-only mandatory-primitive check applies.
          */
-        vdi_backend_ops_validate(ops);
-        return ops;
+        vdi_backend_ops_validate(&planar_backend_ops);
+        return &planar_backend_ops;
     }
 
 #if CONF_WITH_VDI_BACKEND_TRUECOLOR

--- a/vdi/vdi_backend.c
+++ b/vdi/vdi_backend.c
@@ -31,8 +31,13 @@ const vdi_backend_ops *vdi_backend_select(const SCREEN_MODE_DESC *mode)
          * screen.c) from has_videl/has_tt_shifter/has_ste_shifter.
          *
          * The default case (SCREEN_SHIFTER_ST, or any shifter this build
-         * didn't configure in -- can't happen for a valid descriptor, see
-         * screen_mode_desc_valid()) needs no patch: the copied defaults are
+         * didn't configure in -- can't happen in practice, since the only
+         * planar producer of mode->shifter, planar_mode_desc() in bios/
+         * screen.c, derives it from the same HAS_TT_SHIFTER/HAS_STE_SHIFTER/
+         * HAS_VIDEL macros that gate the #if CONF_WITH_* cases below; note
+         * screen_mode_desc_valid() alone does not guarantee this, since it
+         * only checks mode->shifter's value range, not which shifters this
+         * build has compiled in) needs no patch: the copied defaults are
          * already the ST-shifter pair.
          */
         memcpy(&planar_backend_ops, &default_planar_backend_ops, sizeof(planar_backend_ops));

--- a/vdi/vdi_backend.c
+++ b/vdi/vdi_backend.c
@@ -20,7 +20,7 @@ const vdi_backend_ops *vdi_backend_select(const SCREEN_MODE_DESC *mode)
         return NULL;
 
     if (mode->layout == SCREEN_LAYOUT_PLANAR && mode->color_model == SCREEN_COLOR_INDEXED) {
-        vdi_backend_ops *ops;
+        const vdi_backend_ops *ops;
 
         /*
          * Which hardware palette family (issue #173): mode->shifter was
@@ -52,7 +52,12 @@ const vdi_backend_ops *vdi_backend_select(const SCREEN_MODE_DESC *mode)
             break;
         }
 
-        vdi_backend_ops_init(ops);
+        /*
+         * Not vdi_backend_ops_init(): the planar_*_backend_ops variants are
+         * const (see vdi_backend.h) and never have a NULL slot to fill in,
+         * so only the read-only mandatory-primitive check applies.
+         */
+        vdi_backend_ops_validate(ops);
         return ops;
     }
 
@@ -382,6 +387,14 @@ static WORD default_search_left(const VwkClip *clip, WORD x, WORD y, UWORD searc
     return x + 1;       /* output x coord + 1 to endxleft. */
 }
 
+void vdi_backend_ops_validate(const vdi_backend_ops *ops)
+{
+    if (!ops->get_start_addr || !ops->get_pixel || !ops->put_pixel
+        || !ops->get_raw_pixel || !ops->put_raw_pixel
+        || !ops->set_color || !ops->get_color)
+        KDEBUG(("vdi_backend_ops_validate: backend is missing a mandatory primitive\n"));
+}
+
 void vdi_backend_ops_init(vdi_backend_ops *ops)
 {
     if (!ops->open) ops->open = default_open;
@@ -393,8 +406,5 @@ void vdi_backend_ops_init(vdi_backend_ops *ops)
     if (!ops->search_right) ops->search_right = default_search_right;
     if (!ops->search_left) ops->search_left = default_search_left;
 
-    if (!ops->get_start_addr || !ops->get_pixel || !ops->put_pixel
-        || !ops->get_raw_pixel || !ops->put_raw_pixel
-        || !ops->set_color || !ops->get_color)
-        KDEBUG(("vdi_backend_ops_init: backend is missing a mandatory primitive\n"));
+    vdi_backend_ops_validate(ops);
 }

--- a/vdi/vdi_backend.h
+++ b/vdi/vdi_backend.h
@@ -131,25 +131,48 @@ const vdi_backend_ops *vdi_screen_backend(void);
  * unconditional fallback (also what any non-Atari-shifter planar driver,
  * e.g. Amiga, resolves to); the other three exist only when their hardware
  * family is configured in.
+ *
+ * const: every slot in every planar variant is always populated at compile
+ * time, so none of them ever need vdi_backend_ops_init()'s NULL-slot fill-in
+ * (see vdi_backend_ops_validate() below, which vdi_backend_select() uses for
+ * these instead). This isn't just style -- on the m68k targets, .data lives
+ * in the same read-only ROM region as .text (see the FIXME in emutos.ld and
+ * the "DATA segment is not empty" check in the top-level Makefile); a
+ * non-const table there would accept writes that silently do nothing on
+ * real hardware. packed_truecolor_backend_ops can leave optional slots NULL
+ * under CONF_VDI_SPARSE_TABLE (see vdi_backend_truecolor.c), so it genuinely
+ * needs vdi_backend_ops_init()'s mutation and stays non-const -- it only
+ * matters on MACHINE_RPI, where the "ROM" is actually writable RAM.
  */
-extern vdi_backend_ops planar_st_backend_ops;
+extern const vdi_backend_ops planar_st_backend_ops;
 #if CONF_WITH_STE_SHIFTER
-extern vdi_backend_ops planar_ste_backend_ops;
+extern const vdi_backend_ops planar_ste_backend_ops;
 #endif
 #if CONF_WITH_TT_SHIFTER
-extern vdi_backend_ops planar_tt_backend_ops;
+extern const vdi_backend_ops planar_tt_backend_ops;
 #endif
 #if CONF_WITH_VIDEL
-extern vdi_backend_ops planar_videl_backend_ops;
+extern const vdi_backend_ops planar_videl_backend_ops;
 #endif
 extern vdi_backend_ops packed_truecolor_backend_ops;
 
 /*
  * Installs a generic default into every NULL slot of a backend ops table
- * (see the defaults in vdi_backend.c).  Mandatory slots must already be
- * non-NULL.  Idempotent: safe to call on every vdi_backend_select().
+ * (see the defaults in vdi_backend.c), then validates it (see
+ * vdi_backend_ops_validate() below). Mutates ops, so it cannot be used on a
+ * const table -- see the planar_*_backend_ops comment above. Idempotent:
+ * safe to call on every vdi_backend_select().
  */
 void vdi_backend_ops_init(vdi_backend_ops *ops);
+
+/*
+ * Read-only counterpart to vdi_backend_ops_init(), for tables that are
+ * always fully populated and never need the NULL-slot fill-in (currently
+ * the planar_*_backend_ops variants, which are const). KDEBUGs if a
+ * mandatory primitive is missing, same check vdi_backend_ops_init() runs
+ * after filling defaults.
+ */
+void vdi_backend_ops_validate(const vdi_backend_ops *ops);
 
 #endif /* CONF_WITH_VDI_BACKEND_DISPATCH */
 

--- a/vdi/vdi_backend.h
+++ b/vdi/vdi_backend.h
@@ -123,7 +123,25 @@ const vdi_backend_ops *vdi_backend_select(const SCREEN_MODE_DESC *mode);
  */
 const vdi_backend_ops *vdi_screen_backend(void);
 
-extern vdi_backend_ops planar_backend_ops;
+/*
+ * One planar_*_backend_ops per hardware palette family (issue #173),
+ * selected by vdi_backend_select() from SCREEN_MODE_DESC.shifter -- see
+ * the comment on vdi_backend_ops.set_color/get_color above and on
+ * SCREEN_MODE_DESC.shifter (screen_mode.h). planar_st_backend_ops is the
+ * unconditional fallback (also what any non-Atari-shifter planar driver,
+ * e.g. Amiga, resolves to); the other three exist only when their hardware
+ * family is configured in.
+ */
+extern vdi_backend_ops planar_st_backend_ops;
+#if CONF_WITH_STE_SHIFTER
+extern vdi_backend_ops planar_ste_backend_ops;
+#endif
+#if CONF_WITH_TT_SHIFTER
+extern vdi_backend_ops planar_tt_backend_ops;
+#endif
+#if CONF_WITH_VIDEL
+extern vdi_backend_ops planar_videl_backend_ops;
+#endif
 extern vdi_backend_ops packed_truecolor_backend_ops;
 
 /*

--- a/vdi/vdi_backend.h
+++ b/vdi/vdi_backend.h
@@ -124,36 +124,41 @@ const vdi_backend_ops *vdi_backend_select(const SCREEN_MODE_DESC *mode);
 const vdi_backend_ops *vdi_screen_backend(void);
 
 /*
- * One planar_*_backend_ops per hardware palette family (issue #173),
- * selected by vdi_backend_select() from SCREEN_MODE_DESC.shifter -- see
- * the comment on vdi_backend_ops.set_color/get_color above and on
- * SCREEN_MODE_DESC.shifter (screen_mode.h). planar_st_backend_ops is the
- * unconditional fallback (also what any non-Atari-shifter planar driver,
- * e.g. Amiga, resolves to); the other three exist only when their hardware
- * family is configured in.
+ * default_planar_backend_ops/planar_backend_ops (vdi_backend_planar.c) --
+ * the planar backend's ops table, selected by vdi_backend_select() for a
+ * planar screen (issue #173 and its follow-up).
  *
- * const: every slot in every planar variant is always populated at compile
- * time, so none of them ever need vdi_backend_ops_init()'s NULL-slot fill-in
- * (see vdi_backend_ops_validate() below, which vdi_backend_select() uses for
- * these instead). This isn't just style -- on the m68k targets, .data lives
- * in the same read-only ROM region as .text (see the FIXME in emutos.ld and
- * the "DATA segment is not empty" check in the top-level Makefile); a
+ * A single hardware palette family (ST/STE/TT/Videl, see
+ * SCREEN_MODE_DESC.shifter) only ever varies set_color/get_color -- every
+ * other slot is shifter-agnostic. Rather than one const table per family
+ * (four near-identical 15-pointer tables, all but two pointers duplicated),
+ * vdi_backend_select() keeps only the ST-shifter defaults in ROM
+ * (default_planar_backend_ops) and patches a single mutable copy,
+ * planar_backend_ops, at runtime: memcpy() the defaults in, then overwrite
+ * set_color/get_color for the selected family if it isn't ST -- see
+ * vdi_backend_select() in vdi_backend.c.
+ *
+ * const/non-const split matters on the m68k targets, where .data shares
+ * emutos.ld's read-only ROM region with .text (see its FIXME comment): a
  * non-const table there would accept writes that silently do nothing on
- * real hardware. packed_truecolor_backend_ops can leave optional slots NULL
- * under CONF_VDI_SPARSE_TABLE (see vdi_backend_truecolor.c), so it genuinely
- * needs vdi_backend_ops_init()'s mutation and stays non-const -- it only
- * matters on MACHINE_RPI, where the "ROM" is actually writable RAM.
+ * real hardware, and a table this is only ever memcpy()'d *from* has
+ * nothing to gain from living in writable storage. planar_backend_ops has
+ * no initializer, so it lands in .bss -- real RAM even on those targets --
+ * not .data.
+ *
+ * Both are always fully populated (default_planar_backend_ops at compile
+ * time, planar_backend_ops by the copy-then-patch above), so
+ * vdi_backend_select() only ever runs the read-only
+ * vdi_backend_ops_validate() on planar_backend_ops, never the mutating
+ * vdi_backend_ops_init() -- see the comment on that pair below.
+ * packed_truecolor_backend_ops is different: it can leave optional slots
+ * NULL under CONF_VDI_SPARSE_TABLE (see vdi_backend_truecolor.c), so it
+ * genuinely needs vdi_backend_ops_init()'s mutation and stays non-const --
+ * that only matters on MACHINE_RPI, where the "ROM" is actually writable
+ * RAM.
  */
-extern const vdi_backend_ops planar_st_backend_ops;
-#if CONF_WITH_STE_SHIFTER
-extern const vdi_backend_ops planar_ste_backend_ops;
-#endif
-#if CONF_WITH_TT_SHIFTER
-extern const vdi_backend_ops planar_tt_backend_ops;
-#endif
-#if CONF_WITH_VIDEL
-extern const vdi_backend_ops planar_videl_backend_ops;
-#endif
+extern const vdi_backend_ops default_planar_backend_ops;
+extern vdi_backend_ops planar_backend_ops;
 extern vdi_backend_ops packed_truecolor_backend_ops;
 
 /*

--- a/vdi/vdi_backend.h
+++ b/vdi/vdi_backend.h
@@ -165,17 +165,18 @@ extern vdi_backend_ops packed_truecolor_backend_ops;
  * Installs a generic default into every NULL slot of a backend ops table
  * (see the defaults in vdi_backend.c), then validates it (see
  * vdi_backend_ops_validate() below). Mutates ops, so it cannot be used on a
- * const table -- see the planar_*_backend_ops comment above. Idempotent:
- * safe to call on every vdi_backend_select().
+ * const table -- see the default_planar_backend_ops/planar_backend_ops
+ * comment above. Idempotent: safe to call on every vdi_backend_select().
  */
 void vdi_backend_ops_init(vdi_backend_ops *ops);
 
 /*
  * Read-only counterpart to vdi_backend_ops_init(), for tables that are
  * always fully populated and never need the NULL-slot fill-in (currently
- * the planar_*_backend_ops variants, which are const). KDEBUGs if a
- * mandatory primitive is missing, same check vdi_backend_ops_init() runs
- * after filling defaults.
+ * planar_backend_ops: not const itself, but always fully populated by the
+ * copy-and-patch in vdi_backend_select(), so it never has a NULL slot to
+ * fill in either). KDEBUGs if a mandatory primitive is missing, same check
+ * vdi_backend_ops_init() runs after filling defaults.
  */
 void vdi_backend_ops_validate(const vdi_backend_ops *ops);
 

--- a/vdi/vdi_backend_planar.c
+++ b/vdi/vdi_backend_planar.c
@@ -28,8 +28,16 @@ static void planar_close(Vwk *vwk)
  * set_color/get_color is shifter-agnostic and shared verbatim between the
  * variants -- plane count, not chip family, is what the rest of the planar
  * backend varies on, and that's already handled generically.
+ *
+ * const: every slot below is always populated, so vdi_backend_select() only
+ * ever runs the read-only vdi_backend_ops_validate() on these, never the
+ * mutating vdi_backend_ops_init(). That matters on the m68k targets, where
+ * .data shares emutos.ld's read-only ROM region with .text (see its FIXME
+ * comment) -- a non-const table here would silently fail to hold any write,
+ * and vdi_backend_ops_init() would never actually need to write anything to
+ * a table with no NULL slots, so nothing is lost by not calling it.
  */
-vdi_backend_ops planar_st_backend_ops = {
+const vdi_backend_ops planar_st_backend_ops = {
     planar_open,
     planar_close,
     planar_get_start_addr,
@@ -48,7 +56,7 @@ vdi_backend_ops planar_st_backend_ops = {
 };
 
 #if CONF_WITH_STE_SHIFTER
-vdi_backend_ops planar_ste_backend_ops = {
+const vdi_backend_ops planar_ste_backend_ops = {
     planar_open,
     planar_close,
     planar_get_start_addr,
@@ -68,7 +76,7 @@ vdi_backend_ops planar_ste_backend_ops = {
 #endif
 
 #if CONF_WITH_TT_SHIFTER
-vdi_backend_ops planar_tt_backend_ops = {
+const vdi_backend_ops planar_tt_backend_ops = {
     planar_open,
     planar_close,
     planar_get_start_addr,
@@ -88,7 +96,7 @@ vdi_backend_ops planar_tt_backend_ops = {
 #endif
 
 #if CONF_WITH_VIDEL
-vdi_backend_ops planar_videl_backend_ops = {
+const vdi_backend_ops planar_videl_backend_ops = {
     planar_open,
     planar_close,
     planar_get_start_addr,

--- a/vdi/vdi_backend_planar.c
+++ b/vdi/vdi_backend_planar.c
@@ -21,7 +21,15 @@ static void planar_close(Vwk *vwk)
     (void)vwk;
 }
 
-vdi_backend_ops planar_backend_ops = {
+/*
+ * One vdi_backend_ops variant per planar hardware palette family (issue
+ * #173), selected by vdi_backend_select() from SCREEN_MODE_DESC.shifter
+ * (see screen_mode.h, planar_mode_desc() in bios/screen.c). Every slot but
+ * set_color/get_color is shifter-agnostic and shared verbatim between the
+ * variants -- plane count, not chip family, is what the rest of the planar
+ * backend varies on, and that's already handled generically.
+ */
+vdi_backend_ops planar_st_backend_ops = {
     planar_open,
     planar_close,
     planar_get_start_addr,
@@ -29,8 +37,8 @@ vdi_backend_ops planar_backend_ops = {
     planar_put_pixel,
     planar_get_pixel,       /* get_raw_pixel: a planar pixel's raw value is its composed colour index */
     planar_put_pixel,       /* put_raw_pixel: same for writing */
-    planar_set_color,
-    planar_get_color,
+    planar_set_st_color,
+    planar_get_st_color,
     planar_fill_rect,
     planar_text_blit,
     planar_raster_copy,
@@ -38,3 +46,63 @@ vdi_backend_ops planar_backend_ops = {
     planar_search_right,
     planar_search_left,
 };
+
+#if CONF_WITH_STE_SHIFTER
+vdi_backend_ops planar_ste_backend_ops = {
+    planar_open,
+    planar_close,
+    planar_get_start_addr,
+    planar_get_pixel,
+    planar_put_pixel,
+    planar_get_pixel,
+    planar_put_pixel,
+    planar_set_ste_color,
+    planar_get_ste_color,
+    planar_fill_rect,
+    planar_text_blit,
+    planar_raster_copy,
+    planar_draw_line,
+    planar_search_right,
+    planar_search_left,
+};
+#endif
+
+#if CONF_WITH_TT_SHIFTER
+vdi_backend_ops planar_tt_backend_ops = {
+    planar_open,
+    planar_close,
+    planar_get_start_addr,
+    planar_get_pixel,
+    planar_put_pixel,
+    planar_get_pixel,
+    planar_put_pixel,
+    planar_set_tt_color,
+    planar_get_tt_color,
+    planar_fill_rect,
+    planar_text_blit,
+    planar_raster_copy,
+    planar_draw_line,
+    planar_search_right,
+    planar_search_left,
+};
+#endif
+
+#if CONF_WITH_VIDEL
+vdi_backend_ops planar_videl_backend_ops = {
+    planar_open,
+    planar_close,
+    planar_get_start_addr,
+    planar_get_pixel,
+    planar_put_pixel,
+    planar_get_pixel,
+    planar_put_pixel,
+    planar_set_videl_color,
+    planar_get_videl_color,
+    planar_fill_rect,
+    planar_text_blit,
+    planar_raster_copy,
+    planar_draw_line,
+    planar_search_right,
+    planar_search_left,
+};
+#endif

--- a/vdi/vdi_backend_planar.c
+++ b/vdi/vdi_backend_planar.c
@@ -22,22 +22,22 @@ static void planar_close(Vwk *vwk)
 }
 
 /*
- * One vdi_backend_ops variant per planar hardware palette family (issue
- * #173), selected by vdi_backend_select() from SCREEN_MODE_DESC.shifter
- * (see screen_mode.h, planar_mode_desc() in bios/screen.c). Every slot but
- * set_color/get_color is shifter-agnostic and shared verbatim between the
- * variants -- plane count, not chip family, is what the rest of the planar
- * backend varies on, and that's already handled generically.
+ * default_planar_backend_ops - the ST-shifter table, the only planar
+ * vdi_backend_ops this file defines (issue #173 follow-up).
  *
- * const: every slot below is always populated, so vdi_backend_select() only
- * ever runs the read-only vdi_backend_ops_validate() on these, never the
- * mutating vdi_backend_ops_init(). That matters on the m68k targets, where
- * .data shares emutos.ld's read-only ROM region with .text (see its FIXME
- * comment) -- a non-const table here would silently fail to hold any write,
- * and vdi_backend_ops_init() would never actually need to write anything to
- * a table with no NULL slots, so nothing is lost by not calling it.
+ * Earlier revisions of this file defined one const table per planar
+ * hardware palette family (ST/STE/TT/Videl), all sharing every slot but
+ * set_color/get_color verbatim -- four near-identical 15-pointer tables,
+ * each living in ROM on the m68k targets. vdi_backend_select() now keeps
+ * only this one in ROM and patches a single mutable copy, planar_backend_ops
+ * (below), at runtime instead -- see the comment there.
+ *
+ * const: this table itself is never written to (only memcpy()'d from), so
+ * it stays in ROM on the m68k targets, where .data shares emutos.ld's
+ * read-only region with .text (see its FIXME comment) -- a non-const table
+ * here would accept writes that silently do nothing on real hardware.
  */
-const vdi_backend_ops planar_st_backend_ops = {
+const vdi_backend_ops default_planar_backend_ops = {
     planar_open,
     planar_close,
     planar_get_start_addr,
@@ -55,62 +55,15 @@ const vdi_backend_ops planar_st_backend_ops = {
     planar_search_left,
 };
 
-#if CONF_WITH_STE_SHIFTER
-const vdi_backend_ops planar_ste_backend_ops = {
-    planar_open,
-    planar_close,
-    planar_get_start_addr,
-    planar_get_pixel,
-    planar_put_pixel,
-    planar_get_pixel,
-    planar_put_pixel,
-    planar_set_ste_color,
-    planar_get_ste_color,
-    planar_fill_rect,
-    planar_text_blit,
-    planar_raster_copy,
-    planar_draw_line,
-    planar_search_right,
-    planar_search_left,
-};
-#endif
-
-#if CONF_WITH_TT_SHIFTER
-const vdi_backend_ops planar_tt_backend_ops = {
-    planar_open,
-    planar_close,
-    planar_get_start_addr,
-    planar_get_pixel,
-    planar_put_pixel,
-    planar_get_pixel,
-    planar_put_pixel,
-    planar_set_tt_color,
-    planar_get_tt_color,
-    planar_fill_rect,
-    planar_text_blit,
-    planar_raster_copy,
-    planar_draw_line,
-    planar_search_right,
-    planar_search_left,
-};
-#endif
-
-#if CONF_WITH_VIDEL
-const vdi_backend_ops planar_videl_backend_ops = {
-    planar_open,
-    planar_close,
-    planar_get_start_addr,
-    planar_get_pixel,
-    planar_put_pixel,
-    planar_get_pixel,
-    planar_put_pixel,
-    planar_set_videl_color,
-    planar_get_videl_color,
-    planar_fill_rect,
-    planar_text_blit,
-    planar_raster_copy,
-    planar_draw_line,
-    planar_search_right,
-    planar_search_left,
-};
-#endif
+/*
+ * planar_backend_ops - the table vdi_backend_select() actually hands out
+ * for a planar screen (issue #173 follow-up).
+ *
+ * No initializer, so this lands in .bss (real RAM even on the m68k
+ * targets), not .data -- see the comment on default_planar_backend_ops
+ * above. vdi_backend_select() populates it on every call: memcpy() the ST
+ * defaults from default_planar_backend_ops, then patch set_color/get_color
+ * to the selected shifter family's pair if it isn't ST (which needs no
+ * patch -- the copied defaults are already correct).
+ */
+vdi_backend_ops planar_backend_ops;

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -995,8 +995,16 @@ void init_colors(void)
      */
     {
 #if CONF_WITH_VDI_BACKEND_DISPATCH
+        /*
+         * vdi_screen_backend() can return NULL (see its comment in
+         * vdi_backend.h -- can't happen for any of this codebase's drivers
+         * today, but every other call site still guards it, so this does
+         * too); resolved once here rather than via vdi_screen_is_truecolor()
+         * so this doesn't call vdi_screen_backend() a second time.
+         */
+        const vdi_backend_ops *const backend = vdi_screen_backend();
         void (*const set_hw_color)(Vwk *vwk, WORD pen, WORD *rgb) =
-            vdi_screen_is_truecolor() ? NULL : vdi_screen_backend()->set_color;
+            (backend && backend != &packed_truecolor_backend_ops) ? backend->set_color : NULL;
 #elif CONF_WITH_VDI_BACKEND_TRUECOLOR
         void (*const set_hw_color)(Vwk *vwk, WORD pen, WORD *rgb) = NULL;
 #else

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -704,10 +704,11 @@ static WORD (*hw_adjust_colnum)(WORD colnum);
  * has_tt_shifter/has_ste_shifter are boot-time constants (see
  * detect_video(), bios/machine.c), so this mirrors, for the non-dispatch
  * build, exactly what planar_mode_desc() computes into
- * SCREEN_MODE_DESC.shifter for the dispatch build. Also called lazily by
- * planar_set_color()/planar_get_color() below, so a caller reachable before
- * init_colors() has run (none currently) still gets a real answer instead
- * of dispatching through a still-NULL .bss function pointer.
+ * SCREEN_MODE_DESC.shifter for the dispatch build. planar_set_color()/
+ * planar_get_color() below trust that init_colors() has already run and
+ * dispatch through hw_set_color/hw_get_color unconditionally -- no NULL
+ * check, which would just be the per-call runtime test this issue removes,
+ * re-added one level down.
  */
 static void select_color_family(void)
 {
@@ -746,15 +747,11 @@ static void select_color_family(void)
 
 void planar_set_color(Vwk *vwk, WORD pen, WORD *rgb)
 {
-    if (!hw_set_color)
-        select_color_family();
     hw_set_color(vwk, pen, rgb);
 }
 
 void planar_get_color(const Vwk *vwk, WORD pen, WORD *rgb)
 {
-    if (!hw_get_color)
-        select_color_family();
     hw_get_color(vwk, pen, rgb);
 }
 

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -671,6 +671,15 @@ void planar_get_st_color(const Vwk *vwk, WORD pen, WORD *rgb)
  *
  * No initializer, like hw_set_color/hw_get_color below: see the comment
  * there for why these need .bss, not .data.
+ *
+ * hw_adjust_colnum's call sites (vdi_vs_color()/vdi_vq_color()) dispatch
+ * through it unconditionally, with no "has it been resolved yet" check:
+ * every reachable path to a VDI opcode handler runs through vdi_v_opnwk()
+ * first, which calls init_colors() (and so select_colnum_adjust()) before
+ * any workstation exists to make such a call on. A lazy self-init guard
+ * here would just be defending against a call order this codebase's
+ * control flow doesn't allow -- the same per-call runtime check issue
+ * #173 exists to remove, reintroduced for a case that can't happen.
  */
 static WORD identity_colnum(WORD colnum)
 {
@@ -965,29 +974,49 @@ void init_colors(void)
     for (i = 0; i < linea_vars.DEV_TAB[13]; i++)
         REV_MAP_COL[MAP_COL[i]] = i;
 
-#if !CONF_WITH_VDI_BACKEND_DISPATCH && !CONF_WITH_VDI_BACKEND_TRUECOLOR
     /*
-     * Now initialise the hardware. Planar-only: the truecolor backend has
-     * no shared hardware palette to preload here (RGB565 packed pixels
-     * *are* the colour), and seeds each workstation's own pseudo-palette
-     * separately, from vdi_truecolor_init_palette() (init_wk(),
-     * vdi_control.c) instead -- see the vdi_screen_is_truecolor() branches
-     * above.  In a dispatch build, this step (like the pre-#173 code
-     * before it) is only reachable at all in this build configuration, so
-     * a dispatch build that ends up with the planar backend selected at
-     * runtime does not get its hardware palette preloaded here either;
-     * that gap predates this refactor.
+     * Now initialise the hardware -- but only if the active backend is
+     * planar: the truecolor backend has no shared hardware palette to
+     * preload here (RGB565 packed pixels *are* the colour), and seeds each
+     * workstation's own pseudo-palette separately, from
+     * vdi_truecolor_init_palette() (init_wk(), vdi_control.c) instead --
+     * see the vdi_screen_is_truecolor() branches above.
+     *
+     * Pre-#173, this unconditionally called the single planar-only
+     * set_color(), even in what's now a dispatch build, so a dispatch
+     * build's planar hardware always got preloaded here regardless of
+     * which backend ended up active for a given screen. set_hw_color below
+     * preserves that: hw_set_color directly when planar is the only
+     * renderer (the common case, and the only one where it's declared --
+     * see above), or the selected backend's own set_color when dispatch
+     * means hw_set_color doesn't exist -- vwk is unused by every
+     * planar_set_*_color() (see above), so passing NULL here is safe as
+     * long as the active backend actually is planar.
      */
-    for (i = 0; i < linea_vars.DEV_TAB[13]; i++)
     {
-        if (i < 16)
-            hw_set_color(NULL, i, linea_vars.REQ_COL[i]);
+        void (*set_hw_color)(Vwk *vwk, WORD pen, WORD *rgb);
+
+#if CONF_WITH_VDI_BACKEND_DISPATCH
+        set_hw_color = vdi_screen_is_truecolor() ? NULL : vdi_screen_backend()->set_color;
+#elif CONF_WITH_VDI_BACKEND_TRUECOLOR
+        set_hw_color = NULL;
+#else
+        set_hw_color = hw_set_color;
+#endif
+
+        if (set_hw_color)
+        {
+            for (i = 0; i < linea_vars.DEV_TAB[13]; i++)
+            {
+                if (i < 16)
+                    set_hw_color(NULL, i, linea_vars.REQ_COL[i]);
 #if EXTENDED_PALETTE
-        else
-            hw_set_color(NULL, i, req_col2[i-16]);
+                else
+                    set_hw_color(NULL, i, req_col2[i-16]);
 #endif
+            }
+        }
     }
-#endif
 
 #ifdef HATARI_DUOCHROME_WORKAROUND
     /*

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -669,9 +669,18 @@ void planar_get_st_color(const Vwk *vwk, WORD pen, WORD *rgb)
  * per-family functions above -- so there is exactly one implementation of
  * each family's palette I/O, just two different "pick it once" mechanisms
  * for the two build configurations.
+ *
+ * hw_set_color/hw_get_color/hw_adjust_colnum below are deliberately declared
+ * with no initializer, so they zero-init into .bss instead of .data: on the
+ * m68k targets, .data shares emutos.ld's read-only ROM region with .text
+ * (see its FIXME comment, and the "DATA segment is not empty" check in the
+ * top-level Makefile), so a non-zero static initializer here would place
+ * them somewhere select_color_family()'s writes below could silently fail
+ * on real hardware -- these three exist precisely to be written at runtime,
+ * so they must live in .bss, not .data.
  */
-static void (*hw_set_color)(Vwk *vwk, WORD pen, WORD *rgb) = planar_set_st_color;
-static void (*hw_get_color)(const Vwk *vwk, WORD pen, WORD *rgb) = planar_get_st_color;
+static void (*hw_set_color)(Vwk *vwk, WORD pen, WORD *rgb);
+static void (*hw_get_color)(const Vwk *vwk, WORD pen, WORD *rgb);
 
 #if CONF_WITH_TT_SHIFTER
 /*
@@ -685,19 +694,27 @@ static WORD identity_colnum(WORD colnum)
     return colnum;
 }
 
-static WORD (*hw_adjust_colnum)(WORD colnum) = identity_colnum;
+static WORD (*hw_adjust_colnum)(WORD colnum);
 #endif
 
 /*
- * Resolves hw_set_color/hw_get_color once (issue #173). Called from
- * init_colors(), which itself runs once per physical workstation open,
- * before any palette read/write -- has_videl/has_tt_shifter/has_ste_shifter
- * are boot-time constants (see detect_video(), bios/machine.c), so this
- * mirrors, for the non-dispatch build, exactly what planar_mode_desc()
- * computes into SCREEN_MODE_DESC.shifter for the dispatch build.
+ * Resolves hw_set_color/hw_get_color/hw_adjust_colnum once (issue #173).
+ * Called from init_colors(), which itself runs once per physical
+ * workstation open, before any palette read/write -- has_videl/
+ * has_tt_shifter/has_ste_shifter are boot-time constants (see
+ * detect_video(), bios/machine.c), so this mirrors, for the non-dispatch
+ * build, exactly what planar_mode_desc() computes into
+ * SCREEN_MODE_DESC.shifter for the dispatch build. Also called lazily by
+ * planar_set_color()/planar_get_color() below, so a caller reachable before
+ * init_colors() has run (none currently) still gets a real answer instead
+ * of dispatching through a still-NULL .bss function pointer.
  */
 static void select_color_family(void)
 {
+#if CONF_WITH_TT_SHIFTER
+    hw_adjust_colnum = identity_colnum;
+#endif
+
 #if CONF_WITH_VIDEL
     if (has_videl)
     {
@@ -729,11 +746,15 @@ static void select_color_family(void)
 
 void planar_set_color(Vwk *vwk, WORD pen, WORD *rgb)
 {
+    if (!hw_set_color)
+        select_color_family();
     hw_set_color(vwk, pen, rgb);
 }
 
 void planar_get_color(const Vwk *vwk, WORD pen, WORD *rgb)
 {
+    if (!hw_get_color)
+        select_color_family();
     hw_get_color(vwk, pen, rgb);
 }
 

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -501,14 +501,9 @@ static WORD videl2vdi(LONG col)
  *
  * We do the same ...
  */
-static WORD adjust_mono_values(WORD colnum,WORD *rgb)
+static WORD adjust_mono_values(WORD colnum,WORD *rgb,WORD fudge)
 {
-    WORD i, sum, fudge = ST_MONO_FUDGE_FACTOR;
-
-#if CONF_WITH_STE_SHIFTER
-    if (has_ste_shifter)
-        fudge = STE_MONO_FUDGE_FACTOR;
-#endif
+    WORD i, sum;
 
     for (i = 0, sum = 0; i < 3; i++)
     {
@@ -532,41 +527,76 @@ static WORD adjust_mono_values(WORD colnum,WORD *rgb)
 }
 
 
-/* Set an entry in the hardware color palette
+/*
+ * planar_set_*_color/planar_get_*_color - vdi_backend_ops.set_color/
+ * get_color for one specific planar hardware palette family (issue #173).
+ * Each is the vdi_backend_ops table entry for its family's variant
+ * (planar_videl_backend_ops etc., see vdi_backend_planar.c), selected once
+ * per workstation open via SCREEN_MODE_DESC.shifter -> vdi_backend_select()
+ * (see planar_mode_desc(), bios/screen.c) rather than re-testing has_videl/
+ * has_tt_shifter/has_ste_shifter on every vs_color()/vq_color() call the way
+ * the pre-#173 set_color()/planar_get_color() did.
  *
- * Input is VDI-style: colnum is VDI pen#, rgb[] entries are 0-1000
+ * vwk is unused -- unlike the truecolor backend's per-workstation pseudo-
+ * palette, this backend writes real hardware colour registers, which are
+ * necessarily shared across every workstation. pen is the raw VDI pen
+ * number; each resolves it to a hardware register through MAP_COL[] itself,
+ * matching vdi_truecolor_set_color()/vdi_truecolor_get_color()'s own
+ * MAP_COL[]-mapped index convention (see screen_set_color()/
+ * screen_get_color() below).
  */
-static void set_color(WORD colnum, WORD *rgb)
+#if CONF_WITH_VIDEL
+void planar_set_videl_color(Vwk *vwk, WORD pen, WORD *rgb)
+{
+    WORD hwreg = MAP_COL[pen];
+    LONG videlrgb;
+
+    (void)vwk;
+    videlrgb = (vdi2videl(rgb[0]) << 16) | (vdi2videl(rgb[1]) << 8) | vdi2videl(rgb[2]);
+    VsetRGB(hwreg,1,(LONG)&videlrgb);
+}
+
+void planar_get_videl_color(const Vwk *vwk, WORD pen, WORD *rgb)
+{
+    WORD hwreg = MAP_COL[pen];
+    LONG videlrgb;
+
+    (void)vwk;
+    VgetRGB(hwreg,1,(LONG)&videlrgb);
+    rgb[0] = videl2vdi(videlrgb >> 16);
+    rgb[1] = videl2vdi(videlrgb >> 8);
+    rgb[2] = videl2vdi(videlrgb);
+}
+#endif
+
+#if CONF_WITH_TT_SHIFTER
+void planar_set_tt_color(Vwk *vwk, WORD pen, WORD *rgb)
+{
+    (void)vwk;
+    set_tt_color(pen, rgb);
+}
+
+void planar_get_tt_color(const Vwk *vwk, WORD pen, WORD *rgb)
+{
+    (void)vwk;
+    query_tt_color(pen, rgb);
+}
+#endif
+
+#if CONF_WITH_STE_SHIFTER
+void planar_set_ste_color(Vwk *vwk, WORD pen, WORD *rgb)
 {
     WORD r, g, b;
-    WORD hwreg = MAP_COL[colnum];   /* get hardware register */
+    WORD hwreg = MAP_COL[pen];
 
+    (void)vwk;
     r = rgb[0];
     g = rgb[1];
     b = rgb[2];
 
-#if CONF_WITH_VIDEL
-    if (has_videl)
-    {
-        LONG videlrgb;
-
-        videlrgb = (vdi2videl(r) << 16) | (vdi2videl(g) << 8) | vdi2videl(b);
-        VsetRGB(hwreg,1,(LONG)&videlrgb);
-        return;
-    }
-#endif
-
-#if CONF_WITH_TT_SHIFTER
-    if (has_tt_shifter)
-    {
-        set_tt_color(colnum,rgb);
-        return;
-    }
-#endif
-
     if (linea_vars.v_planes == 1)  /* special handling for monochrome screens */
     {
-        hwreg = adjust_mono_values(hwreg,rgb);  /* may update rgb[] */
+        hwreg = adjust_mono_values(hwreg, rgb, STE_MONO_FUDGE_FACTOR);  /* may update rgb[] */
         if (hwreg < 0)                          /* 'do nothing' */
             return;
         r = rgb[0];
@@ -574,82 +604,137 @@ static void set_color(WORD colnum, WORD *rgb)
         b = rgb[2];
     }
 
-#if CONF_WITH_STE_SHIFTER
-    if (has_ste_shifter)
-    {
-        r = vdi2ste(r);
-        g = vdi2ste(g);
-        b = vdi2ste(b);
-    }
-    else
-#endif
-    {
-        r = vdi2st(r);
-        g = vdi2st(g);
-        b = vdi2st(b);
-    }
-
-    Setcolor(hwreg, (r << 8) | (g << 4) | b);
+    Setcolor(hwreg, (vdi2ste(r) << 8) | (vdi2ste(g) << 4) | vdi2ste(b));
 }
 
-/*
- * planar_set_color/planar_get_color - vdi_backend_ops.set_color/get_color
- * for the planar backend (issue #171): hardware colour-register read/write.
- * vwk is unused -- unlike the truecolor backend's per-workstation pseudo-
- * palette, this backend writes real hardware colour registers, which are
- * necessarily shared across every workstation. pen is the raw VDI pen
- * number; both resolve it to a hardware register through MAP_COL[]
- * themselves, matching vdi_truecolor_set_color()/vdi_truecolor_get_color()'s
- * own MAP_COL[]-mapped index convention (see screen_set_color()/
- * screen_get_color() below).
- */
-void planar_set_color(Vwk *vwk, WORD pen, WORD *rgb)
-{
-    (void)vwk;
-    set_color(pen, rgb);
-}
-
-void planar_get_color(const Vwk *vwk, WORD pen, WORD *rgb)
+void planar_get_ste_color(const Vwk *vwk, WORD pen, WORD *rgb)
 {
     WORD hwreg = MAP_COL[pen];
     WORD c;
 
     (void)vwk;
+    c = Setcolor(hwreg, -1);
+    rgb[0] = ste2vdi(c >> 8);
+    rgb[1] = ste2vdi(c >> 4);
+    rgb[2] = ste2vdi(c);
+}
+#endif
 
+/* plain ST shifter -- the unconditional fallback family */
+void planar_set_st_color(Vwk *vwk, WORD pen, WORD *rgb)
+{
+    WORD r, g, b;
+    WORD hwreg = MAP_COL[pen];
+
+    (void)vwk;
+    r = rgb[0];
+    g = rgb[1];
+    b = rgb[2];
+
+    if (linea_vars.v_planes == 1)  /* special handling for monochrome screens */
+    {
+        hwreg = adjust_mono_values(hwreg, rgb, ST_MONO_FUDGE_FACTOR);  /* may update rgb[] */
+        if (hwreg < 0)                          /* 'do nothing' */
+            return;
+        r = rgb[0];
+        g = rgb[1];
+        b = rgb[2];
+    }
+
+    Setcolor(hwreg, (vdi2st(r) << 8) | (vdi2st(g) << 4) | vdi2st(b));
+}
+
+void planar_get_st_color(const Vwk *vwk, WORD pen, WORD *rgb)
+{
+    WORD hwreg = MAP_COL[pen];
+    WORD c;
+
+    (void)vwk;
+    c = Setcolor(hwreg, -1);
+    rgb[0] = st2vdi(c >> 8);
+    rgb[1] = st2vdi(c >> 4);
+    rgb[2] = st2vdi(c);
+}
+
+/*
+ * planar_set_color/planar_get_color - the direct-call entry points
+ * screen_set_color()/screen_get_color() use when CONF_WITH_VDI_BACKEND_
+ * DISPATCH is off (issue #171): a single-renderer planar build has no
+ * SCREEN_MODE_DESC/vdi_backend_select() step at all (see vdi_v_opnwk(),
+ * vdi_control.c), so there is no descriptor-driven table to pick the right
+ * planar_*_color family from the way vdi_backend_select() does for a
+ * dispatch build (issue #173). These resolve the same has_videl/
+ * has_tt_shifter/has_ste_shifter family choice once instead, cached in
+ * hw_set_color/hw_get_color, and call straight through to the same
+ * per-family functions above -- so there is exactly one implementation of
+ * each family's palette I/O, just two different "pick it once" mechanisms
+ * for the two build configurations.
+ */
+static void (*hw_set_color)(Vwk *vwk, WORD pen, WORD *rgb) = planar_set_st_color;
+static void (*hw_get_color)(const Vwk *vwk, WORD pen, WORD *rgb) = planar_get_st_color;
+
+#if CONF_WITH_TT_SHIFTER
+/*
+ * hw_adjust_colnum - resolved-once counterpart (issue #173, secondary scope
+ * item) to the has_tt_shifter check vdi_vs_color()/vdi_vq_color() used to
+ * repeat on every call before adjust_tt_colnum() (see above): identity on
+ * every non-TT family, adjust_tt_colnum itself once TT is confirmed present.
+ */
+static WORD identity_colnum(WORD colnum)
+{
+    return colnum;
+}
+
+static WORD (*hw_adjust_colnum)(WORD colnum) = identity_colnum;
+#endif
+
+/*
+ * Resolves hw_set_color/hw_get_color once (issue #173). Called from
+ * init_colors(), which itself runs once per physical workstation open,
+ * before any palette read/write -- has_videl/has_tt_shifter/has_ste_shifter
+ * are boot-time constants (see detect_video(), bios/machine.c), so this
+ * mirrors, for the non-dispatch build, exactly what planar_mode_desc()
+ * computes into SCREEN_MODE_DESC.shifter for the dispatch build.
+ */
+static void select_color_family(void)
+{
 #if CONF_WITH_VIDEL
     if (has_videl)
     {
-        LONG videlrgb;
-
-        VgetRGB(hwreg,1,(LONG)&videlrgb);
-        rgb[0] = videl2vdi(videlrgb >> 16);
-        rgb[1] = videl2vdi(videlrgb >> 8);
-        rgb[2] = videl2vdi(videlrgb);
+        hw_set_color = planar_set_videl_color;
+        hw_get_color = planar_get_videl_color;
         return;
     }
 #endif
 #if CONF_WITH_TT_SHIFTER
     if (has_tt_shifter)
     {
-        query_tt_color(pen,rgb);
+        hw_set_color = planar_set_tt_color;
+        hw_get_color = planar_get_tt_color;
+        hw_adjust_colnum = adjust_tt_colnum;
         return;
     }
 #endif
 #if CONF_WITH_STE_SHIFTER
     if (has_ste_shifter)
     {
-        c = Setcolor(hwreg, -1);
-        rgb[0] = ste2vdi(c >> 8);
-        rgb[1] = ste2vdi(c >> 4);
-        rgb[2] = ste2vdi(c);
+        hw_set_color = planar_set_ste_color;
+        hw_get_color = planar_get_ste_color;
         return;
     }
 #endif
-    /* ST shifter */
-    c = Setcolor(hwreg, -1);
-    rgb[0] = st2vdi(c >> 8);
-    rgb[1] = st2vdi(c >> 4);
-    rgb[2] = st2vdi(c);
+    hw_set_color = planar_set_st_color;
+    hw_get_color = planar_get_st_color;
+}
+
+void planar_set_color(Vwk *vwk, WORD pen, WORD *rgb)
+{
+    hw_set_color(vwk, pen, rgb);
+}
+
+void planar_get_color(const Vwk *vwk, WORD pen, WORD *rgb)
+{
+    hw_get_color(vwk, pen, rgb);
 }
 
 /*
@@ -718,8 +803,7 @@ void vdi_vs_color(Vwk *vwk)
     }
 
 #if CONF_WITH_TT_SHIFTER
-    if (has_tt_shifter)
-        colnum = adjust_tt_colnum(colnum);  /* handles palette bank issues */
+    colnum = hw_adjust_colnum(colnum);  /* handles palette bank issues (issue #173) */
 #endif
 
 #if CONF_WITH_VDI_BACKEND_TRUECOLOR
@@ -791,6 +875,13 @@ void init_colors(void)
 {
     int i;
 
+    /*
+     * Resolve which hardware palette family drives planar_set_color()/
+     * planar_get_color() (issue #173), before anything below reads or
+     * writes a hardware colour register through them.
+     */
+    select_color_family();
+
     /* set up palette */
     memcpy(linea_vars.REQ_COL, st_palette, sizeof(st_palette));    /* use ST as default */
 
@@ -832,10 +923,10 @@ void init_colors(void)
     for (i = 0; i < linea_vars.DEV_TAB[13]; i++)
     {
         if (i < 16)
-            set_color(i, linea_vars.REQ_COL[i]);
+            hw_set_color(NULL, i, linea_vars.REQ_COL[i]);
 #if EXTENDED_PALETTE
         else
-            set_color(i, req_col2[i-16]);
+            hw_set_color(NULL, i, req_col2[i-16]);
 #endif
     }
 
@@ -903,8 +994,7 @@ void vdi_vq_color(Vwk *vwk)
     INTOUT[0] = colnum;
 
 #if CONF_WITH_TT_SHIFTER
-    if (has_tt_shifter)
-        colnum = adjust_tt_colnum(colnum);  /* handles palette bank issues */
+    colnum = hw_adjust_colnum(colnum);  /* handles palette bank issues (issue #173) */
 #endif
 
     if (INTIN[1] == 0)  /* return last-requested value */

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -994,14 +994,13 @@ void init_colors(void)
      * long as the active backend actually is planar.
      */
     {
-        void (*set_hw_color)(Vwk *vwk, WORD pen, WORD *rgb);
-
 #if CONF_WITH_VDI_BACKEND_DISPATCH
-        set_hw_color = vdi_screen_is_truecolor() ? NULL : vdi_screen_backend()->set_color;
+        void (*const set_hw_color)(Vwk *vwk, WORD pen, WORD *rgb) =
+            vdi_screen_is_truecolor() ? NULL : vdi_screen_backend()->set_color;
 #elif CONF_WITH_VDI_BACKEND_TRUECOLOR
-        set_hw_color = NULL;
+        void (*const set_hw_color)(Vwk *vwk, WORD pen, WORD *rgb) = NULL;
 #else
-        set_hw_color = hw_set_color;
+        void (*const set_hw_color)(Vwk *vwk, WORD pen, WORD *rgb) = hw_set_color;
 #endif
 
         if (set_hw_color)

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -656,38 +656,21 @@ void planar_get_st_color(const Vwk *vwk, WORD pen, WORD *rgb)
     rgb[2] = st2vdi(c);
 }
 
-/*
- * planar_set_color/planar_get_color - the direct-call entry points
- * screen_set_color()/screen_get_color() use when CONF_WITH_VDI_BACKEND_
- * DISPATCH is off (issue #171): a single-renderer planar build has no
- * SCREEN_MODE_DESC/vdi_backend_select() step at all (see vdi_v_opnwk(),
- * vdi_control.c), so there is no descriptor-driven table to pick the right
- * planar_*_color family from the way vdi_backend_select() does for a
- * dispatch build (issue #173). These resolve the same has_videl/
- * has_tt_shifter/has_ste_shifter family choice once instead, cached in
- * hw_set_color/hw_get_color, and call straight through to the same
- * per-family functions above -- so there is exactly one implementation of
- * each family's palette I/O, just two different "pick it once" mechanisms
- * for the two build configurations.
- *
- * hw_set_color/hw_get_color/hw_adjust_colnum below are deliberately declared
- * with no initializer, so they zero-init into .bss instead of .data: on the
- * m68k targets, .data shares emutos.ld's read-only ROM region with .text
- * (see its FIXME comment, and the "DATA segment is not empty" check in the
- * top-level Makefile), so a non-zero static initializer here would place
- * them somewhere select_color_family()'s writes below could silently fail
- * on real hardware -- these three exist precisely to be written at runtime,
- * so they must live in .bss, not .data.
- */
-static void (*hw_set_color)(Vwk *vwk, WORD pen, WORD *rgb);
-static void (*hw_get_color)(const Vwk *vwk, WORD pen, WORD *rgb);
-
 #if CONF_WITH_TT_SHIFTER
 /*
  * hw_adjust_colnum - resolved-once counterpart (issue #173, secondary scope
  * item) to the has_tt_shifter check vdi_vs_color()/vdi_vq_color() used to
  * repeat on every call before adjust_tt_colnum() (see above): identity on
  * every non-TT family, adjust_tt_colnum itself once TT is confirmed present.
+ *
+ * Needed in every build with CONF_WITH_TT_SHIFTER, regardless of dispatch
+ * state: the bank-adjusted colnum it produces feeds REQ_COL/req_col2
+ * storage in vdi_vs_color()/vdi_vq_color(), bookkeeping that is shared
+ * across backends, not planar hardware I/O -- unlike hw_set_color/
+ * hw_get_color below, it has no dispatch-table equivalent to defer to.
+ *
+ * No initializer, like hw_set_color/hw_get_color below: see the comment
+ * there for why these need .bss, not .data.
  */
 static WORD identity_colnum(WORD colnum)
 {
@@ -695,27 +678,63 @@ static WORD identity_colnum(WORD colnum)
 }
 
 static WORD (*hw_adjust_colnum)(WORD colnum);
+
+static void select_colnum_adjust(void)
+{
+    hw_adjust_colnum = has_tt_shifter ? adjust_tt_colnum : identity_colnum;
+}
 #endif
 
+#if !CONF_WITH_VDI_BACKEND_DISPATCH && !CONF_WITH_VDI_BACKEND_TRUECOLOR
 /*
- * Resolves hw_set_color/hw_get_color/hw_adjust_colnum once (issue #173).
- * Called from init_colors(), which itself runs once per physical
- * workstation open, before any palette read/write -- has_videl/
- * has_tt_shifter/has_ste_shifter are boot-time constants (see
- * detect_video(), bios/machine.c), so this mirrors, for the non-dispatch
- * build, exactly what planar_mode_desc() computes into
- * SCREEN_MODE_DESC.shifter for the dispatch build. planar_set_color()/
- * planar_get_color() below trust that init_colors() has already run and
- * dispatch through hw_set_color/hw_get_color unconditionally -- no NULL
- * check, which would just be the per-call runtime test this issue removes,
- * re-added one level down.
+ * planar_set_color/planar_get_color - the direct-call entry points
+ * screen_set_color()/screen_get_color() use when neither dispatch nor the
+ * truecolor backend is built in (issue #171): a pure single-planar-renderer
+ * build has no SCREEN_MODE_DESC/vdi_backend_select() step at all (see
+ * vdi_v_opnwk(), vdi_control.c), so there is no descriptor-driven table to
+ * pick the right planar_*_color family from the way vdi_backend_select()
+ * does for a dispatch build (issue #173). These resolve the same
+ * has_videl/has_tt_shifter/has_ste_shifter family choice once instead,
+ * cached in hw_set_color/hw_get_color, and call straight through to the
+ * same per-family functions above -- so there is exactly one implementation
+ * of each family's palette I/O, just two different "pick it once"
+ * mechanisms for the two build configurations.
+ *
+ * This whole block -- statics, select_color_family() and the two entry
+ * points -- only exists in that one configuration: a dispatch build always
+ * reaches palette I/O through backend->set_color/get_color (a
+ * planar_*_backend_ops table entry, never through here, see
+ * vdi_backend_planar.c), and a truecolor-only build never touches planar
+ * code at all. Compiling this in for either would be exactly the dispatch
+ * overhead that can only ever resolve one way that issue #138 already
+ * excludes elsewhere (see vdi_backend.h).
+ *
+ * hw_set_color/hw_get_color below are deliberately declared with no
+ * initializer, so they zero-init into .bss instead of .data: on the m68k
+ * targets, .data shares emutos.ld's read-only ROM region with .text (see
+ * its FIXME comment, and the "DATA segment is not empty" check in the
+ * top-level Makefile), so a non-zero static initializer here would place
+ * them somewhere select_color_family()'s writes below could silently fail
+ * on real hardware -- these exist precisely to be written at runtime, so
+ * they must live in .bss, not .data.
+ */
+static void (*hw_set_color)(Vwk *vwk, WORD pen, WORD *rgb);
+static void (*hw_get_color)(const Vwk *vwk, WORD pen, WORD *rgb);
+
+/*
+ * Resolves hw_set_color/hw_get_color once (issue #173). Called from
+ * init_colors(), which itself runs once per physical workstation open,
+ * before any palette read/write -- has_videl/has_tt_shifter/has_ste_shifter
+ * are boot-time constants (see detect_video(), bios/machine.c), so this
+ * mirrors, for this build configuration, exactly what planar_mode_desc()
+ * computes into SCREEN_MODE_DESC.shifter for a dispatch build.
+ * planar_set_color()/planar_get_color() below trust that init_colors() has
+ * already run and dispatch through hw_set_color/hw_get_color
+ * unconditionally -- no NULL check, which would just be the per-call
+ * runtime test this issue removes, re-added one level down.
  */
 static void select_color_family(void)
 {
-#if CONF_WITH_TT_SHIFTER
-    hw_adjust_colnum = identity_colnum;
-#endif
-
 #if CONF_WITH_VIDEL
     if (has_videl)
     {
@@ -729,7 +748,6 @@ static void select_color_family(void)
     {
         hw_set_color = planar_set_tt_color;
         hw_get_color = planar_get_tt_color;
-        hw_adjust_colnum = adjust_tt_colnum;
         return;
     }
 #endif
@@ -754,6 +772,7 @@ void planar_get_color(const Vwk *vwk, WORD pen, WORD *rgb)
 {
     hw_get_color(vwk, pen, rgb);
 }
+#endif /* !CONF_WITH_VDI_BACKEND_DISPATCH && !CONF_WITH_VDI_BACKEND_TRUECOLOR */
 
 /*
  * screen_set_color/screen_get_color - dispatch a palette write/read to the
@@ -893,12 +912,21 @@ void init_colors(void)
 {
     int i;
 
+#if CONF_WITH_TT_SHIFTER
+    /* Resolve hw_adjust_colnum (issue #173) -- needed by vdi_vs_color()/
+     * vdi_vq_color() regardless of which backend is active, see the
+     * comment on select_colnum_adjust() above. */
+    select_colnum_adjust();
+#endif
+
+#if !CONF_WITH_VDI_BACKEND_DISPATCH && !CONF_WITH_VDI_BACKEND_TRUECOLOR
     /*
      * Resolve which hardware palette family drives planar_set_color()/
      * planar_get_color() (issue #173), before anything below reads or
      * writes a hardware colour register through them.
      */
     select_color_family();
+#endif
 
     /* set up palette */
     memcpy(linea_vars.REQ_COL, st_palette, sizeof(st_palette));    /* use ST as default */
@@ -937,7 +965,19 @@ void init_colors(void)
     for (i = 0; i < linea_vars.DEV_TAB[13]; i++)
         REV_MAP_COL[MAP_COL[i]] = i;
 
-    /* now initialise the hardware */
+#if !CONF_WITH_VDI_BACKEND_DISPATCH && !CONF_WITH_VDI_BACKEND_TRUECOLOR
+    /*
+     * Now initialise the hardware. Planar-only: the truecolor backend has
+     * no shared hardware palette to preload here (RGB565 packed pixels
+     * *are* the colour), and seeds each workstation's own pseudo-palette
+     * separately, from vdi_truecolor_init_palette() (init_wk(),
+     * vdi_control.c) instead -- see the vdi_screen_is_truecolor() branches
+     * above.  In a dispatch build, this step (like the pre-#173 code
+     * before it) is only reachable at all in this build configuration, so
+     * a dispatch build that ends up with the planar backend selected at
+     * runtime does not get its hardware palette preloaded here either;
+     * that gap predates this refactor.
+     */
     for (i = 0; i < linea_vars.DEV_TAB[13]; i++)
     {
         if (i < 16)
@@ -947,6 +987,7 @@ void init_colors(void)
             hw_set_color(NULL, i, req_col2[i-16]);
 #endif
     }
+#endif
 
 #ifdef HATARI_DUOCHROME_WORKAROUND
     /*

--- a/vdi/vdi_col.c
+++ b/vdi/vdi_col.c
@@ -530,10 +530,11 @@ static WORD adjust_mono_values(WORD colnum,WORD *rgb,WORD fudge)
 /*
  * planar_set_*_color/planar_get_*_color - vdi_backend_ops.set_color/
  * get_color for one specific planar hardware palette family (issue #173).
- * Each is the vdi_backend_ops table entry for its family's variant
- * (planar_videl_backend_ops etc., see vdi_backend_planar.c), selected once
- * per workstation open via SCREEN_MODE_DESC.shifter -> vdi_backend_select()
- * (see planar_mode_desc(), bios/screen.c) rather than re-testing has_videl/
+ * Each is what vdi_backend_select() patches into planar_backend_ops's
+ * set_color/get_color slots for the selected family (see
+ * vdi_backend_planar.c/vdi_backend.c), selected once per workstation open
+ * via SCREEN_MODE_DESC.shifter -> vdi_backend_select() (see
+ * planar_mode_desc(), bios/screen.c) rather than re-testing has_videl/
  * has_tt_shifter/has_ste_shifter on every vs_color()/vq_color() call the way
  * the pre-#173 set_color()/planar_get_color() did.
  *
@@ -711,12 +712,13 @@ static void select_colnum_adjust(void)
  *
  * This whole block -- statics, select_color_family() and the two entry
  * points -- only exists in that one configuration: a dispatch build always
- * reaches palette I/O through backend->set_color/get_color (a
- * planar_*_backend_ops table entry, never through here, see
- * vdi_backend_planar.c), and a truecolor-only build never touches planar
- * code at all. Compiling this in for either would be exactly the dispatch
- * overhead that can only ever resolve one way that issue #138 already
- * excludes elsewhere (see vdi_backend.h).
+ * reaches palette I/O through backend->set_color/get_color (planar_backend_
+ * ops's patched set_color/get_color slots for a planar screen, never
+ * through here -- see vdi_backend_planar.c/vdi_backend.c), and a
+ * truecolor-only build never touches planar code at all. Compiling this in
+ * for either would be exactly the dispatch overhead that can only ever
+ * resolve one way that issue #138 already excludes elsewhere (see
+ * vdi_backend.h).
  *
  * hw_set_color/hw_get_color below are deliberately declared with no
  * initializer, so they zero-init into .bss instead of .data: on the m68k

--- a/vdi/vdi_defs.h
+++ b/vdi/vdi_defs.h
@@ -318,9 +318,14 @@ void planar_fill_rect(const VwkAttrib *attr, const Rect *rect);
 /* planar_set_color/planar_get_color (vdi_col.c) -- hardware colour-register
  * read/write called directly in non-dispatch, planar-only builds (issue
  * #171), see the vdi_backend_ops comment on set_color/get_color in
- * vdi_backend.h */
+ * vdi_backend.h. Only defined in that one build configuration (issue #173)
+ * -- a dispatch build reaches palette I/O through a planar_*_backend_ops
+ * table entry instead, and a truecolor-only build never touches planar
+ * code at all. */
+#if !CONF_WITH_VDI_BACKEND_DISPATCH && !CONF_WITH_VDI_BACKEND_TRUECOLOR
 void planar_set_color(Vwk *vwk, WORD pen, WORD *rgb);
 void planar_get_color(const Vwk *vwk, WORD pen, WORD *rgb);
+#endif
 /* planar_set_*_color/planar_get_*_color (vdi_col.c) -- per-shifter-family
  * vdi_backend_ops.set_color/get_color entries (issue #173), one pair per
  * planar_*_backend_ops variant (vdi_backend_planar.c); see the comment on

--- a/vdi/vdi_defs.h
+++ b/vdi/vdi_defs.h
@@ -316,10 +316,29 @@ UWORD planar_get_pixel(WORD x, WORD y);
 void planar_put_pixel(WORD x, WORD y, UWORD color);
 void planar_fill_rect(const VwkAttrib *attr, const Rect *rect);
 /* planar_set_color/planar_get_color (vdi_col.c) -- hardware colour-register
- * read/write for the planar backend, see the vdi_backend_ops comment on
- * set_color/get_color in vdi_backend.h */
+ * read/write called directly in non-dispatch, planar-only builds (issue
+ * #171), see the vdi_backend_ops comment on set_color/get_color in
+ * vdi_backend.h */
 void planar_set_color(Vwk *vwk, WORD pen, WORD *rgb);
 void planar_get_color(const Vwk *vwk, WORD pen, WORD *rgb);
+/* planar_set_*_color/planar_get_*_color (vdi_col.c) -- per-shifter-family
+ * vdi_backend_ops.set_color/get_color entries (issue #173), one pair per
+ * planar_*_backend_ops variant (vdi_backend_planar.c); see the comment on
+ * SCREEN_MODE_DESC.shifter (screen_mode.h) */
+void planar_set_st_color(Vwk *vwk, WORD pen, WORD *rgb);
+void planar_get_st_color(const Vwk *vwk, WORD pen, WORD *rgb);
+#if CONF_WITH_STE_SHIFTER
+void planar_set_ste_color(Vwk *vwk, WORD pen, WORD *rgb);
+void planar_get_ste_color(const Vwk *vwk, WORD pen, WORD *rgb);
+#endif
+#if CONF_WITH_TT_SHIFTER
+void planar_set_tt_color(Vwk *vwk, WORD pen, WORD *rgb);
+void planar_get_tt_color(const Vwk *vwk, WORD pen, WORD *rgb);
+#endif
+#if CONF_WITH_VIDEL
+void planar_set_videl_color(Vwk *vwk, WORD pen, WORD *rgb);
+void planar_get_videl_color(const Vwk *vwk, WORD pen, WORD *rgb);
+#endif
 /* truecolor backend primitives (vdi_backend_truecolor.c) -- callable
  * directly in truecolor-only builds, where the dispatcher is compiled out */
 UWORD *truecolor_get_start_addr(WORD x, WORD y);

--- a/vdi/vdi_defs.h
+++ b/vdi/vdi_defs.h
@@ -319,16 +319,18 @@ void planar_fill_rect(const VwkAttrib *attr, const Rect *rect);
  * read/write called directly in non-dispatch, planar-only builds (issue
  * #171), see the vdi_backend_ops comment on set_color/get_color in
  * vdi_backend.h. Only defined in that one build configuration (issue #173)
- * -- a dispatch build reaches palette I/O through a planar_*_backend_ops
- * table entry instead, and a truecolor-only build never touches planar
- * code at all. */
+ * -- a dispatch build reaches palette I/O through planar_backend_ops's
+ * patched set_color/get_color slots instead (see vdi_backend_planar.c/
+ * vdi_backend.c), and a truecolor-only build never touches planar code at
+ * all. */
 #if !CONF_WITH_VDI_BACKEND_DISPATCH && !CONF_WITH_VDI_BACKEND_TRUECOLOR
 void planar_set_color(Vwk *vwk, WORD pen, WORD *rgb);
 void planar_get_color(const Vwk *vwk, WORD pen, WORD *rgb);
 #endif
 /* planar_set_*_color/planar_get_*_color (vdi_col.c) -- per-shifter-family
- * vdi_backend_ops.set_color/get_color entries (issue #173), one pair per
- * planar_*_backend_ops variant (vdi_backend_planar.c); see the comment on
+ * vdi_backend_ops.set_color/get_color entries (issue #173), one pair
+ * patched into planar_backend_ops's slots for the selected shifter family
+ * (vdi_backend_planar.c/vdi_backend.c); see the comment on
  * SCREEN_MODE_DESC.shifter (screen_mode.h) */
 void planar_set_st_color(Vwk *vwk, WORD pen, WORD *rgb);
 void planar_get_st_color(const Vwk *vwk, WORD pen, WORD *rgb);


### PR DESCRIPTION
Fixes #173

## Summary

Models each planar hardware palette family (ST/STE/TT/Videl) as its own
`vdi_backend_ops` variant, per the design in #173, instead of re-checking
`has_videl`/`has_tt_shifter`/`has_ste_shifter` on every `vs_color()`/
`vq_color()` call.

- `SCREEN_MODE_DESC` gains a `shifter` axis (`SCREEN_SHIFTER_*`),
  resolved once by `planar_mode_desc()` (`bios/screen.c`) alongside
  `layout`/`color_model`/`pixel_format`, and validated in
  `screen_mode_desc_valid()`.
- `vdi_backend_select()` picks the right palette I/O for the active
  hardware family using that axis.
- `vdi_col.c` gets one `set_color`/`get_color` implementation per family
  (`planar_set_st_color`, `..._ste_color`, `..._tt_color`,
  `..._videl_color`).
- Secondary scope item from the issue: `adjust_tt_colnum()`'s per-call
  `has_tt_shifter` check is similarly resolved once, into
  `hw_adjust_colnum`.

No functional change — same palette I/O per family, just resolved once
per workstation open instead of on every call.

## Follow-up fix 1: keep the new dispatch state out of the ROM `.data` segment

Review caught that the first commit put new mutable dispatch state where
the m68k targets can't actually write it. `emutos.ld` places `.data` in
the same read-only ROM region as `.text`, and the top-level `Makefile`
already checks for this ("DATA segment is not empty"). A non-const
initialized global there accepts writes that silently do nothing on
real hardware.

- `hw_set_color`/`hw_get_color`/`hw_adjust_colnum` (`vdi_col.c`) had
  non-NULL static initializers; dropped them (zero-init into `.bss`
  instead) and made sure every path assigns them.
- The four `planar_*_backend_ops` tables were made `const` (superseded
  by follow-up fix 5 below), validated via a new read-only
  `vdi_backend_ops_validate()` instead of the mutating
  `vdi_backend_ops_init()`.

## Follow-up fix 2: drop the per-call NULL check this reintroduced

The `.data` fix above initially added a lazy self-init guard to
`planar_set_color()`/`planar_get_color()`. Review pointed out that's a
runtime check on every call — exactly what this issue exists to remove.
Dropped it: `init_colors()` already resolves `hw_set_color`/
`hw_get_color` before any palette I/O can reach them.

## Follow-up fix 3: exclude the non-dispatch resolver from dispatch/truecolor builds

`hw_set_color`/`hw_get_color`/`select_color_family()`/
`planar_set_color()`/`planar_get_color()` exist only to serve the
non-dispatch, non-truecolor build — a dispatch build always reaches
palette I/O through the backend ops table, and a truecolor-only build
never touches planar code at all. Now guarded behind
`!CONF_WITH_VDI_BACKEND_DISPATCH && !CONF_WITH_VDI_BACKEND_TRUECOLOR`.

`hw_adjust_colnum` stays universally available whenever
`CONF_WITH_TT_SHIFTER` is on: its call sites feed `REQ_COL`/`req_col2`
bookkeeping shared across backends, not planar hardware I/O, so it has
no dispatch-table equivalent to defer to.

## Follow-up fix 4: restore hardware-palette preload in dispatch builds

Copilot review caught that fix 3 went too far: `init_colors()`'s final
hardware-programming loop got excluded from dispatch builds too, but
pre-#173 it ran unconditionally there (calling the single planar-only
`set_color()` directly), so a dispatch build's planar screen always got
its palette preloaded regardless of which backend ended up active.
Planar has no other hardware-palette init path, so skipping it was a
real regression.

Fixed by resolving a `const` `set_hw_color` function pointer once per
`init_colors()` call: `hw_set_color` directly for the single-planar
build, the active backend's own `set_color` for a dispatch build
(`vwk` is unused by every `planar_set_*_color()`, so `NULL` is safe as
long as the active backend is planar), or skipped when truecolor is
active (it seeds its own per-workstation palette via
`vdi_truecolor_init_palette()`).

Also documented why `hw_adjust_colnum`'s call sites deliberately have
no lazy-init guard: every reachable path already runs through
`init_colors()` first, so a guard there would defend against a call
order the code doesn't allow.

## Follow-up fix 5: one ROM table instead of four

The four `planar_*_backend_ops` tables (one per hardware palette family,
identical but for `set_color`/`get_color`) cost up to 240 bytes of ROM
on the m68k targets, scaling with how many of STE/TT/Videl a config
enables. Per review: replaced with a single const `default_planar_backend_ops`
(the ST-shifter table) plus an uninitialized (`.bss`) mutable
`planar_backend_ops`. `vdi_backend_select()` now `memcpy()`s the ST
defaults in and patches `set_color`/`get_color` to the selected family's
pair if it isn't ST (needing no patch). Fixed ROM cost of one table (60
bytes) regardless of how many shifter families a build enables — a
one-time copy-and-patch per `vdi_backend_select()` call, not a per-call
cost.

## Verification

No m68k-atari-mintelf-/m68k-elf- toolchain is available in this
environment, so verification throughout has relied on: `rpi1_defconfig`
(single truecolor renderer) and `rpi2-sparse_defconfig` (dispatch)
full clean builds/links via `arm-none-eabi-gcc`; `atari512-dispatch_defconfig`
(all of STE/TT/Videl enabled) and `atari512_defconfig`/`cartridge_defconfig`
(single planar renderer) compiling/linking cleanly at `-O0` with a
substitute `m68k-linux-gnu-` toolchain (`-O2` hits a pre-existing
GCC-13 ICE unrelated to this change); and inspecting object/map files
directly to confirm `.data` stays empty and symbols land in the
expected section for each configuration. `make gitready` passes
throughout. CI (real m68k-atari toolchains, all 30 configs) is the
authoritative check — see the check run status on this PR.