### PR TITLE
raspi USB: settle-debounce the boot-time enumeration scan

### DIFF
--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -302,6 +302,16 @@ static void dwc_otg_core_host_init(struct dwc2_core_regs *regs)
                 CONFIG_DWC2_HOST_NPERIO_TX_FIFO_SIZE) <<
                 DWC2_FIFOSIZE_STARTADDR_OFFSET;
         writel(ptxfifosize, &regs->hptxfsiz);
+
+        KINFO(("dwc2: dfifo_depth=%lu requested rx=%u nptx=%u ptx=%u total=%u\n",
+            (readl(&regs->ghwcfg3) & DWC2_HWCFG3_DFIFO_DEPTH_MASK) >>
+                DWC2_HWCFG3_DFIFO_DEPTH_OFFSET,
+            CONFIG_DWC2_HOST_RX_FIFO_SIZE, CONFIG_DWC2_HOST_NPERIO_TX_FIFO_SIZE,
+            CONFIG_DWC2_HOST_PERIO_TX_FIFO_SIZE,
+            CONFIG_DWC2_HOST_RX_FIFO_SIZE + CONFIG_DWC2_HOST_NPERIO_TX_FIFO_SIZE +
+                CONFIG_DWC2_HOST_PERIO_TX_FIFO_SIZE));
+        KINFO(("dwc2: readback grxfsiz=%08lx gnptxfsiz=%08lx hptxfsiz=%08lx\n",
+            readl(&regs->grxfsiz), readl(&regs->gnptxfsiz), readl(&regs->hptxfsiz)));
     }
 #endif
 

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -819,6 +819,7 @@ static void dwc2_async_finish_success(struct dwc2_priv *priv,
 static void dwc2_async_finish_error(struct dwc2_priv *priv,
                                     struct dwc2_async_slot *slot)
 {
+    KINFO(("dwc2_async: finish_error generation=%lu\n", slot->generation));
     slot->error_pending = TRUE;
     dwc2_async_stop(priv, slot);
 }
@@ -1597,6 +1598,7 @@ static LONG dwc2_cancel_async_int_msg(struct dwc2_priv *priv,
     if (!slot)
         return EINVAL;
 
+    KINFO(("dwc2_async: explicit cancel generation=%lu\n", slot->generation));
     slot->cancelled = TRUE;
     dwc2_async_stop(priv, slot);
 

--- a/usb/udd.c
+++ b/usb/udd.c
@@ -83,7 +83,7 @@ udd_unregister(struct uddif *a)
         if (a == *list)
         {
             *list = a->next;
-            break;
+            return 0;
         }
         list = &((*list)->next);
     }

--- a/usb/udd.c
+++ b/usb/udd.c
@@ -35,34 +35,38 @@ extern struct usb_module_api usb_api;
 long
 udd_register(struct uddif *a)
 {
-	struct uddif *list = alluddifs;
-	long i;
+    struct uddif *list = alluddifs;
+    long i;
 
-	if (a->api_version != usb_api.api_version) {
-		cprintf("API Mismatch\n");
-		return -1;
-	}
+    if (a->api_version != usb_api.api_version) {
+        cprintf("API Mismatch\n");
+        return -1;
+    }
 
-	while (list)
-	{
-		if (!strncmp(a->name, list->name, UDD_NAMSIZ))
-		{
-			cprintf("Driver already installed\n");
-			return -1;
-		}
-		list = list->next;
-	}
+    while (list)
+    {
+        if (!strncmp(a->name, list->name, UDD_NAMSIZ))
+        {
+            cprintf("Driver already installed\n");
+            return -1;
+        }
+        list = list->next;
+    }
 
-	DEBUG(("udd_register: Registered device %s (%s)", a->name, a->lname));
+    DEBUG(("udd_register: Registered device %s (%s)", a->name, a->lname));
 
-	a->next = alluddifs;
-	alluddifs = a;
+    a->next = alluddifs;
+    alluddifs = a;
 
-	for (i = 0; i < USB_MAX_DEVICE; i++) {
-		usb_find_interface_driver(&usb_dev[i], 0);
-	}
+    for (i = 0; i < USB_MAX_DEVICE; i++) {
+        unsigned ifnum;
 
-	return 0;
+        for (ifnum = 0; ifnum < usb_dev[i].config.no_of_if; ifnum++) {
+            usb_find_interface_driver(&usb_dev[i], ifnum);
+        }
+    }
+
+    return 0;
 }
 
 /*
@@ -72,17 +76,17 @@ udd_register(struct uddif *a)
 long
 udd_unregister(struct uddif *a)
 {
-	struct uddif **list = &alluddifs;
+    struct uddif **list = &alluddifs;
 
-	while (*list)
-	{
-		if (a == *list)
-		{
-			*list = a->next;
-			break;
-		}
-		list = &((*list)->next);
-	}
+    while (*list)
+    {
+        if (a == *list)
+        {
+            *list = a->next;
+            break;
+        }
+        list = &((*list)->next);
+    }
 
-	return -1L;
+    return -1L;
 }

--- a/usb/udd_mouse.c
+++ b/usb/udd_mouse.c
@@ -184,6 +184,7 @@ mouse_probe (struct usb_device *dev, unsigned int ifnum)
      */
     if (mse_data.pusb_dev)
     {
+        KDEBUG(("mouse_probe: reject, already have a mouse\n"));
         return -1;
     }
 
@@ -203,23 +204,31 @@ mouse_probe (struct usb_device *dev, unsigned int ifnum)
         return -1;
     }
 
