### PR TITLE
Fix desktop never responding to mouse clicks on ARM (endian-unsafe combine_cms())

### DIFF
--- a/aes/gemevlib.h
+++ b/aes/gemevlib.h
@@ -25,22 +25,15 @@ WORD ev_dclick(WORD rate, WORD setit);
 
 /*
  * combine clicks/mask/state into LONG
+ *
+ * downorup() (geminput.c) decodes this value with explicit byte
+ * shifts, so it must be built the same way here: a union of a
+ * {WORD,BYTE,BYTE} struct and a LONG is endian-dependent and gives
+ * the wrong layout on little-endian targets (same bug class as
+ * kb_last in bios/ikbd.c, see issue #185).
  */
 static __inline__ LONG combine_cms(WORD clicks,WORD mask,WORD state)
 {
-    union {
-        LONG result;
-        struct {
-            WORD c;
-            BYTE m;
-            BYTE s;
-        } combined;
-    } u;
-
-    u.combined.c = clicks;
-    u.combined.m = mask;
-    u.combined.s = state;
-
-    return u.result;
+    return (((LONG)clicks & 0xffffL) << 16) | (((LONG)mask & 0xff) << 8) | ((LONG)state & 0xff);
 }
 #endif

--- a/aes/gemevlib.h
+++ b/aes/gemevlib.h
@@ -34,6 +34,6 @@ WORD ev_dclick(WORD rate, WORD setit);
  */
 static __inline__ LONG combine_cms(WORD clicks,WORD mask,WORD state)
 {
-    return (((LONG)clicks & 0xffffL) << 16) | (((LONG)mask & 0xff) << 8) | ((LONG)state & 0xff);
+    return (LONG)(MAKE_ULONG(clicks, 0) | ((ULONG)(UBYTE)mask << 8) | (UBYTE)state);
 }
 #endif


### PR DESCRIPTION
Fixes #192

## Summary

`combine_cms()` (`aes/gemevlib.h`) packs `(clicks, mask, state)` into a `LONG` via a union of a struct and a `LONG` — endianness-dependent type punning, the same anti-pattern already fixed for `kb_last` in #185/PR #189. On little-endian ARM this produces a different byte layout than `downorup()` (`aes/geminput.c`) expects when decoding via explicit byte shifts, so the desktop's registered button-wait event can never be satisfied and clicks on the desktop are silently swallowed. Menu/dialog clicks are unaffected because `ctlmgr` bypasses `combine_cms()` and uses a raw hardcoded constant instead.

See #192 for the full diagnosis trail.

## Fix

Build the `LONG` in `combine_cms()` with explicit shifts instead of a union.

Draft while I verify the fix on real QEMU testing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYCiZG3khh8RefXwY5M4Ti)_