### PR TITLE
Fix Raspberry Pi EmuCon keyboard input

### DIFF
--- a/docs/superpowers/plans/2026-08-13-rpi-emucon-usb-keyboard.md
+++ b/docs/superpowers/plans/2026-08-13-rpi-emucon-usb-keyboard.md
@@ -1,0 +1,288 @@
+# Raspberry Pi EmuCon USB Keyboard Input Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make USB keyboard input continue to reach EmuCon launched from the GEM desktop on QEMU Raspberry Pi 1 and 2 images.
+
+**Architecture:** USB HID keyboard reports remain integrated through pTOS's BIOS input path.  The investigation first compares the current direct `kbd_int()` call from DWC2 IRQ context with upstream's deferred `send_data()` plus `fake_hwint()` injection: execution context, vector dispatch, and the values visible in the keyboard IOREC.  It must prove which difference matters before changing `kbd_int()`, process CPSR, or introducing a deferred/vector injection path.
+
+**Tech Stack:** GNU90 C, ARMv6/ARMv7 CPSR exception return, pTOS BIOS/BDOS, QEMU `raspi1ap` and `raspi2b`.
+
+## Global Constraints
+
+- Scope is QEMU Raspberry Pi 1 and Raspberry Pi 2 only; physical hardware is out of scope.
+- QEMU must attach USB keyboard, USB mouse, and an empty valid FAT16 SD-card image.
+- Build an AES-free Raspberry Pi kernel (`CONF_WITH_AES=n`) for the primary direct-to-EmuCon diagnostic; use the normal desktop image only for the final launch regression.
+- Desktop input and EmuCon input must both use the existing USB HID -> `kbd_int()` -> `ikbdiorec` path.
+- Do not poll USB from `bconin2()` and do not change EmuCon's console API.
+- Keep shared m68k behavior unchanged.
+- Remove temporary diagnostic tracing before the final change unless it is a concise, established-style trace.
+- Do not substitute upstream `send_data()`/`fake_hwint()` semantics until tracing proves that pTOS's direct `kbd_int()` path misses a consumer-visible side effect.
+
+---
+
+## File Structure
+
+- Modify only if proven: `usb/udd_keyboard.c`, `bios/ikbd.c`, and the ARM DWC2/timer integration point selected by tracing.
+- Temporarily modify: `usb/ucd_dwc2.c`, `usb/udd_keyboard.c`, and `bios/ikbd.c` — provides boundary traces for completion, direct injection, queue insertion, and queue consumption; remove before the final commit.
+- Create: `/var/folders/_3/s5x2rvs93b9d1b0hmmt664mh0000gn/T/opencode/empty-fat16-sd.img` — disposable 64 MiB FAT16 QEMU SD-card test medium; never add it to Git.
+- Create only if retained: `configs/rpi1-cli_defconfig` and `configs/rpi2-cli_defconfig` — generated with `CONF_WITH_AES=n`, retaining the Raspberry Pi kernel image target and default `CONF_WITH_CLI=y`.
+
+### Task 1: Prove the Runtime Boundary Where Input Stops
+
+**Files:**
+- Modify temporarily: `usb/ucd_dwc2.c:773-816`
+- Modify temporarily: `usb/udd_keyboard.c:183-265`
+- Modify temporarily: `bios/ikbd.c:140-180,629-...`
+
+**Interfaces:**
+- Consumes: `keyboard_report_complete(struct usb_async_int_msg *msg, LONG status, LONG actual_length)`, `kbd_int(UBYTE scancode)`, and `LONG bconin2(void)`.
+- Compares: upstream `send_data(kbd_entry, iokbd, scancode)` plus `fake_hwint()` with pTOS `kbd_int(scancode)`.
+- Produces: serial evidence identifying whether a key press reaches DWC2 completion, HID decoding, the pTOS queue insertion, and `bconin2()` after EmuCon is launched; it also records the exact 32-bit queue value at insertion and consumption.
+
+- [ ] **Step 1: Add bounded temporary traces at the three input boundaries**
+
+  In `usb/ucd_dwc2.c`, trace one callback delivery per completed keyboard report.
+
+  ```c
+  KDEBUG(("dwc2_async: keyboard callback generation=%lu\n", generation));
+  ```
+
+  In `usb/udd_keyboard.c`, immediately before each call to `kbd_int(scancode)` for a key press, add:
+
+  ```c
+  KDEBUG(("usb keyboard: press scancode 0x%02x\n", scancode));
+  ```
+
+  In `bios/ikbd.c`, use the existing `kbd_int()` entry trace and add a bounded trace at `push_ikbdiorec()` with the inserted value; add one trace in `bconin2()` after it dequeues `value`:
+
+  ```c
+  KDEBUG(("bconin2: dequeued 0x%08lx\n", value));
+  ```
+
+  Do not trace the empty polling loop in `bconin2()`; it would flood the serial console.  Also record whether a keyboard vector (`kbdvecs.ikbdsys`) is invoked by the direct path; upstream's `send_data()` deliberately targets the installed vector while pTOS's direct `kbd_int()` does not.
+
+- [ ] **Step 2: Build an AES-free Raspberry Pi 2 diagnostic image**
+
+  Start from `rpi2_defconfig`, set `CONF_WITH_AES=n` in `make menuconfig`,
+  preserve the configuration with `make savedefconfig`, and build it:
+
+  ```sh
+  make rpi2_defconfig
+  make menuconfig
+  make savedefconfig
+  make
+  ```
+
+  Expected: successful build producing `kernel7.img` that boots directly into
+  EmuCon, without AES or EmuDesk.
+
+- [ ] **Step 3: Create the required FAT16 test image outside the repository**
+
+  Run:
+
+  ```sh
+  qemu-img create -f raw /var/folders/_3/s5x2rvs93b9d1b0hmmt664mh0000gn/T/opencode/empty-fat16-sd.img 64M
+  hdiutil attach -imagekey diskimage-class=CRawDiskImage -nobrowse -noverify -nomount /var/folders/_3/s5x2rvs93b9d1b0hmmt664mh0000gn/T/opencode/empty-fat16-sd.img
+  /sbin/newfs_msdos -F 16 -S 512 -c 1 /dev/rdiskN
+  hdiutil detach /dev/diskN
+  ```
+
+  Replace `diskN` with the disk identifier printed by `hdiutil attach`.  Expected: `file .../empty-fat16-sd.img` reports `FAT (16 bit)`.
+
+- [ ] **Step 4: Reproduce the failure and capture the trace**
+
+  Run:
+
+  ```sh
+  qemu-system-arm -M raspi2b -bios kernel7.img -d guest_errors \
+    -device usb-mouse -device usb-kbd \
+    -drive file=/var/folders/_3/s5x2rvs93b9d1b0hmmt664mh0000gn/T/opencode/empty-fat16-sd.img,if=sd,format=raw \
+    -serial stdio
+  ```
+
+  At the booted EmuCon prompt, type `h`. This tests the USB-to-console path
+  without AES application launch or desktop input handling.
+  Expected before the fix: the trace proves one of these mutually exclusive outcomes:
+
+  ```text
+  A. no USB keyboard press trace: USB IRQ delivery stopped
+  B. USB and kbd_int traces, but no bconin2 dequeue: queue insertion/visibility stopped
+  C. USB, kbd_int, insertion, and bconin2 dequeue traces: input is consumed elsewhere
+  D. USB, kbd_int, and insertion traces but no dequeue: EmuCon cannot observe the pTOS direct-injection result
+  ```
+
+  If direct EmuCon accepts input, rebuild normal `rpi2_defconfig` and repeat
+  the trace after **File > Execute EmuCon**. The changed boundary then isolates
+  the AES launch state.
+
+- [ ] **Step 5: Compare direct and upstream injection semantics**
+
+  Compare pTOS `kbd_int()`'s queue value and vector calls with upstream's
+  `send_data(kbd_entry, iokbd, scancode)` followed by one `fake_hwint()` per
+  report.  Determine whether the installed `ikbdsys` vector or the hardware-
+  interrupt emulation is required for the failing console consumer.  Record
+  exact serial lines and the observed queue values in the issue work notes.
+
+- [ ] **Step 6: Remove the temporary HID and BIOS diagnostics**
+
+  Delete the temporary traces from `usb/udd_keyboard.c` and `bios/ikbd.c`.  Retain no diagnostic-only changes there.
+
+- [ ] **Step 7: Commit the diagnostic evidence only if it contains a lasting, concise trace**
+
+  Do not commit temporary instrumentation.  If a lasting `proc_go()` trace is justified by existing `KDEBUG` conventions, commit it separately:
+
+  ```sh
+  git add bdos/proc.c
+  git commit -m "Trace ARM process interrupt state"
+  ```
+
+  Otherwise proceed with no commit from this task.
+
+### Task 2: Implement Only the Injection Correction Proven by Task 1
+
+**Files:**
+- Modify: exact file and function identified by Task 1
+
+**Interfaces:**
+- Consumes: Task 1 evidence for one proven failure boundary.
+- Produces: the existing HID press/release sequence delivered through the single pTOS BIOS input path, with the missing required side effect restored.
+
+- [ ] **Step 1: State the single confirmed hypothesis before editing**
+
+  Write the result in the issue work notes in this exact form:
+
+  ```text
+  Hypothesis: <one boundary> prevents EmuCon from receiving USB key <key> because <trace evidence>.
+  ```
+
+  Do not edit code until the statement names one of: DWC2 IRQ delivery,
+  IRQ-context direct injection, a missing `send_data()`/`fake_hwint()` side
+  effect, queue visibility, or child CPSR IRQ masking.
+
+- [ ] **Step 2: Implement the corresponding minimal experiment**
+
+  Apply exactly one change matching the hypothesis:
+
+  ```text
+  IRQ-context direct injection: defer only existing kbd_int() calls; do not poll USB.
+  Missing vector/interrupt side effect: add the minimal pTOS-native equivalent around the existing kbd_int() path.
+  Child CPSR IRQ masking: clear only the CPSR IRQ mask in the ARM child SPSR.
+  ```
+
+  Preserve key ordering: released keys, released modifiers, pressed modifiers,
+  then pressed keys.  Do not combine these alternatives in one experiment.
+
+- [ ] **Step 3: Build the AES-free Raspberry Pi 2 diagnostic image to verify the change**
+
+  Run:
+
+  ```sh
+  make rpi2_defconfig
+  make menuconfig
+  make
+  ```
+
+  Set `CONF_WITH_AES=n` in `make menuconfig`. Expected: successful build
+  producing a direct-to-EmuCon `kernel7.img`.
+
+- [ ] **Step 4: Verify direct EmuCon, then desktop-launched EmuCon, on Raspberry Pi 2 QEMU**
+
+  Run:
+
+  ```sh
+  qemu-system-arm -M raspi2b -bios kernel7.img -d guest_errors \
+    -device usb-mouse -device usb-kbd \
+    -drive file=/var/folders/_3/s5x2rvs93b9d1b0hmmt664mh0000gn/T/opencode/empty-fat16-sd.img,if=sd,format=raw \
+    -serial stdio
+  ```
+
+  First verify direct EmuCon accepts `help`. Then rebuild normal
+  `rpi2_defconfig` and verify:
+
+  ```text
+  1. Use the keyboard in the GEM desktop.
+  2. Select File > Execute EmuCon.
+  3. Type help and press Enter; verify command output.
+  4. Type exit and press Enter; verify return to GEM.
+  ```
+
+  Expected: every step succeeds and no new guest errors appear after desktop startup.
+
+- [ ] **Step 5: Commit the minimal proven fix**
+
+  Run:
+
+  ```sh
+  git add <only-the-proven-source-files>
+  git commit -m "Fix USB keyboard console input"
+  ```
+
+### Task 3: Confirm Raspberry Pi 1 and Guard Against Shared-Target Regression
+
+**Files:**
+- Modify: none expected
+
+**Interfaces:**
+- Consumes: the single injection correction from Task 2.
+- Produces: QEMU evidence that the same BIOS input path works on `raspi1ap` and that an m68k configuration still builds without changes.
+
+- [ ] **Step 1: Build the AES-free Raspberry Pi 1 diagnostic image**
+
+  Run:
+
+  ```sh
+  make rpi1_defconfig
+  make menuconfig
+  make savedefconfig
+  make
+  ```
+
+  Set `CONF_WITH_AES=n` in `make menuconfig`. Expected: successful build
+  producing a direct-to-EmuCon `kernel.img`.
+
+- [ ] **Step 2: Verify direct EmuCon and desktop-launched EmuCon on Raspberry Pi 1 QEMU**
+
+  Run:
+
+  ```sh
+  qemu-system-arm -M raspi1ap -bios kernel.img -d guest_errors \
+    -device usb-mouse -device usb-kbd \
+    -drive file=/var/folders/_3/s5x2rvs93b9d1b0hmmt664mh0000gn/T/opencode/empty-fat16-sd.img,if=sd,format=raw \
+    -serial stdio
+  ```
+
+  Verify direct EmuCon accepts `help`. Then rebuild normal `rpi1_defconfig`
+  and verify desktop keyboard input, File > Execute EmuCon, `help`, and
+  `exit`. Expected: both direct and desktop-launched EmuCon accept input;
+  desktop-launched `exit` returns to GEM.
+
+- [ ] **Step 3: Build an m68k configuration without altering its behavior**
+
+  Run:
+
+  ```sh
+  make atari512_defconfig && make
+  ```
+
+  Expected: successful build.  The selected integration boundary must keep the
+  m68k keyboard path unchanged.
+
+- [ ] **Step 4: Run repository hygiene checks**
+
+  Run:
+
+  ```sh
+  make gitready
+  git diff --check
+  git status --short
+  ```
+
+  Expected: formatter/checks pass; no FAT16 image, serial log, or temporary trace remains in the worktree.
+
+- [ ] **Step 5: Update GitHub issue #185 with evidence and close it if the acceptance criteria pass**
+
+  Add a comment describing the confirmed injection difference and fix,
+  including whether pTOS required deferred execution, a vector side effect, or
+  a CPSR correction.  Include the two QEMU machine names and the `help`/`exit`
+  checks.  Close #185 only after both QEMU validations pass.

