### PR TITLE
raspi: drive VBL from firmware vsync IRQ on Pi 1-3 when available

### DIFF
--- a/bios/Kconfig
+++ b/bios/Kconfig
@@ -467,6 +467,28 @@ config CONF_WITH_NOVA
 	default n if TARGET_192 || TARGET_CART || MACHINE_ARANYM || MACHINE_FIREBEE
 	default y
 
+config CONF_WITH_RASPI_VSYNC_IRQ
+	bool "Raspberry Pi real vsync-driven VBL (SMI IRQ)"
+	depends on MACHINE_RPI && !TARGET_RPI4
+	default n
+	help
+	  Some Raspberry Pi GPU firmware builds support a legacy, otherwise
+	  undocumented config.txt option ("fake_vsync_isr=1") that raises an
+	  SMI interrupt synchronized to the real display refresh -- a
+	  facility historically used by RISC OS on the BCM2835/36/37.  Say y
+	  to drive VBL from that interrupt when it is actually arriving,
+	  instead of always faking it off the 200 Hz system timer; VBL falls
+	  back to the timer-driven 50 Hz automatically whenever the real
+	  interrupt is absent or stops arriving.  See doc/readme-raspi.md
+	  for the config.txt addition this depends on.
+
+	  pTOS ships with no config.txt by default, and the firmware option
+	  this looks for is opt-in, so leaving this off changes nothing;
+	  turning it on without the firmware option is also harmless, since
+	  the interrupt this reacts to then simply never arrives.  It
+	  defaults to n because the SMI interrupt has not yet been verified
+	  against current firmware on real Pi 1/2/3 hardware.
+
 config CONF_VRAM_ADDRESS
 	hex "Fixed video RAM address (0 = allocate in ST-RAM)"
 	default 0x0

--- a/bios/Kconfig
+++ b/bios/Kconfig
@@ -470,7 +470,7 @@ config CONF_WITH_NOVA
 config CONF_WITH_RASPI_VSYNC_IRQ
 	bool "Raspberry Pi real vsync-driven VBL (SMI IRQ)"
 	depends on MACHINE_RPI && !TARGET_RPI4
-	default n
+	default y
 	help
 	  Some Raspberry Pi GPU firmware builds support a legacy, otherwise
 	  undocumented config.txt option ("fake_vsync_isr=1") that raises an
@@ -483,11 +483,10 @@ config CONF_WITH_RASPI_VSYNC_IRQ
 	  for the config.txt addition this depends on.
 
 	  pTOS ships with no config.txt by default, and the firmware option
-	  this looks for is opt-in, so leaving this off changes nothing;
-	  turning it on without the firmware option is also harmless, since
-	  the interrupt this reacts to then simply never arrives.  It
-	  defaults to n because the SMI interrupt has not yet been verified
-	  against current firmware on real Pi 1/2/3 hardware.
+	  this looks for is opt-in, so leaving this on changes nothing unless
+	  fake_vsync_isr=1 is also set; turning it on without the firmware
+	  option is harmless, since the interrupt this reacts to then simply
+	  never arrives.
 
 config CONF_VRAM_ADDRESS
 	hex "Fixed video RAM address (0 = allocate in ST-RAM)"

--- a/bios/arch/arm/vectors.c
+++ b/bios/arch/arm/vectors.c
@@ -106,6 +106,12 @@ void int_vbl(void)
     vblsem++; // release vbl semaphore (TODO: non-atomic)
 }
 
+// VBL source seam, declared in vectors.h.  Defaults to int_vbl(), so
+// machines with no real vsync source (virt-arm) are unaffected; raspi
+// points it at raspi_vbl_fallback() (bios/raspi_vsync.c) when
+// CONF_WITH_RASPI_VSYNC_IRQ is on.
+void (*timer_vbl_hook)(void) = int_vbl;
+
 // ==== Timer C interrupt handler ============================================
 // Machine-independent: every ARM machine's periodic tick (raspi's system /
 // generic timer, virt's generic timer) ends up here through vector_5ms.
@@ -119,8 +125,9 @@ void int_timerc(void)
 #       if CONF_WITH_YM2149
             sndirq();   // dosound support
 #       endif
-        // Fake vbl interrupt every 4 timer_c calls (50Hz)
-        int_vbl();
+        // Fake vbl interrupt every 4 timer_c calls (50Hz), unless the
+        // hook has been pointed at a real vsync source's fallback.
+        timer_vbl_hook();
     }
 }
 

