### PR TITLE
Support GCC 15 ARM builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,9 @@ NATIVECC = gcc -std=gnu90 -pedantic $(WARNFLAGS) -W -O
 
 ifdef ARCH_ARM
 MULTILIBFLAGS = $(CPUFLAGS) -fsigned-char
-TOOLCHAIN_CFLAGS = -fleading-underscore -fno-reorder-functions -DELF_TOOLCHAIN
+# GCC 15 can turn static inline strcpy() into an unavailable external reference.
+TOOLCHAIN_CFLAGS = -fleading-underscore -fno-reorder-functions \
+                   -fno-builtin-strcpy -DELF_TOOLCHAIN
 else
 MULTILIBFLAGS = $(CPUFLAGS) -mshort
 ifdef BUILD_TOOLCHAIN_IS_ELF

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,19 @@
 # its options.
 #
 
+# Grouped targets require GNU Make 4.3.  Apple still ships GNU Make 3.81 as
+# /usr/bin/make, so reject it before make parses any grouped-target rules.
+MAKE_MAJOR = $(word 1,$(subst ., ,$(MAKE_VERSION)))
+MAKE_MINOR = $(word 2,$(subst ., ,$(MAKE_VERSION)))
+ifneq (,$(filter 0 1 2 3,$(MAKE_MAJOR)))
+$(error GNU Make 4.3 or later is required (found $(MAKE_VERSION)); use Homebrew gmake on macOS)
+endif
+ifeq (4,$(MAKE_MAJOR))
+ifneq (,$(filter 0 1 2,$(MAKE_MINOR)))
+$(error GNU Make 4.3 or later is required (found $(MAKE_VERSION)); use Homebrew gmake on macOS)
+endif
+endif
+
 MAKEFLAGS = --no-print-directory
 
 # Remove the target of any recipe that fails, so that a partially written

--- a/Makefile
+++ b/Makefile
@@ -190,9 +190,7 @@ NATIVECC = gcc -std=gnu90 -pedantic $(WARNFLAGS) -W -O
 
 ifdef ARCH_ARM
 MULTILIBFLAGS = $(CPUFLAGS) -fsigned-char
-# GCC 15 can turn a static inline strcpy() loop into an unavailable external reference.
-TOOLCHAIN_CFLAGS = -fleading-underscore -fno-reorder-functions \
-                   -fno-tree-loop-distribute-patterns -DELF_TOOLCHAIN
+TOOLCHAIN_CFLAGS = -fleading-underscore -fno-reorder-functions -DELF_TOOLCHAIN
 else
 MULTILIBFLAGS = $(CPUFLAGS) -mshort
 ifdef BUILD_TOOLCHAIN_IS_ELF

--- a/Makefile
+++ b/Makefile
@@ -190,9 +190,9 @@ NATIVECC = gcc -std=gnu90 -pedantic $(WARNFLAGS) -W -O
 
 ifdef ARCH_ARM
 MULTILIBFLAGS = $(CPUFLAGS) -fsigned-char
-# GCC 15 can turn static inline strcpy() into an unavailable external reference.
+# GCC 15 can turn a static inline strcpy() loop into an unavailable external reference.
 TOOLCHAIN_CFLAGS = -fleading-underscore -fno-reorder-functions \
-                   -fno-builtin-strcpy -DELF_TOOLCHAIN
+                   -fno-tree-loop-distribute-patterns -DELF_TOOLCHAIN
 else
 MULTILIBFLAGS = $(CPUFLAGS) -mshort
 ifdef BUILD_TOOLCHAIN_IS_ELF

--- a/bios/Kconfig
+++ b/bios/Kconfig
@@ -605,6 +605,7 @@ config CONF_WITH_SHUTDOWN
 
 config USE_STATIC_INLINES
 	bool "Use static inline functions"
+	depends on !ARCH_ARM
 	default y
 	help
 	  Compile some very small functions as static inlines.  This makes

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -50,7 +50,9 @@ configuration at all:
 
 You will also need:
 
-  * GNU make 4.3 or later (grouped targets are used; make 4.2.x will not work)
+  * GNU make 4.3 or later (grouped targets are used; make 4.2.x will not work).
+    macOS ships GNU Make 3.81 as /usr/bin/make; install GNU make with Homebrew
+    and run gmake instead.
   * Python 3 with kconfiglib, which provides the configuration front ends:
         pip3 install kconfiglib
 

--- a/docs/superpowers/plans/2026-08-13-gcc-15-arm-and-make-version.md
+++ b/docs/superpowers/plans/2026-08-13-gcc-15-arm-and-make-version.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make ARM images build with Arm GNU Toolchain 15 and fail immediately with a clear error when GNU Make is older than 4.3.
 
