### PR TITLE
ARM SVC trap entry permanently masks IRQ, freezing input

### DIFF
--- a/bios/ikbd.c
+++ b/bios/ikbd.c
@@ -404,14 +404,28 @@ static BOOL handle_mouse_mode(WORD newkey)
 static WORD kb_initial;
 static WORD kb_repeat;
 static WORD kb_ticks;
-static union {
-    ULONG key;                  /* combined value */
-    struct {
-        UBYTE shifty;           /* state of 'shifty' */
-        UBYTE scancode;         /* actual scancode */
-        UWORD ascii;            /* derived ascii value */
-    } k;
+static struct {
+    UBYTE shifty;           /* state of 'shifty' */
+    UBYTE scancode;         /* actual scancode */
+    UWORD ascii;            /* derived ascii value */
 } kb_last;
+
+/*
+ * Pack kb_last into the shifty/scancode/ascii ULONG that bconin2() callers
+ * expect (shifty in bits 24-31, scancode in bits 16-23, ascii in bits 0-15
+ * -- see bconin2()'s "value &= 0x00ffffffL" and push_ascii_ikbdiorec()'s
+ * identical layout). This used to be a union with kb_last.key as the ULONG
+ * view, which only produced this layout on a big-endian host; on ARM it
+ * silently read back a scrambled value, e.g. the ASCII character landing in
+ * bits 16-23 instead of bits 0-15, so every USB-sourced keystroke read as
+ * ASCII NUL and was discarded by callers like EmuCON's read_line().
+ */
+static ULONG kb_last_key(void)
+{
+    return MAKE_ULONG(kb_last.scancode, kb_last.ascii) |
+           ((ULONG)kb_last.shifty << 24);
+}
+
 static PFVOID kb_last_ikbdsys;  /* ikbdsys when kb_last was set */
 
 WORD kbrate(WORD initial, WORD repeat)
@@ -471,19 +485,19 @@ static void do_key_repeat(void)
 
     /* Play the key click sound */
     if (conterm & 1)
-        keyclick(kb_last.k.scancode);
+        keyclick(kb_last.scancode);
 
     /*
      * changing the modifier keys no longer stops key repeat, so when
      * they change, we must do the scancode conversion again
      */
-    if (shifty != kb_last.k.shifty) {
+    if (shifty != kb_last.shifty) {
         UBYTE scancode;
 
         /* use a copy of scancode because convert_scancode() can change it */
-        scancode = kb_last.k.scancode;
-        kb_last.k.ascii = convert_scancode(&scancode);
-        kb_last.k.shifty = shifty;
+        scancode = kb_last.scancode;
+        kb_last.ascii = convert_scancode(&scancode);
+        kb_last.shifty = shifty;
         kb_last_ikbdsys = kbdvecs.ikbdsys;
     }
 
@@ -491,7 +505,7 @@ static void do_key_repeat(void)
     if (mouse_packet[0]) {
         KDEBUG(("Repeating mouse packet %02x%02x%02x\n",mouse_packet[0],mouse_packet[1],mouse_packet[2]));
         call_mousevec(mouse_packet);
-    } else push_ikbdiorec(kb_last.key);
+    } else push_ikbdiorec(kb_last_key());
 
     /* The key will repeat again until some key up */
     kb_ticks = kb_repeat;
@@ -758,16 +772,16 @@ void kbd_int(UBYTE scancode)
     /*
      * save last key info for do_key_repeat()
      */
-    kb_last.k.shifty = shifty;
-    kb_last.k.scancode = scancode;
-    kb_last.k.ascii = ascii;
+    kb_last.shifty = shifty;
+    kb_last.scancode = scancode;
+    kb_last.ascii = ascii;
     kb_last_ikbdsys = kbdvecs.ikbdsys;
 
     /*
      * if we're not sending mouse packets, send a real key
      */
     if (!mouse_packet[0])
-        push_ikbdiorec(kb_last.key);
+        push_ikbdiorec(kb_last_key());
 }
 
 

--- a/bios/machine/raspi/startup.S
+++ b/bios/machine/raspi/startup.S
@@ -328,6 +328,16 @@ _arm_dispatch_undef:
 
     .globl _arm_dispatch_svc
 _arm_dispatch_svc:
+    // Taking the svc exception itself already masked IRQ (architectural,
+    // not our choice). Unlike m68k TRAP #n, which never raised the
+    // interrupt priority level, that means any handler below which blocks
+    // waiting for an interrupt -- e.g. bconin2()'s stop_until_interrupt()
+    // loop in bios/ikbd.c waiting on kb_timerc_int() -- would deadlock:
+    // the interrupt it needs can't fire while it's masked here. A call
+    // that returns normally is unaffected (rfefd restores CPSR from the
+    // pre-trap SPSR_svc), so this only bit us on the first blocking
+    // console read a process makes (#185).
+    cpsie i
     ldr ip, [lr, #-4]      // load svc instruction from code
     and ip, ip, #0xF       // mask out low nybble of instruction (we emulate trap #0 - #15)
     lsl ip, ip, #0x2       // multiply index by 4

--- a/bios/machine/virt-arm/startup.S
+++ b/bios/machine/virt-arm/startup.S
@@ -257,6 +257,12 @@ _arm_dispatch_undef:
 
     .globl _arm_dispatch_svc
 _arm_dispatch_svc:
+    // See the matching comment in bios/machine/raspi/startup.S: taking the
+    // svc exception already masked IRQ (architectural), and unlike m68k
+    // TRAP #n this would leave any handler that blocks waiting for an
+    // interrupt (e.g. bconin2()'s stop_until_interrupt() loop) unable to
+    // ever be woken (#185).
+    cpsie i
     ldr ip, [lr, #-4]
     and ip, ip, #0xF
     lsl ip, ip, #0x2


### PR DESCRIPTION
## Summary

Fixes #185. Two independent bugs, both needed to actually get keyboard input working end-to-end:

**1. ARM `svc` trap entry permanently masks IRQ.** ARM `svc` exception entry architecturally sets `CPSR.I` (masks IRQ). `_arm_dispatch_svc` (duplicated in `bios/machine/raspi/startup.S` and `bios/machine/virt-arm/startup.S`) never re-enabled it before jumping into the shared BIOS/XBIOS/GEMDOS trap handlers. Calls that return immediately are unaffected (`rfefd` restores the pre-trap CPSR from `SPSR_svc`), but a call that blocks *inside* the trap waiting for an interrupt — `bconin2()`'s `while (!bconstat2()) stop_until_interrupt();` in `bios/ikbd.c` — can never be woken, because the interrupt it's waiting for is now permanently masked. This hits on the very first blocking console read a process makes, which is why the console works fine through boot (native supervisor context, no trap) and goes dead exactly when EmuCon starts waiting at its prompt. Fix: `cpsie i` as the first instruction of `_arm_dispatch_svc` in both machines, matching m68k's `TRAP #n` semantics (which never masked interrupts in the first place).

**2. `kb_last`'s union scrambled the pushed key value on little-endian hosts.** `bios/ikbd.c`'s `kb_last` packed `{shifty, scancode, ascii}` into a `union` with a `ULONG key` alternate view, then pushed `kb_last.key` to `ikbdiorec`. That only produces the `shifty<<24 | scancode<<16 | ascii` layout `bconin2()` callers expect (see its `value &= 0x00ffffffL` masking and `push_ascii_ikbdiorec()`'s identical, endian-safe construction) on a big-endian host — this code predates the ARM port and was written for m68k. On ARM (little-endian), the same struct writes read back scrambled through the `.key` view: the ASCII byte lands in bits 16-23 instead of bits 0-15, so every USB-sourced keystroke read as ASCII NUL and was silently discarded by callers like EmuCon's `read_line()` (`LOBYTE(charcode) == 0` → `continue`). This is why, even after fixing bug 1, keystrokes still didn't echo — traced and confirmed against real hardware/QEMU logs (see #185 for the full trace: `key=00672200` for scancode `0x22`/ASCII `'g'`, exactly matching the predicted little-endian corruption). Fix: replace the union with a plain struct and an explicit bit-shift-based packer, matching `push_ascii_ikbdiorec()`'s existing endian-safe pattern.

## Verified

- Reproduced the IRQ freeze independent of the reported Mac/QEMU environment: `rpi2_defconfig` with `CONF_WITH_AES=n`, `qemu-system-arm -M raspi2b` on a fresh Linux x86_64 container (distro QEMU 8.2.2). Instrumented both the DWC2 USB IRQ handler and the unrelated periodic timer tick independently — both went completely silent the instant EmuCon reached `C:>`; resumed continuously with the fix.
- Diagnosed the endianness bug from real trace data the PR author (@kelihlodversson) captured on their own Mac/QEMU session: `kbd_int()` and the USB HID completion callback both fired correctly with valid data, but the packed value didn't match what the consumer expected, byte-for-byte matching the union's predicted little-endian corruption.
- The PR author confirmed Alt+Arrow-keys-move-the-mouse worked even before the second fix — that path calls `call_mousevec()` directly, bypassing the broken `kb_last.key` entirely, which is exactly consistent with "USB keyboard delivery works, only the `ikbdiorec`-bound path is broken."
- **@kelihlodversson confirmed on real hardware/QEMU: keystrokes now echo correctly in EmuCon with both fixes applied.**
- `make rpi2_defconfig && make`, `make virt-arm_defconfig && make`: both build clean with both fixes applied.
- `qemu-system-arm -M virt,highmem=off -cpu cortex-a7 -m 128 -kernel virt-arm.elf`: boots to `AES: EMUDESK: evnt_multi()` as expected, no regression on the full AES/desktop path.
- `make gitready`: passes.
- Local build reproducibility double-checked against this PR's own CI artifact (byte-identical except for a harmless per-run table-ordering difference in `obj/country.o`, unrelated to either fix).

## Known follow-up (separate issue, not blocking this PR)

Testing surfaced a distinct key-repeat timing bug — see #191. Repeat fires much sooner than the configured ~300ms delay. Root cause not yet identified; scoped separately since it's independent of #185's "no input at all" symptom.

## Test plan

- [x] Timer tick and USB IRQ activity confirmed to continue past `C:>` with fix 1 (temporary instrumentation, not in the final diff)
- [x] `make rpi2_defconfig && make`, `make virt-arm_defconfig && make` both build clean
- [x] virt-arm boots to the AES event loop with no regression
- [x] `make gitready`
- [x] Confirmed by @kelihlodversson: keystrokes now echo in EmuCon with both fixes applied