--- a/docs/superpowers/plans/2026-08-13-rpi-emucon-usb-keyboard.md
+++ b/docs/superpowers/plans/2026-08-13-rpi-emucon-usb-keyboard.md
@@ -68,16 +68,16 @@
   preserve the configuration with `make savedefconfig`, and build it:
 
   ```sh
-   gmake rpi2_defconfig
-   gmake menuconfig
-   gmake savedefconfig
-   gmake
-  ```
+   make rpi2_defconfig
+   make menuconfig
+   make savedefconfig
+   make
+   ```
 
-   On macOS, use Homebrew GNU Make (`gmake`): the system `make` is GNU Make
-   3.81 while this tree requires 4.3 or later.  Do not run `olddefconfig` with
-   `--kconfig`: the installed kconfiglib accepts `Kconfig` only as a positional
-   argument.
+   In the tested macOS environment, use Homebrew GNU Make (`gmake`) in place
+   of the system `make`, which is GNU Make 3.81 while this tree requires 4.3
+   or later. In that environment, do not run `olddefconfig` with `--kconfig`:
+   the installed kconfiglib accepts `Kconfig` only as a positional argument.
 
    Expected: successful build producing `kernel7.img` that boots directly into
   EmuCon, without AES or EmuDesk.
@@ -133,16 +133,19 @@
 
   Delete the temporary traces from `usb/udd_keyboard.c` and `bios/ikbd.c`.  Retain no diagnostic-only changes there.
 
-- [ ] **Step 7: Commit the diagnostic evidence only if it contains a lasting, concise trace**
+- [ ] **Step 7: Commit retained Task 1 documentation or lasting diagnostics**
 
-  Do not commit temporary instrumentation.  If a lasting `proc_go()` trace is justified by existing `KDEBUG` conventions, commit it separately:
+   Do not commit temporary instrumentation. Commit accurate, environment-
+   specific diagnostic command corrections made to this plan separately. If a
+   lasting `proc_go()` trace is justified by existing `KDEBUG` conventions,
+   commit it separately:
 
   ```sh
   git add bdos/proc.c
   git commit -m "Trace ARM process interrupt state"
   ```
 
-  Otherwise proceed with no commit from this task.
+   Otherwise proceed with no commit from this task.
 
 ### Task 2: Implement Only the Injection Correction Proven by Task 1
 

--- a/docs/superpowers/plans/2026-08-13-rpi-emucon-usb-keyboard.md
+++ b/docs/superpowers/plans/2026-08-13-rpi-emucon-usb-keyboard.md
@@ -147,95 +147,138 @@
 
    Otherwise proceed with no commit from this task.
 
-### Task 2: Implement Only the Injection Correction Proven by Task 1
+### Task 2: Trace the ARM DWC2 IRQ Path
 
 **Files:**
-- Modify: exact file and function identified by Task 1
+- Modify temporarily: `bios/raspi_int.c:263-317`
+- Modify temporarily: `usb/ucd_dwc2.c:832-932`
 
 **Interfaces:**
-- Consumes: Task 1 evidence for one proven failure boundary.
-- Produces: the existing HID press/release sequence delivered through the single pTOS BIOS input path, with the missing required side effect restored.
+- Consumes: the submitted keyboard async slot and generation from
+  `usb/udd_keyboard.c`, `raspi_int_handler()`, and `dwc2_irq_handler()`.
+- Produces: serial evidence classifying a manual USB key press as absent from
+  the Raspberry Pi IRQ dispatcher, absent from DWC2 host-channel completion,
+  or blocked before `dwc2_async_complete()` invokes the callback.
 
-- [ ] **Step 1: State the single confirmed hypothesis before editing**
+- [ ] **Step 1: Add bounded, temporary IRQ-path diagnostics**
 
-  Write the result in the issue work notes in this exact form:
+  In `bios/raspi_int.c`, when the pending peripheral IRQ scan selects
+  `ARM_IRQ_USB` and finds a handler, add one `KDEBUG()` that records USB IRQ
+  dispatch. In `usb/ucd_dwc2.c`, add `KDEBUG()` calls at these exact points:
 
-  ```text
-  Hypothesis: <one boundary> prevents EmuCon from receiving USB key <key> because <trace evidence>.
+  ```c
+  /* dwc2_irq_handler(): after reading gintsts */
+  KDEBUG(("dwc2_irq: gintsts=%08lx\n", gintsts));
+
+  /* each pending DWC2 async channel, after reading hcint */
+  KDEBUG(("dwc2_irq: channel=%d generation=%lu hcint=%08lx\n",
+          channel, slot->generation, hcint));
+
+  /* dwc2_async_complete(): immediately before the callback */
+  KDEBUG(("dwc2_async: deliver generation=%lu status=%ld length=%ld\n",
+          slot->generation, status, actual_length));
   ```
 