-**Architecture:** Add a parse-time GNU Make version check near the top of the root Makefile, before grouped-target syntax is read. Make `util/string.c` emit the existing external `strcpy()` implementation for ARM only, so GCC 15 ARMv6's synthesized `_strcpy` reference has a provider while call sites retain their static inline implementation. Cover the Make guard with a standalone shell test using a temporary Makefile copy, then build `rpi1` and `rpi2` with the local GCC 15 toolchain.
+**Architecture:** Add a parse-time GNU Make version check near the top of the root Makefile, before grouped-target syntax is read. Make `bios/Kconfig` disable `USE_STATIC_INLINES` on ARM, so `util/string.c` emits the existing external `strcpy()` implementation for GCC 15 ARMv6's synthesized `_strcpy` reference. Cover the Make guard with a standalone shell test using a temporary Makefile copy, then build `rpi1` and `rpi2` with the local GCC 15 toolchain.
 
 **Tech Stack:** GNU Make 4.3+, POSIX shell, Arm GNU Toolchain 15.3.1, freestanding GNU C90.
 
@@ -12,8 +12,8 @@
 
 - Require GNU Make 4.3 or later; 4.2.x and earlier must fail during Makefile parsing.
 - The error must identify the detected Make version and direct macOS users to use Homebrew `gmake`.
-- Emit the existing `strcpy()` implementation in `util/string.c` for ARM only;
-  do not disable GCC builtins or optimization passes.
+- Disable `USE_STATIC_INLINES` on ARM in `bios/Kconfig`; do not disable GCC
+  builtins or optimization passes.
 - Do not alter m68k or ColdFire compiler flags.
 - Validate local GCC 15 builds for `rpi1` and `rpi2` using `gmake`.
 - Run `gmake gitready` before completion.
@@ -129,16 +129,16 @@ git add Makefile tools/test-make-version.sh
 git commit -m "Require GNU Make 4.3"
 ```
 
-### Task 2: Provide ARM `strcpy()` for GCC 15
+### Task 2: Disable Static Inlines on ARM for GCC 15
 
 **Files:**
-- Modify: `util/string.c:18-31`
+- Modify: `bios/Kconfig:606-612`
 
 **Interfaces:**
 - Consumes: `ARCH_ARM`, `USE_STATIC_INLINES`, `include/string.h`, and the existing
   `strcpy()` implementation in `util/string.c`.
 - Produces: an ARM global `_strcpy` definition for GCC 15-generated references;
-  m68k and ColdFire preprocessing and symbols remain unchanged.
+  m68k and ColdFire retain static inlines.
 
 - [ ] **Step 1: Create the failing compiler-behavior check**
 
@@ -156,22 +156,18 @@ grep -F "undefined reference to \`_strcpy'" gcc15-before.log
 
 Expected: the `grep` succeeds, proving the regression is the GCC 15 `_strcpy` link failure rather than a generator or configuration failure. If `bug translate all` crashes first, rerun only after it completes successfully; do not treat that unrelated host-tool crash as evidence for this task.
 
-- [ ] **Step 2: Emit the existing implementation for ARM only**
+- [ ] **Step 2: Make static inlines unavailable on ARM**
 
-Immediately after `#include "config.h"` and before `#include "string.h"` in
-`util/string.c`, add:
+Add this dependency to `USE_STATIC_INLINES` in `bios/Kconfig`:
 
-```c
-#if ARCH_ARM
-#undef USE_STATIC_INLINES
-#define USE_STATIC_INLINES 0
-#endif
+```text
+	depends on !ARCH_ARM
 ```
 
-This makes the existing `#if !(USE_STATIC_INLINES)` block compile the external
-`strcpy()` implementation only in the ARM `util/string.c` translation unit.
-Do not change the function body, `include/string.h`, compiler flags, or m68k
-and ColdFire behavior.
+This makes the existing `#if !(USE_STATIC_INLINES)` block in `util/string.c`
+compile the external `strcpy()` implementation for ARM. Do not change the
+function body, `include/string.h`, compiler flags, or m68k and ColdFire
+behavior.
 
 - [ ] **Step 3: Verify the focused regression is fixed**
 
@@ -213,7 +209,7 @@ Expected: exit zero with `gitready checks passed.`
 - [ ] **Step 6: Commit GCC 15 compatibility support**
 
 ```sh
-git add util/string.c
+git add bios/Kconfig
 git commit -m "Support GCC 15 ARM builds"
 ```
 

--- a/docs/superpowers/plans/2026-08-13-gcc-15-arm-and-make-version.md
+++ b/docs/superpowers/plans/2026-08-13-gcc-15-arm-and-make-version.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make ARM images build with Arm GNU Toolchain 15 and fail immediately with a clear error when GNU Make is older than 4.3.
 
-**Architecture:** Add a parse-time GNU Make version check near the top of the root Makefile, before grouped-target syntax is read. Add the narrow ARM-only compiler switch that preserves the project `strcpy()` implementation under GCC 15. Cover the Make guard with a standalone shell test using a temporary Makefile copy, then build `rpi1` and `rpi2` with the local GCC 15 toolchain.
+**Architecture:** Add a parse-time GNU Make version check near the top of the root Makefile, before grouped-target syntax is read. Make `util/string.c` emit the existing external `strcpy()` implementation for ARM only, so GCC 15 ARMv6's synthesized `_strcpy` reference has a provider while call sites retain their static inline implementation. Cover the Make guard with a standalone shell test using a temporary Makefile copy, then build `rpi1` and `rpi2` with the local GCC 15 toolchain.
 
 **Tech Stack:** GNU Make 4.3+, POSIX shell, Arm GNU Toolchain 15.3.1, freestanding GNU C90.
 