--- a/bios/build.mk
+++ b/bios/build.mk
@@ -42,6 +42,7 @@ obj-$(CPU_ARMV7) += cache_armv7.o cache_armv7_asm.o
 obj-$(MACHINE_RPI) += raspi_board.o raspi_uart.o raspi_int.o raspi_mbox.o \
 	 raspi_screen.o raspi_emmc.o
 obj-$(CONF_WITH_USB_XHCI) += raspi_vl805.o
+obj-$(CONF_WITH_RASPI_VSYNC_IRQ) += raspi_vsync.o
 
 obj-$(MACHINE_VIRT_ARM) += virt_uart.o virt_mmu.o virt_pic.o virt_timer.o
 obj-$(CONF_WITH_VDI_TRUECOLOR32_TEST) += virt_screen.o

--- a/bios/mfp.c
+++ b/bios/mfp.c
@@ -21,6 +21,7 @@
 #include "vectors.h"
 #include "coldfire.h"
 #include "raspi_int.h"
+#include "raspi_vsync.h"
 
 #if CONF_WITH_MFP || CONF_WITH_TT_MFP
 
@@ -200,6 +201,9 @@ void init_system_timer(void)
     coldfire_init_system_timer();
 #elif CONF_RASPI_TIMER_C
     raspi_init_system_timer();
+#if CONF_WITH_RASPI_VSYNC_IRQ
+    raspi_vsync_init();
+#endif
 #elif CONF_WITH_MFP
     /* Timer C: ctrl = divide 64, data = 192 */
     xbtimer(2, 0x50, 192, (LONG)int_timerc);

--- a/bios/raspi_vsync.c
+++ b/bios/raspi_vsync.c
@@ -1,0 +1,105 @@
+/*
+ * raspi_vsync.c - real vsync-driven VBL for the Raspberry Pi (Pi 1-3)
+ *
+ * Copyright (C) 2013-2026 The EmuTOS development team
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+/*
+ * Some Raspberry Pi GPU firmware builds support a legacy, otherwise
+ * undocumented config.txt option, fake_vsync_isr=1, that raises
+ * ARM_IRQ_SMI synchronized to the real display refresh -- a facility
+ * historically used by RISC OS on the BCM2835/36/37.  When it is
+ * actually firing, this drives int_vbl() from it instead of from the
+ * every-4th-200Hz-tick fake in int_timerc() (bios/arch/arm/vectors.c),
+ * so VBL timing tracks the real display refresh instead of a fixed
+ * 50 Hz.
+ *
+ * This is opt-in, unofficial firmware behaviour the user adds to
+ * config.txt themselves (see doc/readme-raspi.md); pTOS never depends
+ * on it, and boots exactly as before without it.  Whether it never
+ * arrives at all -- no config.txt (the default), older or different
+ * firmware -- or it stops arriving after having worked, VBL falls
+ * back to (and stays on) the existing timer-driven 50 Hz, driven by
+ * raspi_vbl_fallback() below.
+ *
+ * Not used on Pi 4 (TARGET_RPI4): its interrupts aren't routed through
+ * the legacy interrupt controller raspi_connect_irq() drives, and its
+ * real vsync source is the Pixel Valve, tracked separately (#206).
+ *
+ * The exact SMI acknowledge sequence current firmware needs -- if any
+ * -- is unverified; this has not yet been tested against real Pi 1/2/3
+ * hardware, which is why CONF_WITH_RASPI_VSYNC_IRQ defaults to n.
+ */
+
+#include "config.h"
+#ifndef MACHINE_RPI
+#error This file must only be compiled for raspberry PI targets
+#endif
+
+#if CONF_WITH_RASPI_VSYNC_IRQ
+
+#include "portab.h"
+#include "raspi_int.h"
+#include "raspi_vsync.h"
+#include "tosvars.h"
+#include "vectors.h"
+
+/*
+ * Number of 200 Hz ticks without a fresh SMI-vsync interrupt before
+ * reverting to the timer-driven fallback VBL.  Real vsync is expected
+ * roughly every 4 ticks (50 Hz) or every 3-4 ticks (60 Hz); a few
+ * missed periods is enough margin to not flap on a single dropped
+ * interrupt while still falling back quickly if the source is gone.
+ */
+#define VSYNC_MISS_TICKS (4 * 3)
+
+static volatile LONG last_vsync_hz200;
+static volatile BOOL vsync_healthy;
+
+/*
+ * ARM_IRQ_SMI handler, connected via raspi_connect_irq().  Marks real
+ * vsync as healthy and drives VBL directly; int_timerc()'s every-4th-
+ * tick fake (routed through raspi_vbl_fallback() below) then stays
+ * quiet as long as this keeps arriving on time.
+ */
+static void raspi_vsync_isr(void)
+{
+    last_vsync_hz200 = hz_200;
+    vsync_healthy = TRUE;
+    int_vbl();
+}
+
+/*
+ * Installed as timer_vbl_hook (bios/arch/arm/vectors.c); called from
+ * int_timerc() on every 4th 200 Hz tick, in place of int_vbl().  Acts
+ * as a standing watchdog, not just an initial fallback: it fires VBL
+ * itself whenever real vsync hasn't been seen recently, and re-locks
+ * onto real vsync as soon as raspi_vsync_isr() runs again.
+ */
+static void raspi_vbl_fallback(void)
+{
+    if (!vsync_healthy || (hz_200 - last_vsync_hz200) > VSYNC_MISS_TICKS)
+    {
+        vsync_healthy = FALSE;
+        int_vbl();
+    }
+}
+
+/*
+ * Called once at startup, with the existing timer-driven VBL already
+ * active: installs the fallback hook and enables the SMI IRQ, but
+ * changes nothing about VBL timing until (unless) a real SMI-vsync
+ * interrupt actually arrives.
+ */
+void raspi_vsync_init(void)
+{
+    last_vsync_hz200 = hz_200;
+    vsync_healthy = FALSE;
+    timer_vbl_hook = raspi_vbl_fallback;
+    raspi_connect_irq(ARM_IRQ_SMI, raspi_vsync_isr);
+}
+
+#endif /* CONF_WITH_RASPI_VSYNC_IRQ */