-  Do not edit code until the statement names one of: DWC2 IRQ delivery,
-  IRQ-context direct injection, a missing `send_data()`/`fake_hwint()` side
-  effect, queue visibility, or child CPSR IRQ masking.
+  Ensure the trace is bounded to USB dispatches and active async channels. Do
+  not log every non-USB IRQ, poll loop, or SOF frame. Do not alter channel
+  state, interrupt masks, callback ordering, or HID injection.
 
-- [ ] **Step 2: Implement the corresponding minimal experiment**
+- [ ] **Step 2: Build the AES-free Raspberry Pi 2 diagnostic image**
 
-  Apply exactly one change matching the hypothesis:
-
-  ```text
-  IRQ-context direct injection: defer only existing kbd_int() calls; do not poll USB.
-  Missing vector/interrupt side effect: add the minimal pTOS-native equivalent around the existing kbd_int() path.
-  Child CPSR IRQ masking: clear only the CPSR IRQ mask in the ARM child SPSR.
-  ```
-
-  Preserve key ordering: released keys, released modifiers, pressed modifiers,
-  then pressed keys.  Do not combine these alternatives in one experiment.
-
-- [ ] **Step 3: Build the AES-free Raspberry Pi 2 diagnostic image to verify the change**
-
-  Run:
+  On this macOS host use `gmake`. Start from the RPi2 default configuration,
+  set `CONF_WITH_AES=n` in `make menuconfig`, and build:
 
   ```sh
-  make rpi2_defconfig
-  make menuconfig
-  make
+  gmake rpi2_defconfig
+  gmake menuconfig
+  gmake
   ```
 