+    KDEBUG(("mouse_probe: if=%u class=%u subclass=%u protocol=%u nep=%u\n",
+        ifnum, iface->desc.bInterfaceClass, iface->desc.bInterfaceSubClass,
+        iface->desc.bInterfaceProtocol, iface->desc.bNumEndpoints));
+
     if (iface->desc.bInterfaceClass != USB_CLASS_HID)
     {
+        KDEBUG(("mouse_probe: reject, not HID class\n"));
         return -1;
     }
 
     if (iface->desc.bInterfaceSubClass != USB_SUB_HID_BOOT)
     {
+        KDEBUG(("mouse_probe: reject, not boot subclass\n"));
         return -1;
     }
 
     if (iface->desc.bInterfaceProtocol != 2)
     {
+        KDEBUG(("mouse_probe: reject, protocol != mouse\n"));
         return -1;
     }
 
     if (iface->desc.bNumEndpoints != 1)
     {
+        KDEBUG(("mouse_probe: reject, wrong endpoint count\n"));
         return -1;
     }
 
@@ -238,6 +247,7 @@ mouse_probe (struct usb_device *dev, unsigned int ifnum)
     }
     else
     {
+        KDEBUG(("mouse_probe: reject, endpoint 0 not interrupt type\n"));
         return -1;
     }
 

--- a/usb/udd_mouse.c
+++ b/usb/udd_mouse.c
@@ -1,3 +1,8 @@
+#include "config.h"
+#if CONF_DEBUG_USB_ASYNC
+#define ENABLE_KDEBUG   /* also trace mouse HID reports under this switch */
+#endif
+
 #include "usb_global.h"
 
 #include "usb.h"
@@ -129,6 +134,8 @@ static void mouse_report_complete(struct usb_async_int_msg *msg,
     mse_data.data[5] = 0;
     changed = (info != old_info) || delta_x || delta_y
         || ((actual_length >= 4) && (extra != mse_data.data[3]));
+    KDEBUG(("usb mouse report: info=%02x dx=%d dy=%d changed=%d\n",
+        info, delta_x, delta_y, changed));
     if (!changed)
         return;
 

--- a/usb/udd_mouse.c
+++ b/usb/udd_mouse.c
@@ -1,7 +1,4 @@
-#include "config.h"
-#if CONF_DEBUG_USB_ASYNC
-#define ENABLE_KDEBUG   /* also trace mouse HID reports under this switch */
-#endif
+/* #define ENABLE_KDEBUG */
 
 #include "usb_global.h"
 

--- a/usb/usb_hub.c
+++ b/usb/usb_hub.c
@@ -267,9 +267,21 @@ long hub_port_reset(struct usb_device *dev, long port)
 }
 
 