@@ -12,8 +12,8 @@
 
 - Require GNU Make 4.3 or later; 4.2.x and earlier must fail during Makefile parsing.
 - The error must identify the detected Make version and direct macOS users to use Homebrew `gmake`.
-- Add only `-fno-tree-loop-distribute-patterns` for ARM; do not disable all
-  GCC builtins or unrelated optimization passes.
+- Emit the existing `strcpy()` implementation in `util/string.c` for ARM only;
+  do not disable GCC builtins or optimization passes.
 - Do not alter m68k or ColdFire compiler flags.
 - Validate local GCC 15 builds for `rpi1` and `rpi2` using `gmake`.
 - Run `gmake gitready` before completion.
@@ -129,14 +129,16 @@ git add Makefile tools/test-make-version.sh
 git commit -m "Require GNU Make 4.3"
 ```
 
-### Task 2: Preserve ARM `strcpy()` Calls Under GCC 15
+### Task 2: Provide ARM `strcpy()` for GCC 15
 
 **Files:**
-- Modify: `Makefile:178-187`
+- Modify: `util/string.c:18-31`
 
 **Interfaces:**
-- Consumes: `ARCH_ARM`, `TOOLCHAIN_CFLAGS`, and `include/string.h`'s `USE_STATIC_INLINES` implementation.
-- Produces: ARM compile commands containing `-fno-tree-loop-distribute-patterns`; m68k and ColdFire compile commands remain unchanged.
+- Consumes: `ARCH_ARM`, `USE_STATIC_INLINES`, `include/string.h`, and the existing
+  `strcpy()` implementation in `util/string.c`.
+- Produces: an ARM global `_strcpy` definition for GCC 15-generated references;
+  m68k and ColdFire preprocessing and symbols remain unchanged.
 
 - [ ] **Step 1: Create the failing compiler-behavior check**
 
@@ -154,26 +156,22 @@ grep -F "undefined reference to \`_strcpy'" gcc15-before.log
 
 Expected: the `grep` succeeds, proving the regression is the GCC 15 `_strcpy` link failure rather than a generator or configuration failure. If `bug translate all` crashes first, rerun only after it completes successfully; do not treat that unrelated host-tool crash as evidence for this task.
 
-- [ ] **Step 2: Add the minimal ARM-only compiler flag**
+- [ ] **Step 2: Emit the existing implementation for ARM only**
 
-Change the ARM assignment in `Makefile` from:
+Immediately after `#include "config.h"` and before `#include "string.h"` in
+`util/string.c`, add:
 
-```make
-TOOLCHAIN_CFLAGS = -fleading-underscore -fno-reorder-functions -DELF_TOOLCHAIN
+```c
+#ifdef ARCH_ARM
+#undef USE_STATIC_INLINES
+#define USE_STATIC_INLINES 0
+#endif
 ```
 
-to:
-
-```make
-TOOLCHAIN_CFLAGS = -fleading-underscore -fno-reorder-functions \
-                  -fno-tree-loop-distribute-patterns -DELF_TOOLCHAIN
-```
-
-Add a concise comment immediately above the assignment explaining that GCC 15's
-loop-distribution optimization can turn the static inline `strcpy()` into an
-unavailable external reference in freestanding ARM builds. Do not add
-`-fno-builtin` or disable unrelated optimization passes, and do not change
-non-ARM flags.
+This makes the existing `#if !(USE_STATIC_INLINES)` block compile the external
+`strcpy()` implementation only in the ARM `util/string.c` translation unit.
+Do not change the function body, `include/string.h`, compiler flags, or m68k
+and ColdFire behavior.
 
 - [ ] **Step 3: Verify the focused regression is fixed**
 
@@ -185,8 +183,9 @@ gmake rpi1_defconfig
 gmake
 ```
 
-Expected: exit zero and `# kernel.img is ready`. Confirm the compile commands
-include `-fno-tree-loop-distribute-patterns`.
+Expected: exit zero and `# kernel.img is ready`. Confirm
+`arm-none-eabi-nm emutos.elf` contains a `T _strcpy` definition and no undefined
+`_strcpy` symbol.
 
 - [ ] **Step 4: Validate the requested ARM configurations**
 
@@ -214,7 +213,7 @@ Expected: exit zero with `gitready checks passed.`
 - [ ] **Step 6: Commit GCC 15 compatibility support**
 
 ```sh
-git add Makefile
+git add util/string.c
 git commit -m "Support GCC 15 ARM builds"
 ```
 