-  Set `CONF_WITH_AES=n` in `make menuconfig`. Expected: successful build
-  producing a direct-to-EmuCon `kernel7.img`.
+  Expected: a successful `kernel7.img` build that boots directly to EmuCon.
 
-- [ ] **Step 4: Verify direct EmuCon, then desktop-launched EmuCon, on Raspberry Pi 2 QEMU**
+- [ ] **Step 3: Capture a manual key press in the traced direct EmuCon image**
 
   Run:
 
   ```sh
   qemu-system-arm -M raspi2b -bios kernel7.img -d guest_errors \
+    -D /var/folders/_3/s5x2rvs93b9d1b0hmmt664mh0000gn/T/opencode/rpi2-irq-path-qemu.log \
     -device usb-mouse -device usb-kbd \
     -drive file=/var/folders/_3/s5x2rvs93b9d1b0hmmt664mh0000gn/T/opencode/empty-fat16-sd.img,if=sd,format=raw \
-    -serial stdio
+    -serial file:/var/folders/_3/s5x2rvs93b9d1b0hmmt664mh0000gn/T/opencode/rpi2-irq-path-serial.log
   ```
 
-  First verify direct EmuCon accepts `help`. Then rebuild normal
-  `rpi2_defconfig` and verify:
+  In the visible QEMU window, wait for `C:>`, focus the window, and press
+  `h` once. Preserve the serial and guest-error logs.
+
+- [ ] **Step 4: Classify the first missing signal and remove diagnostics**
+
+  Classify the capture exactly as one of:
 
   ```text
-  1. Use the keyboard in the GEM desktop.
-  2. Select File > Execute EmuCon.
-  3. Type help and press Enter; verify command output.
-  4. Type exit and press Enter; verify return to GEM.
+  A. No Raspberry Pi USB-dispatch trace: USB IRQ is not delivered to the
+     pTOS dispatcher; inspect the child CPSR IRQ mask and QEMU device input.
+  B. USB-dispatch trace but no DWC2 channel trace: DWC2 global/host interrupt
+     state does not expose the keyboard channel.
+  C. Channel trace without XFERCOMP: inspect hcint state and DWC2 async
+     scheduling/rearm conditions.
+  D. XFERCOMP trace without deliver trace: inspect dwc2_async_complete() slot
+     state (`active`, `cancelled`, and `shutting_down`).
+  E. Deliver trace: resume the existing HID-to-kbd_int()/IOREC diagnosis;
+     only then compare upstream vector injection semantics.
   ```
 