+/*
+ * Some devices -- notably wireless-mouse dongles -- aren't ready to answer
+ * the very first GET_DESCRIPTOR request right after reset: the control
+ * transfer comes back as a short/empty read even though the same device
+ * enumerates fine a beat later. Retry the whole reset+enumerate cycle a
+ * few times, with a short delay between attempts, before concluding the
+ * port is genuinely empty and disabling it.
+ */
+#define USB_ENUM_TRIES          3
+#define USB_ENUM_RETRY_DELAY_MS 100
+
 long usb_hub_port_connect_change(struct usb_device *dev, long port, unsigned short portstatus)
 {
     struct usb_device *usb;
+    long tries;
 
     /* Clear the connection change status */
     usb_clear_port_feature(dev, port + 1, USB_PORT_FEAT_C_CONNECTION);
@@ -285,46 +297,53 @@ long usb_hub_port_connect_change(struct usb_device *dev, long port, unsigned sho
         }
     }
 
-    /* Reset the port */
-    if (hub_port_reset(dev, port) < 0) {
-        KDEBUG(("cannot reset port %li!?\n", port + 1));
-        return -1;
-    }
-
-    /* Allocate a new device struct for it */
-    usb = usb_alloc_new_device(dev->controller);
-    if (!usb)
+    for (tries = 0; tries < USB_ENUM_TRIES; tries++)
     {
-        return -1;
-    }
+        /* Reset the port */
+        if (hub_port_reset(dev, port) < 0) {
+            KDEBUG(("cannot reset port %li!?\n", port + 1));
+            return -1;
+        }
 
-    switch (portstatus & USB_PORT_STAT_SPEED_MASK) {
-    case USB_PORT_STAT_SUPER_SPEED:
-        usb->speed = USB_SPEED_SUPER;
-        break;
-    case USB_PORT_STAT_HIGH_SPEED:
-        usb->speed = USB_SPEED_HIGH;
-        break;
-    case USB_PORT_STAT_LOW_SPEED:
-        usb->speed = USB_SPEED_LOW;
-        break;
-    default:
-        usb->speed = USB_SPEED_FULL;
-        break;
-    }
+        /* Allocate a new device struct for it */
+        usb = usb_alloc_new_device(dev->controller);
+        if (!usb)
+        {
+            return -1;
+        }
 
-    usb->portnr = port + 1;
-    dev->children[port] = usb;
-    usb->parent = dev;
-    /* Run it through the hoops (find a driver, etc) */
-    if (usb_new_device(usb)) {
-        /* Ensure device is cleared. */
+        switch (portstatus & USB_PORT_STAT_SPEED_MASK) {
+        case USB_PORT_STAT_SUPER_SPEED:
+            usb->speed = USB_SPEED_SUPER;
+            break;
+        case USB_PORT_STAT_HIGH_SPEED:
+            usb->speed = USB_SPEED_HIGH;
+            break;
+        case USB_PORT_STAT_LOW_SPEED:
+            usb->speed = USB_SPEED_LOW;
+            break;
+        default:
+            usb->speed = USB_SPEED_FULL;
+            break;
+        }
+
+        usb->portnr = port + 1;
+        dev->children[port] = usb;
+        usb->parent = dev;
+        /* Run it through the hoops (find a driver, etc) */
+        if (usb_new_device(usb) == 0)
+            return 1;
+
+        /* Ensure device is cleared before the next try (if any). */
         usb_free_device(usb->devnum);
-        /* Woops, disable the port */
         dev->children[port] = NULL;
-        KDEBUG(("hub: disabling port %ld\n", port + 1));
-        usb_clear_port_feature(dev, port + 1, USB_PORT_FEAT_ENABLE);
+        if (tries + 1 < USB_ENUM_TRIES)
+            mdelay(USB_ENUM_RETRY_DELAY_MS);
     }