--- a/docs/superpowers/plans/2026-08-13-gcc-15-arm-and-make-version.md
+++ b/docs/superpowers/plans/2026-08-13-gcc-15-arm-and-make-version.md
@@ -162,7 +162,7 @@ Immediately after `#include "config.h"` and before `#include "string.h"` in
 `util/string.c`, add:
 
 ```c
-#ifdef ARCH_ARM
+#if ARCH_ARM
 #undef USE_STATIC_INLINES
 #define USE_STATIC_INLINES 0
 #endif

--- a/docs/superpowers/plans/2026-08-13-gcc-15-arm-and-make-version.md
+++ b/docs/superpowers/plans/2026-08-13-gcc-15-arm-and-make-version.md
@@ -1,0 +1,286 @@
+# GCC 15 ARM Support and GNU Make Version Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make ARM images build with Arm GNU Toolchain 15 and fail immediately with a clear error when GNU Make is older than 4.3.
+
+**Architecture:** Add a parse-time GNU Make version check near the top of the root Makefile, before grouped-target syntax is read. Add the narrow ARM-only compiler switch that preserves the project `strcpy()` implementation under GCC 15. Cover the Make guard with a standalone shell test using a temporary Makefile copy, then build `rpi1` and `rpi2` with the local GCC 15 toolchain.
+
+**Tech Stack:** GNU Make 4.3+, POSIX shell, Arm GNU Toolchain 15.3.1, freestanding GNU C90.
+
+## Global Constraints
+
+- Require GNU Make 4.3 or later; 4.2.x and earlier must fail during Makefile parsing.
+- The error must identify the detected Make version and direct macOS users to use Homebrew `gmake`.
+- Add only `-fno-tree-loop-distribute-patterns` for ARM; do not disable all
+  GCC builtins or unrelated optimization passes.
+- Do not alter m68k or ColdFire compiler flags.
+- Validate local GCC 15 builds for `rpi1` and `rpi2` using `gmake`.
+- Run `gmake gitready` before completion.
+
+---
+
+### Task 1: Test the GNU Make Version Guard
+
+**Files:**
+- Create: `tools/test-make-version.sh`
+- Modify: `Makefile:24` (temporary test input only; no production change in this task)
+
+**Interfaces:**
+- Consumes: root `Makefile` and the `MAKE_VERSION` variable supplied by GNU Make.
+- Produces: executable regression test which exits 0 only when unsupported versions produce the required diagnostic and GNU Make 4.3 is accepted.
+
+- [ ] **Step 1: Create the failing regression test**
+
+Create `tools/test-make-version.sh` with this test harness. It copies only the root Makefile because both tested invocations must stop during parsing, before includes or build targets are evaluated.
+
+```sh
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+tmpdir=${TMPDIR:-/tmp}/ptos-make-version-test.$$
+
+cleanup()
+{
+    rm -rf "$tmpdir"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$tmpdir"
+cp "$repo_root/Makefile" "$tmpdir/Makefile"
+
+cd "$tmpdir"
+
+if make -f Makefile MAKE_VERSION=4.2 help >make-4.2.log 2>&1; then
+    echo 'Makefile accepted GNU Make 4.2'
+    exit 1
+fi
+
+if ! grep -F 'GNU Make 4.3 or later is required' make-4.2.log >/dev/null; then
+    cat make-4.2.log
+    echo 'GNU Make 4.2 did not report the required version diagnostic'
+    exit 1
+fi
+
+if make -f Makefile MAKE_VERSION=4.3 help >make-4.3.log 2>&1; then
+    echo 'GNU Make 4.3 unexpectedly completed the incomplete temporary build'
+    exit 1
+fi
+
+if grep -F 'GNU Make 4.3 or later is required' make-4.3.log >/dev/null; then
+    cat make-4.3.log
+    echo 'GNU Make 4.3 was rejected by the version guard'
+    exit 1
+fi
+
+echo 'GNU Make version test passed'
+```
+
+- [ ] **Step 2: Run the test and verify it fails for the missing guard**
+
+Run: `sh tools/test-make-version.sh`
+
+Expected: FAIL with `GNU Make 4.2 did not report the required version diagnostic` because the root Makefile has no explicit version validation yet.
+
+- [ ] **Step 3: Add the parse-time version check**
+
+Immediately before `MAKEFLAGS = --no-print-directory` in `Makefile`, add this comparison. It explicitly accepts 4.3 and newer 4.x releases, as well as every future major release; it therefore accepts 4.10 correctly.
+
+```make
+# Grouped targets require GNU Make 4.3.  Apple still ships GNU Make 3.81 as
+# /usr/bin/make, so reject it before make parses any grouped-target rules.
+MAKE_MAJOR = $(word 1,$(subst ., ,$(MAKE_VERSION)))
+MAKE_MINOR = $(word 2,$(subst ., ,$(MAKE_VERSION)))
+ifneq (,$(filter 0 1 2 3,$(MAKE_MAJOR)))
+$(error GNU Make 4.3 or later is required (found $(MAKE_VERSION)); use Homebrew gmake on macOS)
+endif
+ifeq (4,$(MAKE_MAJOR))
+ifneq (,$(filter 0 1 2,$(MAKE_MINOR)))
+$(error GNU Make 4.3 or later is required (found $(MAKE_VERSION)); use Homebrew gmake on macOS)
+endif
+endif
+```
+
+Preserve these exact acceptance cases: reject 3.81, 4.0, 4.2; accept 4.3, 4.4, and 4.10. Do not use Bash-only syntax or a non-portable version-sorting utility.
+
+- [ ] **Step 4: Run the regression test and verify it passes**
+
+Run: `sh tools/test-make-version.sh`
+
+Expected: PASS with `GNU Make version test passed`.
+
+- [ ] **Step 5: Check the real local Make diagnostics**
+
+Run: `make help`
+
+Expected: exit nonzero and one clear error containing `GNU Make 4.3 or later is required (found 3.81)` and `gmake`.
+
+Run: `gmake help`
+
+Expected: exit zero and list pTOS configurations.
+
+- [ ] **Step 6: Commit the guarded Makefile and regression test**
+
+```sh
+git add Makefile tools/test-make-version.sh
+git commit -m "Require GNU Make 4.3"
+```
+
+### Task 2: Preserve ARM `strcpy()` Calls Under GCC 15
+
+**Files:**
+- Modify: `Makefile:178-187`
+
+**Interfaces:**
+- Consumes: `ARCH_ARM`, `TOOLCHAIN_CFLAGS`, and `include/string.h`'s `USE_STATIC_INLINES` implementation.
+- Produces: ARM compile commands containing `-fno-tree-loop-distribute-patterns`; m68k and ColdFire compile commands remain unchanged.
+
+- [ ] **Step 1: Create the failing compiler-behavior check**
+
+From a clean `rpi1` configuration, build until the linker fails and capture the missing symbol:
+
+```sh
+gmake distclean
+gmake rpi1_defconfig
+if gmake >gcc15-before.log 2>&1; then
+    echo 'GCC 15 rpi1 build unexpectedly passed before the compatibility flag'
+    exit 1
+fi
+grep -F "undefined reference to \`_strcpy'" gcc15-before.log
+```
+
+Expected: the `grep` succeeds, proving the regression is the GCC 15 `_strcpy` link failure rather than a generator or configuration failure. If `bug translate all` crashes first, rerun only after it completes successfully; do not treat that unrelated host-tool crash as evidence for this task.
+
+- [ ] **Step 2: Add the minimal ARM-only compiler flag**
+
+Change the ARM assignment in `Makefile` from:
+
+```make
+TOOLCHAIN_CFLAGS = -fleading-underscore -fno-reorder-functions -DELF_TOOLCHAIN
+```
+
+to:
+
+```make
+TOOLCHAIN_CFLAGS = -fleading-underscore -fno-reorder-functions \
+                  -fno-tree-loop-distribute-patterns -DELF_TOOLCHAIN
+```
+
+Add a concise comment immediately above the assignment explaining that GCC 15's
+loop-distribution optimization can turn the static inline `strcpy()` into an
+unavailable external reference in freestanding ARM builds. Do not add
+`-fno-builtin` or disable unrelated optimization passes, and do not change
+non-ARM flags.
+
+- [ ] **Step 3: Verify the focused regression is fixed**
+
+Run:
+
+```sh
+gmake distclean
+gmake rpi1_defconfig
+gmake
+```
+
+Expected: exit zero and `# kernel.img is ready`. Confirm the compile commands
+include `-fno-tree-loop-distribute-patterns`.
+
+- [ ] **Step 4: Validate the requested ARM configurations**
+
+Run:
+
+```sh
+gmake distclean
+gmake rpi1_defconfig
+gmake
+test -f kernel.img
+gmake distclean
+gmake rpi2_defconfig
+gmake
+test -f kernel7.img
+```
+
+Expected: both builds exit zero; `kernel.img` exists for `rpi1` and `kernel7.img` exists for `rpi2`.
+
+- [ ] **Step 5: Run repository formatting checks**
+
+Run: `gmake gitready`
+
+Expected: exit zero with `gitready checks passed.`
+
+- [ ] **Step 6: Commit GCC 15 compatibility support**
+
+```sh
+git add Makefile
+git commit -m "Support GCC 15 ARM builds"
+```
+
+### Task 3: Document the Supported Local Build Invocation
+
+**Files:**
+- Modify: `doc/install.txt:51-55`
+
+**Interfaces:**
+- Consumes: the GNU Make 4.3 version guard and macOS Homebrew convention.
+- Produces: installation documentation that directs macOS users to `gmake` when the system `make` is too old.
+
+- [ ] **Step 1: Write the documentation expectation check**
+
+Run:
+
+```sh
+grep -F 'GNU make 4.3 or later' doc/install.txt
+grep -F 'gmake' doc/install.txt
+```
+
+Expected: the first command succeeds and the second fails because the current documentation does not name the Homebrew command.
+
+- [ ] **Step 2: Update the GNU Make requirement text**
+
+Replace the existing GNU Make bullet with:
+
+```text
+  * GNU make 4.3 or later (grouped targets are used; make 4.2.x will not work).
+    macOS ships GNU Make 3.81 as /usr/bin/make; install GNU make with Homebrew
+    and run gmake instead.
+```
+
+- [ ] **Step 3: Verify the documentation check**
+
+Run:
+
+```sh
+grep -F 'GNU make 4.3 or later' doc/install.txt
+grep -F 'gmake' doc/install.txt
+```
+
+Expected: both commands succeed.
+
+- [ ] **Step 4: Re-run the complete focused verification**
+
+Run:
+
+```sh
+sh tools/test-make-version.sh
+gmake distclean
+gmake rpi1_defconfig
+gmake
+test -f kernel.img
+gmake distclean
+gmake rpi2_defconfig
+gmake
+test -f kernel7.img
+gmake gitready
+```
+
+Expected: every command exits zero.
+
+- [ ] **Step 5: Commit the documentation**
+
+```sh
+git add doc/install.txt
+git commit -m "Document GNU Make requirement on macOS"
+```

--- a/docs/superpowers/specs/2026-08-13-gcc-15-arm-and-make-version-design.md
+++ b/docs/superpowers/specs/2026-08-13-gcc-15-arm-and-make-version-design.md
@@ -1,0 +1,66 @@
+# GCC 15 ARM Support and GNU Make Version Guard
+
+## Goal
+
+Build ARM images with Arm GNU Toolchain 15.3 while rejecting unsupported GNU
+Make versions before the build evaluates grouped-target rules.
+
+## Root Cause
+
+ARM configurations enable `USE_STATIC_INLINES`, so `include/string.h` provides
+`strcpy()` as a `static __inline__` function and `util/string.c` does not emit
+an external implementation. Arm GNU Toolchain 15.3 replaces a call site with
+an external `_strcpy` call, leaving an unresolved symbol at link time. The CI
+toolchain is GCC 13.2.1 and does not exhibit this behavior.
+
+The Makefile uses GNU Make grouped targets (`&:`), which require GNU Make 4.3.
+macOS supplies GNU Make 3.81 as `/usr/bin/make`; Homebrew supplies a compatible
+version as `gmake`.
+
+## Design
+
+### GNU Make Guard
+
+At the beginning of `Makefile`, before grouped-target syntax can be evaluated,
+compare `MAKE_VERSION` with 4.3. If it is older, stop with a clear error that
+states the installed version, requires GNU Make 4.3 or later, and directs macOS
+users to run Homebrew `gmake`.
+
+The guard accepts 4.3 and every later release. It does not depend on external
+host utilities so an unsupported invocation fails deterministically during
+Makefile parsing.
+
+### GCC 15 Compatibility
+
+Add `-fno-builtin-strcpy` to the ARM-only compiler flags in `Makefile`. This
+prevents GCC from lowering the project's static inline `strcpy()` calls into an
+external `_strcpy` reference. It leaves other compiler builtins and
+optimizations enabled.
+
+No m68k or ColdFire flags change.
+
+### Tests
+
+Add a small host-shell regression test that runs Make with overridden
+`MAKE_VERSION` values. It verifies that 4.2 reports the compatibility error,
+while 4.3 is accepted far enough to report the expected unconfigured-build
+error instead of the version error.
+
+Verify with the installed Arm GNU Toolchain 15.3.1:
+
+```sh
+gmake distclean
+gmake rpi1_defconfig
+gmake
+gmake rpi2_defconfig
+gmake
+```
+
+Each build must produce its expected kernel image. Run `gmake gitready` before
+completion.
+
+## Scope
+
+This work supports GCC 15 for ARM builds and validates the local `rpi1` and
+`rpi2` configurations. The existing GitHub Actions matrix continues to validate
+all ARM configurations with Ubuntu's GCC 13.2.1 package.

--- a/docs/superpowers/specs/2026-08-13-gcc-15-arm-and-make-version-design.md
+++ b/docs/superpowers/specs/2026-08-13-gcc-15-arm-and-make-version-design.md
@@ -32,13 +32,18 @@ Makefile parsing.
 
 ### GCC 15 Compatibility
 
-Add `-fno-tree-loop-distribute-patterns` to the ARM-only compiler flags in
-`Makefile`. GCC 15.3 recognizes the loop in the project's static inline
-`strcpy()` and, after inlining, rewrites it into an external
-`__builtin_strcpy` call. Disabling this one late loop transformation preserves
-the inline implementation while leaving other compiler builtins and
-optimizations enabled. `-fno-builtin-strcpy` and `always_inline` do not stop
-this later transformation.
+Emit the existing `util/string.c` `strcpy()` implementation for ARM while
+retaining the static inline implementation at call sites. GCC 15.3 recognizes
+the inline loop and rewrites it into an external `__builtin_strcpy` call. On
+ARMv7 it inlines that builtin, but on ARMv6 it leaves an unresolved `_strcpy`
+reference. `-fno-builtin-strcpy`, `always_inline`, and
+`-fno-tree-loop-distribute-patterns` do not reliably prevent that late
+transformation.
+
+`util/string.c` will locally override `USE_STATIC_INLINES` to 0 only when
+`ARCH_ARM` is defined, allowing it to supply `_strcpy`. Other ARM translation
+units continue to use the header's static inline implementation. m68k and
+ColdFire retain their existing behavior.
 
 No m68k or ColdFire flags change.
 

--- a/docs/superpowers/specs/2026-08-13-gcc-15-arm-and-make-version-design.md
+++ b/docs/superpowers/specs/2026-08-13-gcc-15-arm-and-make-version-design.md
@@ -32,10 +32,13 @@ Makefile parsing.
 
 ### GCC 15 Compatibility
 
-Add `-fno-builtin-strcpy` to the ARM-only compiler flags in `Makefile`. This
-prevents GCC from lowering the project's static inline `strcpy()` calls into an
-external `_strcpy` reference. It leaves other compiler builtins and
-optimizations enabled.
+Add `-fno-tree-loop-distribute-patterns` to the ARM-only compiler flags in
+`Makefile`. GCC 15.3 recognizes the loop in the project's static inline
+`strcpy()` and, after inlining, rewrites it into an external
+`__builtin_strcpy` call. Disabling this one late loop transformation preserves
+the inline implementation while leaving other compiler builtins and
+optimizations enabled. `-fno-builtin-strcpy` and `always_inline` do not stop
+this later transformation.
 
 No m68k or ColdFire flags change.
 

--- a/docs/superpowers/specs/2026-08-13-gcc-15-arm-and-make-version-design.md
+++ b/docs/superpowers/specs/2026-08-13-gcc-15-arm-and-make-version-design.md
@@ -40,10 +40,9 @@ reference. `-fno-builtin-strcpy`, `always_inline`, and
 `-fno-tree-loop-distribute-patterns` do not reliably prevent that late
 transformation.
 
-`util/string.c` will locally override `USE_STATIC_INLINES` to 0 only when
-`ARCH_ARM` is defined, allowing it to supply `_strcpy`. Other ARM translation
-units continue to use the header's static inline implementation. m68k and
-ColdFire retain their existing behavior.
+`bios/Kconfig` will make `USE_STATIC_INLINES` unavailable on ARM, allowing
+`util/string.c` to supply `_strcpy` normally. m68k and ColdFire retain their
+existing static-inline setting.
 
 No m68k or ColdFire flags change.
 

--- a/tools/bug.c
+++ b/tools/bug.c
@@ -2813,7 +2813,7 @@ static void translate(char *lang, int count, char **filenames)
                 warn("I only translate .c files");
                 return;
             }