-  Expected: every step succeeds and no new guest errors appear after desktop startup.
+  Remove all temporary traces and local `ENABLE_KDEBUG` definitions after the
+  capture. Rebuild once to prove the cleanup compiles. Record the exact class,
+  relevant register values, and next single hypothesis in the task report.
 
-- [ ] **Step 5: Commit the minimal proven fix**
+- [ ] **Step 5: Commit only retained documentation**
 
-  Run:
+  Do not commit temporary diagnostics or a production fix from this task. If
+  the plan or report needs a precise correction based on the capture, commit
+  only those documents:
 
   ```sh
-  git add <only-the-proven-source-files>
-  git commit -m "Fix USB keyboard console input"
+  git add docs/superpowers/specs/2026-08-13-rpi-emucon-usb-keyboard-design.md \
+    docs/superpowers/plans/2026-08-13-rpi-emucon-usb-keyboard.md
+  git commit -m "Document #185 IRQ path findings"
   ```
 
-### Task 3: Confirm Raspberry Pi 1 and Guard Against Shared-Target Regression
+### Task 3: Implement and Validate the Correction Proven by Task 2
 
 **Files:**
 - Modify: none expected
 
 **Interfaces:**
-- Consumes: the single injection correction from Task 2.
-- Produces: QEMU evidence that the same BIOS input path works on `raspi1ap` and that an m68k configuration still builds without changes.
+- Consumes: one classified IRQ-path failure from Task 2.
+- Produces: the smallest correction for that failure plus QEMU evidence that
+  direct and desktop-launched EmuCon accept USB input on `raspi1ap` and
+  `raspi2b`.
 