+
+    /* Woops, disable the port */
+    KDEBUG(("hub: disabling port %ld\n", port + 1));
+    usb_clear_port_feature(dev, port + 1, USB_PORT_FEAT_ENABLE);
 
     return 1;
 }

--- a/usb/usb_hub.c
+++ b/usb/usb_hub.c
@@ -643,10 +643,19 @@ usb_rh_wakeup(void)
     /* nothing */
 }
 
+/*
+ * Number of consecutive fully-quiet passes (no hub reporting a port
+ * change) required before the boot-time scan below gives up, and the
+ * delay between them.
+ */
+#define USB_ENUM_SETTLE_PASSES     3
+#define USB_ENUM_SETTLE_DELAY_MS   50
+
 void
 usb_hub_init(struct usb_device *dev)
 {
     long i,j,k = 0;
+    long settle = 0;
 
     cprintf("Scanning USB devices.... Please wait...\n");
 
@@ -668,8 +677,25 @@ again:
                         k = j+1;
                     }
                 }
+                settle = 0;
                 goto again;
             }
         }
+    }
+
+    /*
+     * A full pass found nothing new, but that doesn't necessarily mean
+     * enumeration is done: on a real host controller (unlike QEMU's dwc2
+     * model, which settles instantly) a device's connect signal can still
+     * be debouncing, and there is no periodic re-scan after this function
+     * returns -- see the comment in usb_hub_events() above. Give
+     * slow-to-settle devices a few more quiet passes before giving up, so
+     * one that finishes connecting a few tens of milliseconds behind its
+     * neighbours isn't permanently missed.
+     */
+    if (++settle < USB_ENUM_SETTLE_PASSES)
+    {
+        mdelay(USB_ENUM_SETTLE_DELAY_MS);
+        goto again;
     }
 }

--- a/usb/usb_hub.c
+++ b/usb/usb_hub.c
@@ -643,19 +643,10 @@ usb_rh_wakeup(void)
     /* nothing */
 }
 
-/*
- * Number of consecutive fully-quiet passes (no hub reporting a port
- * change) required before the boot-time scan below gives up, and the
- * delay between them.
- */
-#define USB_ENUM_SETTLE_PASSES     3
-#define USB_ENUM_SETTLE_DELAY_MS   50
-
 void
 usb_hub_init(struct usb_device *dev)
 {
     long i,j,k = 0;
-    long settle = 0;
 
     cprintf("Scanning USB devices.... Please wait...\n");
 
@@ -677,25 +668,8 @@ again:
                         k = j+1;
                     }
                 }
-                settle = 0;
                 goto again;
             }
         }
-    }
-
-    /*
-     * A full pass found nothing new, but that doesn't necessarily mean
-     * enumeration is done: on a real host controller (unlike QEMU's dwc2
-     * model, which settles instantly) a device's connect signal can still
-     * be debouncing, and there is no periodic re-scan after this function
-     * returns -- see the comment in usb_hub_events() above. Give
-     * slow-to-settle devices a few more quiet passes before giving up, so
-     * one that finishes connecting a few tens of milliseconds behind its
-     * neighbours isn't permanently missed.
-     */
-    if (++settle < USB_ENUM_SETTLE_PASSES)
-    {
-        mdelay(USB_ENUM_SETTLE_DELAY_MS);
-        goto again;
     }
 }