--- a/bios/raspi_vsync.c
+++ b/bios/raspi_vsync.c
@@ -30,8 +30,9 @@
  * real vsync source is the Pixel Valve, tracked separately (#206).
  *
  * The exact SMI acknowledge sequence current firmware needs -- if any
- * -- is unverified; this has not yet been tested against real Pi 1/2/3
- * hardware, which is why CONF_WITH_RASPI_VSYNC_IRQ defaults to n.
+ * -- is unverified; without fake_vsync_isr=1 in config.txt, the SMI
+ * IRQ this connects simply never arrives, so CONF_WITH_RASPI_VSYNC_IRQ
+ * defaults to y.
  */
 
 #include "config.h"

--- a/bios/raspi_vsync.h
+++ b/bios/raspi_vsync.h
@@ -1,0 +1,21 @@
+/*
+ * raspi_vsync.h - real vsync-driven VBL for the Raspberry Pi (Pi 1-3)
+ *
+ * Copyright (C) 2013-2026 The EmuTOS development team
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef RASPI_VSYNC_H
+#define RASPI_VSYNC_H
+
+#ifdef MACHINE_RPI
+
+#if CONF_WITH_RASPI_VSYNC_IRQ
+void raspi_vsync_init(void);
+#endif
+
+#endif /* MACHINE_RPI */
+
+#endif /* RASPI_VSYNC_H */

--- a/bios/vectors.h
+++ b/bios/vectors.h
@@ -93,6 +93,17 @@ extern WORD trap_save_area[];
 extern void (*vector_5ms)(void);              /* 200 Hz system timer */
 #endif
 
+/*
+ * VBL source seam for the machine-independent ARM int_timerc()
+ * (bios/arch/arm/vectors.c): normally int_vbl() itself, faked off the
+ * every-4th-tick 50 Hz as before, but a machine with a real vsync
+ * interrupt can point this at its own handler instead, so it drives
+ * VBL and int_timerc()'s fake becomes a fallback.  Only ARM machines
+ * define and use this; m68k's int_timerc (bios/arch/m68k/vectors.S)
+ * always calls int_vbl() directly.
+ */
+extern void (*timer_vbl_hook)(void);
+
 /* protect d2/a2 when calling external user-supplied code */
 #ifdef __m68k__
 LONG protect_v(LONG (*func)(void));

--- a/doc/readme-raspi.md
+++ b/doc/readme-raspi.md
@@ -46,3 +46,30 @@ versions of the Atari TOS desktop.
 These images have been built using:
 make rpi1_defconfig && make
 (and likewise for rpi2, rpi3 and rpi4)
+
+## Real vsync-driven VBL (Pi 1, 2 and 3 only)
+
+By default, pTOS's VBL (vertical blank) interrupt on the Raspberry Pi is
+faked at a fixed 50 Hz off the 200 Hz system timer, unrelated to whatever
+the display is actually doing.
+
+If the kernel was built with `CONF_WITH_RASPI_VSYNC_IRQ` (off by default;
+see `make menuconfig`'s Video menu), pTOS can instead drive VBL from a real
+vsync interrupt, when the firmware provides one. This requires adding to
+`config.txt`:
+
+```
+fake_vsync_isr=1
+```
+
+`fake_vsync_isr` is a legacy, otherwise undocumented option -- it is not
+part of the officially documented `config.txt` option set, was historically
+used by RISC OS on the BCM2835/36/37, and may not work, or may need pairing
+with other options, on all firmware versions; it has not yet been verified
+against current firmware on real hardware. It is entirely optional: without
+it (including with no `config.txt` at all, the default described above),
+pTOS keeps faking VBL at 50 Hz exactly as before, and if it stops arriving
+after having worked, pTOS falls back to the 50 Hz fake automatically.
+
+Not applicable to the Pi 4: see issue #206 for its Pixel Valve-based vsync
+instead.

--- a/doc/readme-raspi.md
+++ b/doc/readme-raspi.md
@@ -53,10 +53,10 @@ By default, pTOS's VBL (vertical blank) interrupt on the Raspberry Pi is
 faked at a fixed 50 Hz off the 200 Hz system timer, unrelated to whatever
 the display is actually doing.
 
-If the kernel was built with `CONF_WITH_RASPI_VSYNC_IRQ` (off by default;
-see `make menuconfig`'s Video menu), pTOS can instead drive VBL from a real
-vsync interrupt, when the firmware provides one. This requires adding to
-`config.txt`:
+The shipped Pi 1/2/3 kernels are built with `CONF_WITH_RASPI_VSYNC_IRQ`
+(on by default; see `make menuconfig`'s Video menu), which lets pTOS
+instead drive VBL from a real vsync interrupt when the firmware provides
+one. This requires adding to `config.txt`:
 
 ```
 fake_vsync_isr=1


### PR DESCRIPTION
Fixes #205

## Summary

- Adds a machine-independent `timer_vbl_hook` seam to `int_timerc()` (`bios/arch/arm/vectors.c`), replacing its unconditional `int_vbl()` call. virt-arm is untouched — the hook just keeps its `int_vbl` default there.
- New `bios/raspi_vsync.c`/`.h` (Pi 1-3 only): connects `ARM_IRQ_SMI` via `raspi_connect_irq()`. The ISR calls `int_vbl()` and marks real vsync healthy; `raspi_vbl_fallback()` (installed as the hook) fires `int_vbl()` itself only when real vsync hasn't been seen for a few `hz_200` ticks — a standing watchdog that re-locks onto real vsync as soon as it resumes, not just a one-time boot fallback.
- New `CONF_WITH_RASPI_VSYNC_IRQ` Kconfig option in the Video menu, `depends on MACHINE_RPI && !TARGET_RPI4`, `default y` on Pi 1-3. Enabling it is harmless without `fake_vsync_isr=1` in `config.txt` — the SMI IRQ this connects simply never arrives, and VBL keeps coming from the existing 200 Hz-derived fallback exactly as before.
- `bios/mfp.c` calls `raspi_vsync_init()` right after `raspi_init_system_timer()`, so the existing timer-driven VBL is already active when the SMI handler is installed — no added boot latency.
- `doc/readme-raspi.md` documents the optional `fake_vsync_isr=1` config.txt addition, flagged as legacy/undocumented.

Not applicable to the Pi 4 (tracked separately in #206): its interrupts don't route through the legacy interrupt controller `raspi_connect_irq()` drives.

## Test plan

- [x] `make rpi1_defconfig && make`, `make rpi2_defconfig && make`, `make rpi3_defconfig && make`, `make rpi4_defconfig && make` all build clean with the new default
- [x] Confirmed `CONF_WITH_RASPI_VSYNC_IRQ` is forced off (unselectable) on the rpi4 config via its `depends on`
- [x] `make virt-arm_defconfig && make` builds clean, confirming the seam's default (`int_vbl`) path is unaffected
- [x] `make gitready` passes
- [ ] Hardware verification of `fake_vsync_isr=1` (and the exact SMI IRQ semantics) against real Pi 1/2/3 boards — not done in this environment; see the open questions in #205

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0179Gb9zXgfx7on5MF9CsgS5

---
_Generated by [Claude Code](https://claude.ai/code/session_0179Gb9zXgfx7on5MF9CsgS5)_