-- [ ] **Step 1: Build the AES-free Raspberry Pi 1 diagnostic image**
+- [ ] **Step 1: State and test one correction hypothesis**
+
+  Write this in the issue work notes before editing production code:
+
+  ```text
+  Hypothesis: <Task 2 class and exact state> prevents USB keyboard completion
+  because <register/trace evidence>. The minimal correction is <one change>.
+  ```
+
+  Do not combine IRQ-mask, DWC2 state-machine, and HID-injection changes.
+
+- [ ] **Step 2: Implement the minimal correction and build direct EmuCon**
+
+  Modify only the file/function named by the hypothesis. Rebuild the
+  AES-free RPi2 image and manually verify that `help` is echoed and executed
+  at direct EmuCon. If it fails, return to Task 2 with new diagnostics; do not
+  stack a second correction.
+
+- [ ] **Step 3: Verify the desktop-launched RPi2 regression path**
+
+  Rebuild normal `rpi2_defconfig`, then manually verify desktop keyboard
+  input, File > Execute EmuCon, `help`, and `exit`.
+
+- [ ] **Step 4: Build the AES-free Raspberry Pi 1 diagnostic image**
 
   Run:
 
@@ -249,7 +292,7 @@
   Set `CONF_WITH_AES=n` in `make menuconfig`. Expected: successful build
   producing a direct-to-EmuCon `kernel.img`.
 
-- [ ] **Step 2: Verify direct EmuCon and desktop-launched EmuCon on Raspberry Pi 1 QEMU**
+- [ ] **Step 5: Verify direct EmuCon and desktop-launched EmuCon on Raspberry Pi 1 QEMU**
 
   Run:
 
@@ -265,7 +308,7 @@
   `exit`. Expected: both direct and desktop-launched EmuCon accept input;
   desktop-launched `exit` returns to GEM.
 
-- [ ] **Step 3: Build an m68k configuration without altering its behavior**
+- [ ] **Step 6: Build an m68k configuration without altering its behavior**
 
   Run:
 
@@ -276,7 +319,7 @@
   Expected: successful build.  The selected integration boundary must keep the
   m68k keyboard path unchanged.
 
-- [ ] **Step 4: Run repository hygiene checks**
+- [ ] **Step 7: Run repository hygiene checks**
 
   Run:
 
@@ -288,7 +331,7 @@
 
   Expected: formatter/checks pass; no FAT16 image, serial log, or temporary trace remains in the worktree.
 
-- [ ] **Step 5: Update GitHub issue #185 with evidence and close it if the acceptance criteria pass**
+- [ ] **Step 8: Update GitHub issue #185 with evidence and close it if the acceptance criteria pass**
 
   Add a comment describing the confirmed injection difference and fix,
   including whether pTOS required deferred execution, a vector side effect, or

--- a/docs/superpowers/plans/2026-08-13-rpi-emucon-usb-keyboard.md
+++ b/docs/superpowers/plans/2026-08-13-rpi-emucon-usb-keyboard.md
@@ -68,13 +68,18 @@
   preserve the configuration with `make savedefconfig`, and build it:
 
   ```sh
-  make rpi2_defconfig
-  make menuconfig
-  make savedefconfig
-  make
+   gmake rpi2_defconfig
+   gmake menuconfig
+   gmake savedefconfig
+   gmake
   ```
 
-  Expected: successful build producing `kernel7.img` that boots directly into
+   On macOS, use Homebrew GNU Make (`gmake`): the system `make` is GNU Make
+   3.81 while this tree requires 4.3 or later.  Do not run `olddefconfig` with
+   `--kconfig`: the installed kconfiglib accepts `Kconfig` only as a positional
+   argument.
+
+   Expected: successful build producing `kernel7.img` that boots directly into
   EmuCon, without AES or EmuDesk.
 
 - [ ] **Step 3: Create the required FAT16 test image outside the repository**