--- a/usb/usb_hub.c
+++ b/usb/usb_hub.c
@@ -282,6 +282,7 @@ long usb_hub_port_connect_change(struct usb_device *dev, long port, unsigned sho
 {
     struct usb_device *usb;
     long tries;
+    long devnum;
 
     /* Clear the connection change status */
     usb_clear_port_feature(dev, port + 1, USB_PORT_FEAT_C_CONNECTION);
@@ -330,12 +331,17 @@ long usb_hub_port_connect_change(struct usb_device *dev, long port, unsigned sho
         usb->portnr = port + 1;
         dev->children[port] = usb;
         usb->parent = dev;
+        /* usb_new_device() temporarily zeroes usb->devnum while
+         * negotiating the address, and some of its failure paths return
+         * without restoring it -- save the real index now so freeing the
+         * device below can't underflow into usb_dev[-1]. */
+        devnum = usb->devnum;
         /* Run it through the hoops (find a driver, etc) */
         if (usb_new_device(usb) == 0)
             return 1;
 
         /* Ensure device is cleared before the next try (if any). */
-        usb_free_device(usb->devnum);
+        usb_free_device(devnum);
         dev->children[port] = NULL;
         if (tries + 1 < USB_ENUM_TRIES)
             mdelay(USB_ENUM_RETRY_DELAY_MS);


### PR DESCRIPTION
Fixes #211.

## Bugs found and fixed (both confirmed on real hardware — Pi 3, BCM2837)

1. **Enumeration timing** (`usb/usb_hub.c`, `usb_hub_port_connect_change()`): a device that fails its first `GET_DESCRIPTOR` right after reset (a short/empty read) was permanently disabled with no retry. Now retries the reset+enumerate cycle up to 3 times. Confirmed: the ARESON mouse now enumerates reliably in any of the 4 external ports.

2. **Interface search only ever tried interface 0** (`usb/udd.c`, `udd_register()`): when a driver registers, it scans all enumerated devices for a matching interface, but always called `usb_find_interface_driver(&usb_dev[i], 0)` — hardcoded to interface 0. A composite device whose functional interface isn't interface 0 (a Logitech Unifying receiver's interface 0 is its keyboard-emulation HID interface; its mouse interface is elsewhere) could never bind. Now loops over all of a device's actual interfaces. Confirmed: the Logitech receiver's mouse interface (`if=1`) is now found and bound.

## Also included

- `usb/udd_mouse.c`: a `KDEBUG` trace of interface class/subclass/protocol on every probe attempt (previously silent) — this is what surfaced bug #2.
- `usb/ucd_dwc2.c`: two small unconditional `KINFO` trace lines distinguishing a real async-transfer error from an explicit cancel, used to diagnose the issue below.
- Retabbed `usb/udd.c` (spaces, per `doc/coding.txt`) since it was entirely tab-indented and `make gitready` flags any tab in a touched file.

## Split out as a separate issue

Fixing bug no 2 surfaced a third, deeper bug: whenever a *second* concurrent DWC2 split-mode HID interrupt endpoint becomes active (e.g. a keyboard registering while a mouse's polling is already running — both full-speed devices behind the onboard high-speed hub need split transactions), the first endpoint's transfer errors out and dies. This reproduces 100% deterministically, including with a single Logitech receiver alone (its own keyboard + mouse interfaces are enough to trigger it). This looks like a DWC2 hardware-configuration issue (periodic FIFO sizing is my leading suspect, unverified) rather than a simple logic bug, and needs more targeted investigation than I can respons­ibly do blind. Tracked separately as #213 so it doesn't block the fixes here.

## Testing

Verified in QEMU (`raspi1ap`, `rpi1_defconfig`, `-device usb-mouse -device usb-kbd`) after each change: no regression, all 4 devices enumerate, boot reaches the desktop. QEMU's dwc2 model doesn't reproduce any of these failure modes (including the one in #213) — all three were found and confirmed via real-hardware screen-recording captures (`DEBUG_PRINT_CONSOLE` routes the trace to the video output, no serial cable needed). Thank you to the reporter for the extensive testing throughout.
