### PR TITLE
raspi: 8-byte align the GEMDOS fs-stack (fixes Data Abort opening folders)

### DIFF
--- a/bdos/arch/arm/rwa.S
+++ b/bdos/arch/arm/rwa.S
@@ -150,6 +150,13 @@ _termuser:
         .even
 
         .ds.w   1000
+        // AAPCS requires the stack to be 8-byte aligned at every public
+        // C function call boundary; .even here only guarantees 2 bytes
+        // (a leftover from the m68k original). GCC relies on the
+        // stronger guarantee and will happily emit alignment-checked
+        // NEON loads/stores (e.g. vld1.64 ... :64) for plain struct
+        // assignments, which hard-fault if this stack starts unaligned.
+        .balign 8
 fstrt:
         .ds.l   1
 


### PR DESCRIPTION
Fixes #214

Draft while awaiting real-hardware confirmation — see the issue and commit message for the full root-cause analysis (NEON alignment fault in `makofd()` caused by the GEMDOS trap's scratch stack, `fstrt`, only being 2-byte aligned instead of the 8 bytes AAPCS requires).