--- a/docs/superpowers/specs/2026-08-13-rpi-emucon-usb-keyboard-design.md
+++ b/docs/superpowers/specs/2026-08-13-rpi-emucon-usb-keyboard-design.md
@@ -1,0 +1,45 @@
+# Raspberry Pi EmuCon USB Keyboard Input Design
+
+## Scope
+
+Fix GitHub issue #185 for QEMU Raspberry Pi 1 and Raspberry Pi 2 images.
+The issue occurs after launching EmuCon from the GEM desktop with a USB
+keyboard.  Desktop keyboard input works, but EmuCon receives no input.
+
+An attached FAT16 SD-card image is required during testing because EmuCon
+hangs when no SD card is present (issue #184).  Physical Raspberry Pi
+hardware is out of scope.
+
+## Existing Input Path
+
+The DWC2 interrupt handler completes USB HID keyboard transfers.  The HID
+driver translates USB usages into Atari scancodes and calls `kbd_int()`.
+`kbd_int()` translates them and queues values in `ikbdiorec`.  EmuCon reads
+that queue through `conin()` and `bconin2()`.
+
+## Design
+
+Instrument the USB-completion, HID-to-`kbd_int()`, and `bconin2()` queue
+boundaries while reproducing the failure in QEMU.  This identifies whether
+events stop at DWC2 interrupt delivery, HID report completion, keyboard queue
+insertion, or queue consumption after the AES launches EmuCon.
+
+Apply one minimal correction at the identified ARM/QEMU boundary.  Do not add
+a second input route, poll USB from `bconin2()`, or change the generic EmuCon
+or BIOS console APIs.  The existing DWC2-to-IKBD path remains the sole input
+path.
+
+Diagnostic instrumentation is temporary and must not remain in the final
+change unless it is a concise, useful existing-style trace.
+
+## Acceptance Criteria
+
+For `raspi1ap` and `raspi2b` QEMU machines, launched with USB keyboard,
+USB mouse, and a valid FAT16 SD-card image:
+
+1. The GEM desktop still accepts USB keyboard input.
+2. File > Execute EmuCon launches the console.
+3. Typing `help` at the EmuCon prompt echoes and executes the command.
+4. Typing `exit` returns to the GEM desktop.
+
+The normal project build must continue to succeed for the selected target.

--- a/docs/superpowers/specs/2026-08-13-rpi-emucon-usb-keyboard-design.md
+++ b/docs/superpowers/specs/2026-08-13-rpi-emucon-usb-keyboard-design.md
@@ -10,6 +10,11 @@ An attached FAT16 SD-card image is required during testing because EmuCon
 hangs when no SD card is present (issue #184).  Physical Raspberry Pi
 hardware is out of scope.
 
+Testing has two stages. The primary diagnostic build keeps the Raspberry Pi
+kernel target but sets `CONF_WITH_AES=n`, which boots directly into EmuCon.
+This isolates USB-to-console input from AES and desktop process launch. The
+normal desktop image remains the regression test for File > Execute EmuCon.
+
 ## Existing Input Path
 
 The DWC2 interrupt handler completes USB HID keyboard transfers.  The HID
@@ -17,17 +22,39 @@ driver translates USB usages into Atari scancodes and calls `kbd_int()`.
 `kbd_int()` translates them and queues values in `ikbdiorec`.  EmuCon reads
 that queue through `conin()` and `bconin2()`.
 
+The FreeMiNT upstream driver does not inject input from a USB controller IRQ.
+It polls the HID interrupt endpoint from a kernel thread (or periodic TOS
+callback), then uses its TOS keyboard-injection mechanism.  pTOS changed to
+the DWC2 asynchronous IRQ callback in commit `905a7552`.
+
+The injection mechanisms also differ.  Upstream sends each translated
+press/release through the installed extended keyboard vector with
+`send_data(kbd_entry, iokbd, scancode)`, then calls `fake_hwint()` after the
+report.  pTOS calls its own `kbd_int(scancode)` directly.  That updates pTOS
+translation, modifier, repeat, and `ikbdiorec` state, but does not use a
+separate keyboard-vector injection path.  The investigation must determine
+whether EmuCon depends on a side effect of the upstream-style injection.
+
 ## Design
 
-Instrument the USB-completion, HID-to-`kbd_int()`, and `bconin2()` queue
-boundaries while reproducing the failure in QEMU.  This identifies whether
-events stop at DWC2 interrupt delivery, HID report completion, keyboard queue
-insertion, or queue consumption after the AES launches EmuCon.
+Instrument the DWC2 completion, HID-to-`kbd_int()`, keyboard-queue insertion,
+and `bconin2()` consumption boundaries while reproducing the failure in QEMU.
+This identifies whether events stop at USB interrupt delivery, report
+completion, queue insertion, or queue consumption after AES launches EmuCon.
 
-Apply one minimal correction at the identified ARM/QEMU boundary.  Do not add
-a second input route, poll USB from `bconin2()`, or change the generic EmuCon
-or BIOS console APIs.  The existing DWC2-to-IKBD path remains the sole input
-path.
+First test whether calling `kbd_int()` directly from the DWC2 IRQ callback is
+the regression, using a minimal deferred execution mechanism in the USB/BIOS
+integration layer.  The deferred path must retain the existing HID report
+translation and BIOS `kbd_int()` queue path; it must not poll USB from
+`bconin2()` or create an EmuCon-specific input route.  Only change ARM process
+CPSR handling if the diagnostic evidence independently proves that IRQ masking
+prevents USB completion delivery.
+
+Before replacing the current injection path, trace the actual values inserted
+into `ikbdiorec` and the `bconin2()` values consumed by EmuCon.  Compare that
+with the upstream `send_data()` contract and `fake_hwint()` role.  Implement
+an upstream-style vector injection only if this proves a missing consumer-
+visible side effect; do not add it merely to match upstream structure.
 
 Diagnostic instrumentation is temporary and must not remain in the final
 change unless it is a concise, useful existing-style trace.
@@ -37,9 +64,12 @@ change unless it is a concise, useful existing-style trace.
 For `raspi1ap` and `raspi2b` QEMU machines, launched with USB keyboard,
 USB mouse, and a valid FAT16 SD-card image:
 
-1. The GEM desktop still accepts USB keyboard input.
-2. File > Execute EmuCon launches the console.
-3. Typing `help` at the EmuCon prompt echoes and executes the command.
-4. Typing `exit` returns to the GEM desktop.
+1. An AES-free Raspberry Pi kernel boots directly into EmuCon and accepts
+   `help` input.
+2. The normal GEM desktop still accepts USB keyboard input.
+3. File > Execute EmuCon launches the console.
+4. Typing `help` at the launched EmuCon prompt echoes and executes the
+   command.
+5. Typing `exit` returns to the GEM desktop.
 
 The normal project build must continue to succeed for the selected target.

--- a/docs/superpowers/specs/2026-08-13-rpi-emucon-usb-keyboard-design.md
+++ b/docs/superpowers/specs/2026-08-13-rpi-emucon-usb-keyboard-design.md
@@ -42,19 +42,19 @@ and `bconin2()` consumption boundaries while reproducing the failure in QEMU.
 This identifies whether events stop at USB interrupt delivery, report
 completion, queue insertion, or queue consumption after AES launches EmuCon.
 
-First test whether calling `kbd_int()` directly from the DWC2 IRQ callback is
-the regression, using a minimal deferred execution mechanism in the USB/BIOS
-integration layer.  The deferred path must retain the existing HID report
-translation and BIOS `kbd_int()` queue path; it must not poll USB from
-`bconin2()` or create an EmuCon-specific input route.  Only change ARM process
-CPSR handling if the diagnostic evidence independently proves that IRQ masking
-prevents USB completion delivery.
+First trace the ARM DWC2 IRQ path without changing behavior.  The trace must
+show whether the Raspberry Pi interrupt dispatcher receives and invokes the
+USB handler, whether the handler observes a host-channel interrupt, and
+whether the submitted keyboard channel reaches a completion state.  Direct
+EmuCon fails before the DWC2 callback, so neither `kbd_int()` injection nor
+the AES child-process CPSR can be selected as a cause before this result.
 
-Before replacing the current injection path, trace the actual values inserted
-into `ikbdiorec` and the `bconin2()` values consumed by EmuCon.  Compare that
-with the upstream `send_data()` contract and `fake_hwint()` role.  Implement
-an upstream-style vector injection only if this proves a missing consumer-
-visible side effect; do not add it merely to match upstream structure.
+Only after the IRQ-path trace identifies the failed condition, apply one
+minimal correction at that condition.  Preserve the existing HID report
+translation and BIOS `kbd_int()` queue path.  Do not poll USB from `bconin2()`
+or create an EmuCon-specific input route.  Compare the upstream `send_data()`
+and `fake_hwint()` semantics only if DWC2 completion reaches `kbd_int()` and
+the BIOS queue path is then shown to miss a consumer-visible side effect.
 
 Diagnostic instrumentation is temporary and must not remain in the final
 change unless it is a concise, useful existing-style trace.


### PR DESCRIPTION
Fixes #185\n\nInvestigating USB keyboard delivery to EmuCon on QEMU Raspberry Pi targets.