### PR TITLE
raspi: poll UART0 RX into the IKBD queue for CONF_SERIAL_CONSOLE

### DIFF
--- a/.claude/skills/ptos-smoketest/SKILL.md
+++ b/.claude/skills/ptos-smoketest/SKILL.md
@@ -292,7 +292,32 @@ cat /tmp/qemu.log
     raspi, `CONF_SERIAL_CONSOLE` defaults on alongside the video desktop
     (`default y if !CONF_WITH_ATARI_VIDEO && !MACHINE_AMIGA`), so serial
     input there feeds the same console the video desktop uses, not a
-    separate EmuCON boot path.
+    separate EmuCON boot path. To smoke-test raspi serial input specifically,
+    build a throwaway CLI variant the same way `virt-arm-cli_defconfig`
+    derives from `virt-arm_defconfig`: copy `configs/rpi1_defconfig`, append
+    `CONF_WITH_AES=n`, then `CONFIG_= KCONFIG_CONFIG=.config python3 -m
+    defconfig --kconfig Kconfig <path>` (the plain `make <name>_defconfig`
+    target only works for files already under `configs/`; invoking
+    `defconfig` directly on an arbitrary path needs those two env vars set,
+    matching what `tools/kconfig.mk` exports, or `CONFIG_=` defaults to
+    kconfiglib's `CONFIG_` prefix and every line in the fragment is silently
+    ignored as "malformed"). This reaches `C:>` over `-serial` exactly like
+    the `-cli` targets. Confirmed working end-to-end (#190): a keystroke that
+    actually lands in `UART0_DR` is picked up by `raspi_uart0_poll_rx()` and
+    echoed at the EmuCON prompt — observed directly when a `help\r` sent too
+    early (during the boot-options banner, which also reads single
+    keystrokes) had two of its four characters "leak" through and echo once
+    EmuCON started, i.e. bytes delivered to the guest UART do reach the
+    console. Getting bytes reliably delivered *to* the guest UART from a
+    scripted host process is the unreliable part in a sandboxed container,
+    same as the caveat below for virt-arm-cli — see there. It reproduces
+    identically over `-serial chardev:...,socket,server=on` (not just a pty):
+    `strace` on the QEMU process shows `ppoll()` reporting the fd `POLLIN`
+    exactly once, right when the host side writes, but QEMU never calls
+    `read()` on it before the fd is masked out of the next `ppoll()`'s fd
+    set — so this is a QEMU/container chardev-servicing gap affecting every
+    serial backend in that environment, not something specific to ptys or to
+    the raspi driver.
   - **Verifying input interactively is unreliable in a sandboxed/CI
     shell.** `strace -f -e trace=read,poll,ppoll` on a spawned
     `qemu-system-arm -M virt ... -serial stdio` process, in at least one
@@ -302,10 +327,11 @@ cat /tmp/qemu.log
     poll set entirely. TX was unaffected (verified extensively: boot
     banner, EmuCON prompt, etc. all render correctly), and QEMU's own
     monitor chardev on the same spawned process consumed typed input
-    correctly in the same session — so this looks like a QEMU/host-pty
+    correctly in the same session — so this looks like a QEMU/host
     interaction gap specific to the guest-UART chardev path in that
-    container, not a general "no ptys here" limitation, and not something
-    the pTOS-side driver can work around. **Do not conclude the feature is
+    container (confirmed on both a pty and a `socket,server=on` chardev
+    while testing #190 on raspi, see above — not pty-specific), not
+    something the pTOS-side driver can work around. **Do not conclude the feature is
     broken from a failed automated keystroke test alone** — first confirm
     with `strace` (or by testing from a real interactive terminal) whether
     the environment is actually delivering bytes to QEMU's serial chardev

--- a/.claude/skills/ptos-smoketest/SKILL.md
+++ b/.claude/skills/ptos-smoketest/SKILL.md
@@ -286,6 +286,13 @@ cat /tmp/qemu.log
     (`coldfire_rs232_enable_interrupt()`). This also fixed a real pre-existing
     bug: virt-arm's PL011 init never set `LCRH.FEN`, so the UART never
     actually ran in FIFO mode despite the code comment claiming it did.
+    raspi1/raspi2 (below) use the same PL011 and the same polling pattern
+    via `raspi_uart0_poll_rx()` from `raspi_timer3_handler()` (#190), even
+    though there is no `rpi*-cli` config to boot straight to EmuCON — on
+    raspi, `CONF_SERIAL_CONSOLE` defaults on alongside the video desktop
+    (`default y if !CONF_WITH_ATARI_VIDEO && !MACHINE_AMIGA`), so serial
+    input there feeds the same console the video desktop uses, not a
+    separate EmuCON boot path.
   - **Verifying input interactively is unreliable in a sandboxed/CI
     shell.** `strace -f -e trace=read,poll,ppoll` on a spawned
     `qemu-system-arm -M virt ... -serial stdio` process, in at least one

--- a/bios/raspi_int.c
+++ b/bios/raspi_int.c
@@ -14,6 +14,7 @@
 #include "asm.h"
 #include "vectors.h"
 #include "mfp.h"
+#include "raspi_uart.h"
 
 #define HZ                                200      // ticks per second
 #define CLOCKHZ                        1000000     // Sytem timer runs at 1MHz
@@ -133,6 +134,10 @@ static inline void disable_irq(int num)
 void raspi_timer3_handler(void)
 {
     ULONG compare;
+
+#if CONF_SERIAL_CONSOLE && CONF_WITH_RASPI_UART0
+    raspi_uart0_poll_rx();
+#endif
 
     vector_5ms();
 

--- a/bios/raspi_uart.c
+++ b/bios/raspi_uart.c
@@ -158,4 +158,4 @@ void raspi_uart0_poll_rx(void)
 
 #endif /* CONF_SERIAL_CONSOLE */
 
-#endif /* CONF_WITH_COLDFIRE_RS232 */
+#endif /* CONF_WITH_RASPI_UART0 */

--- a/bios/raspi_uart.c
+++ b/bios/raspi_uart.c
@@ -74,10 +74,10 @@ void raspi_uart0_init(void)
 {
     ULONG val;
     ULONG clock_rate = get_base_clock();
-	ULONG baud16 = BAUDRATE * 16;
-	ULONG int_div = clock_rate / baud16;
-	ULONG fractdiv2 = (clock_rate % baud16) * 8 / BAUDRATE;
-	ULONG fractdiv = fractdiv2 / 2 + fractdiv2 % 2;
+    ULONG baud16 = BAUDRATE * 16;
+    ULONG int_div = clock_rate / baud16;
+    ULONG fractdiv2 = (clock_rate % baud16) * 8 / BAUDRATE;
+    ULONG fractdiv = fractdiv2 / 2 + fractdiv2 % 2;
 
     UART0_CR = 0;
 
@@ -140,5 +140,22 @@ UBYTE raspi_uart0_read_byte(void)
     /* Read the received byte */
     return (UBYTE) UART0_DR;
 }
+
+#if CONF_SERIAL_CONSOLE
+
+/* Feeds bytes typed at the far end of -serial (or a real serial cable)
+ * into the same emulated IKBD event queue a real keyboard would use, so
+ * CONF_SERIAL_CONSOLE ("read the console input exclusively from the
+ * serial port") actually has something to read. Called from
+ * raspi_timer3_handler() (200 Hz) rather than a UART interrupt, mirroring
+ * virt_uart0_poll_rx() on the QEMU virt-arm machine, which uses the same
+ * PL011 UART. */
+void raspi_uart0_poll_rx(void)
+{
+    while (raspi_uart0_can_read())
+        push_ascii_ikbdiorec(raspi_uart0_read_byte());
+}
+
+#endif /* CONF_SERIAL_CONSOLE */
 
 #endif /* CONF_WITH_COLDFIRE_RS232 */

--- a/bios/raspi_uart.h
+++ b/bios/raspi_uart.h
@@ -18,6 +18,10 @@ BOOL raspi_uart0_can_write(void);
 void raspi_uart0_write_byte(UBYTE b);
 BOOL raspi_uart0_can_read(void);
 UBYTE raspi_uart0_read_byte(void);
+
+#if CONF_SERIAL_CONSOLE
+void raspi_uart0_poll_rx(void);
+#endif
 #endif
 
 


### PR DESCRIPTION
## Summary

`CONF_SERIAL_CONSOLE` defaults to `y` on Raspberry Pi builds and its help text promises "read the console input exclusively from the serial port." The output half worked, but nothing ever read UART0 RX and fed it into the console input path, so typing into `-serial stdio` (or a real serial cable) did nothing.

This mirrors the fix already in place for the QEMU virt-arm machine (`virt_uart0_poll_rx()`), which uses the same PL011 UART.

## Changes

- Add `raspi_uart0_poll_rx()` to `bios/raspi_uart.c`/`.h`, guarded by `CONF_SERIAL_CONSOLE`, mirroring `virt_uart0_poll_rx()` — drains UART0 RX into `push_ascii_ikbdiorec()`.
- Call it from `raspi_timer3_handler()` in `bios/raspi_int.c` (the 200 Hz tick), guarded by `CONF_SERIAL_CONSOLE && CONF_WITH_RASPI_UART0`.
- Fix pre-existing tab indentation in `raspi_uart0_init()` that was blocking `make gitready`.
- Update `.claude/skills/ptos-smoketest/SKILL.md` to note that raspi1/raspi2 now poll serial RX the same way as virt-arm/virt-m68k, even though there's no `rpi*-cli` EmuCON config — on raspi, `CONF_SERIAL_CONSOLE` feeds the same console the video desktop uses.

## Testing

- Built `rpi1_defconfig` and `rpi2_defconfig` clean (`make gitready` passes).
- Booted the rpi1 image under QEMU (`-M raspi1ap`); boot banner renders on `-serial stdio` and the boot reaches the AES `evnt_multi()` event loop with no new `guest_errors`, matching the documented pass signal.
- Did not verify interactive serial keystroke delivery end-to-end — the smoke-test skill notes this is unreliable to test automatically in a sandboxed shell (QEMU's guest-UART chardev may not receive bytes from a scripted stdin at all, independent of the driver).

Fixes #190


---
_Generated by [Claude Code](https://claude.ai/code/session_014yomtHQrU9Gaxzahvho5Mb)_