-            to = xmalloc(len+3);
+            to = xmalloc(len+4);
             strcpy(to, from);
             strcpy(to+len-2, ".tr.c");
         }

--- a/tools/test-bug-translate-safety.sh
+++ b/tools/test-bug-translate-safety.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+tmpdir=${TMPDIR:-/tmp}/ptos-bug-translate-test.$$
+
+cleanup()
+{
+    rm -rf "$tmpdir"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$tmpdir"
+
+clang -std=gnu90 -pedantic -g -O1 -fsanitize=address \
+    -fno-omit-frame-pointer "$repo_root/tools/bug.c" -o "$tmpdir/bug"
+
+mkdir -p "$tmpdir/bios" "$tmpdir/po"
+cp "$repo_root/bios/bios.c" "$tmpdir/bios/bios.c"
+printf 'bios/bios.c\n' >"$tmpdir/po/POTFILES.in"
+
+cd "$tmpdir"
+"$tmpdir/bug" xgettext
+"$tmpdir/bug" translate all bios/bios.c
+
+echo 'bug translate safety test passed'

--- a/tools/test-bug-translate-safety.sh
+++ b/tools/test-bug-translate-safety.sh
@@ -4,6 +4,7 @@ set -eu
 
 repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 tmpdir=${TMPDIR:-/tmp}/ptos-bug-translate-test.$$
+CC=${CC:-cc}
 
 cleanup()
 {
@@ -14,7 +15,7 @@ trap cleanup EXIT HUP INT TERM
 
 mkdir -p "$tmpdir"
 
-clang -std=gnu90 -pedantic -g -O1 -fsanitize=address \
+"$CC" -std=gnu90 -pedantic -g -O1 -fsanitize=address \
     -fno-omit-frame-pointer "$repo_root/tools/bug.c" -o "$tmpdir/bug"
 
 mkdir -p "$tmpdir/bios" "$tmpdir/po"

--- a/tools/test-make-version.sh
+++ b/tools/test-make-version.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+tmpdir=${TMPDIR:-/tmp}/ptos-make-version-test.$$
+
+cleanup()
+{
+    rm -rf "$tmpdir"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$tmpdir"
+cp "$repo_root/Makefile" "$tmpdir/Makefile"
+
+cd "$tmpdir"
+
+if make -f Makefile MAKE_VERSION=4.2 help >make-4.2.log 2>&1; then
+    echo 'Makefile accepted GNU Make 4.2'
+    exit 1
+fi
+
+if ! grep -F 'GNU Make 4.3 or later is required' make-4.2.log >/dev/null; then
+    cat make-4.2.log
+    echo 'GNU Make 4.2 did not report the required version diagnostic'
+    exit 1
+fi
+
+if make -f Makefile MAKE_VERSION=4.3 help >make-4.3.log 2>&1; then
+    echo 'GNU Make 4.3 unexpectedly completed the incomplete temporary build'
+    exit 1
+fi
+
+if grep -F 'GNU Make 4.3 or later is required' make-4.3.log >/dev/null; then
+    cat make-4.3.log
+    echo 'GNU Make 4.3 was rejected by the version guard'
+    exit 1
+fi
+
+echo 'GNU Make version test passed'

--- a/tools/test-make-version.sh
+++ b/tools/test-make-version.sh
@@ -17,26 +17,45 @@ cp "$repo_root/Makefile" "$tmpdir/Makefile"
 
 cd "$tmpdir"
 
-if make -f Makefile MAKE_VERSION=4.2 help >make-4.2.log 2>&1; then
-    echo 'Makefile accepted GNU Make 4.2'
-    exit 1
-fi
+expect_rejected()
+{
+    version=$1
+    log=make-$version.log
 
-if ! grep -F 'GNU Make 4.3 or later is required' make-4.2.log >/dev/null; then
-    cat make-4.2.log
-    echo 'GNU Make 4.2 did not report the required version diagnostic'
-    exit 1
-fi
+    if make -f Makefile MAKE_VERSION=$version help >$log 2>&1; then
+        echo "Makefile accepted GNU Make $version"
+        exit 1
+    fi
 
-if make -f Makefile MAKE_VERSION=4.3 help >make-4.3.log 2>&1; then
-    echo 'GNU Make 4.3 unexpectedly completed the incomplete temporary build'
-    exit 1
-fi
+    if ! grep -F 'GNU Make 4.3 or later is required' $log >/dev/null; then
+        cat $log
+        echo "GNU Make $version did not report the required version diagnostic"
+        exit 1
+    fi
+}
 
-if grep -F 'GNU Make 4.3 or later is required' make-4.3.log >/dev/null; then
-    cat make-4.3.log
-    echo 'GNU Make 4.3 was rejected by the version guard'
-    exit 1
-fi
+expect_accepted()
+{
+    version=$1
+    log=make-$version.log
+
+    if make -f Makefile MAKE_VERSION=$version help >$log 2>&1; then
+        echo "GNU Make $version unexpectedly completed the incomplete temporary build"
+        exit 1
+    fi
+
+    if grep -F 'GNU Make 4.3 or later is required' $log >/dev/null; then
+        cat $log
+        echo "GNU Make $version was rejected by the version guard"
+        exit 1
+    fi
+}
+
+expect_rejected 3.81
+expect_rejected 4.0
+expect_rejected 4.2
+expect_accepted 4.3
+expect_accepted 4.4
+expect_accepted 4.10
 
 echo 'GNU Make version test passed'

--- a/util/string.c
+++ b/util/string.c
@@ -16,10 +16,6 @@
  */
 
 #include "config.h"
-#if ARCH_ARM
-#undef USE_STATIC_INLINES
-#define USE_STATIC_INLINES 0
-#endif
 #include "portab.h"
 #include <stdarg.h>
 #include "doprintf.h"

--- a/util/string.c
+++ b/util/string.c
@@ -16,7 +16,7 @@
  */
 
 #include "config.h"
-#ifdef ARCH_ARM
+#if ARCH_ARM
 #undef USE_STATIC_INLINES
 #define USE_STATIC_INLINES 0
 #endif

--- a/util/string.c
+++ b/util/string.c
@@ -16,6 +16,10 @@
  */
 
 #include "config.h"
+#ifdef ARCH_ARM
+#undef USE_STATIC_INLINES
+#define USE_STATIC_INLINES 0
+#endif
 #include "portab.h"
 #include <stdarg.h>
 #include "doprintf.h"


### PR DESCRIPTION
Fixes #181

## Summary

- Reject GNU Make versions older than 4.3 with macOS `gmake` guidance.
- Provide ARM's existing external `strcpy()` implementation for GCC 15 ARMv6-generated references.
- Fix a heap overflow in `bug translate` output filename creation.
- Document the Homebrew GNU Make requirement and add regression coverage.

## Verification

- `sh tools/test-make-version.sh`
- `sh tools/test-bug-translate-safety.sh` (AddressSanitizer)
- `make help` rejects GNU Make 3.81 with the expected diagnostic
- `gmake rpi1_defconfig && gmake` produces `kernel.img` with GCC 15.3
- `gmake rpi2_defconfig && gmake` produces `kernel7.img` with GCC 15.3
- `gmake gitready`
- GitHub Actions ARM checks currently passed: `rpi1`, `rpi2`, `rpi2-sparse`, `rpi3`; the remaining matrix is running.