### PR TITLE
ARM: marshal 5+ argument BIOS/XBIOS calls via a struct pointer

### DIFF
--- a/bios/arch/arm/biosargs.h
+++ b/bios/arch/arm/biosargs.h
@@ -1,0 +1,72 @@
+/*
+ * biosargs.h - argument-marshaling structs for wide-argument ARM BIOS/XBIOS calls
+ *
+ * Copyright (C) 2026 The EmuTOS development team
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef BIOSARGS_H
+#define BIOSARGS_H
+
+#include "portab.h"
+
+/*
+ * _biostrap/_xbiostrap (vectorsasm.S) call the vectored handler with at
+ * most 4 real arguments in r0-r3 -- that's all _arm_dispatch_svc's callers
+ * put in registers, and nothing marshals a 5th+ argument to the stack.
+ * The handful of BIOS/XBIOS functions that need more than that (Rwabs/
+ * Lrwabs, Floprd/Flopwr/Flopver, Flopfmt, Rsconf) take a pointer to one of
+ * these structs as their single real argument instead, on ARM only.
+ *
+ * This is part of the trap ABI shared with libcmini's ARM osbind.h
+ * (include/mint/arch/arm/biosargs.h in the libcmini repo) -- keep the
+ * field order and types in sync between the two.
+ */
+
+struct bios_lrwabs_args         /* Rwabs/Lrwabs -- BIOS function 0x04 */
+{
+    LONG r_w;
+    void *adr;
+    LONG numb;
+    LONG first;
+    LONG drive;
+    LONG lfirst;
+};
+
+struct xbios_flop_io_args       /* Floprd/Flopwr/Flopver -- XBIOS 0x08/0x09/0x13 */
+{
+    void *buf;
+    LONG filler;
+    LONG dev;
+    LONG sect;
+    LONG track;
+    LONG side;
+    LONG count;
+};
+
+struct xbios_flopfmt_args       /* Flopfmt -- XBIOS 0x0a */
+{
+    void *buf;
+    void *skew;
+    LONG dev;
+    LONG spt;
+    LONG track;
+    LONG side;
+    LONG interlv;
+    LONG magic;
+    LONG virgin;
+};
+
+struct xbios_rsconf_args        /* Rsconf -- XBIOS 0x0f */
+{
+    LONG baud;
+    LONG ctrl;
+    LONG ucr;
+    LONG rsr;
+    LONG tsr;
+    LONG scr;
+};
+
+#endif /* BIOSARGS_H */

--- a/bios/bios.c
+++ b/bios/bios.c
@@ -38,6 +38,9 @@
 #include "nls.h"
 #include "biosmem.h"
 #include "aespub.h"
+#if defined(__arm__)
+#include "arch/arm/biosargs.h"
+#endif
 #include "ikbd.h"
 #include "mouse.h"
 #include "midi.h"
@@ -1061,6 +1064,20 @@ LONG lrwabs(WORD r_w, UBYTE *adr, WORD numb, WORD first, WORD drive, LONG lfirst
     return protect_wlwwwl((PFLONG)hdv_rw, r_w, (LONG)adr, numb, first, drive, lfirst);
 }
 
+#if defined(__arm__)
+/*
+ * ARM's trap entry (_biostrap, vectorsasm.S) only delivers 4 real
+ * arguments in registers; lrwabs() needs 6, so it's called through the
+ * vec table via this trampoline instead, unpacking a struct pointer.
+ * See arch/arm/biosargs.h.
+ */
+static LONG bios_4_arm(struct bios_lrwabs_args *a)
+{
+    return lrwabs((WORD)a->r_w, (UBYTE *)a->adr, (WORD)a->numb,
+                  (WORD)a->first, (WORD)a->drive, a->lfirst);
+}
+#endif
+
 #if DBGBIOS
 static LONG bios_4(WORD r_w, UBYTE *adr, WORD numb, WORD first, WORD drive, LONG lfirst)
 {
@@ -1270,7 +1287,11 @@ const PFLONG bios_vecs[] = {
     VEC(bios_1, bconstat),
     VEC(bios_2, bconin),
     VEC(bios_3, bconout),
+#if defined(__arm__)
+    (PFLONG) bios_4_arm,
+#else
     VEC(bios_4, lrwabs),
+#endif
     VEC(bios_5, setexc),
     VEC(bios_6, tickcal),
     VEC(bios_7, getbpb),

--- a/bios/bios.c
+++ b/bios/bios.c
@@ -39,7 +39,7 @@
 #include "biosmem.h"
 #include "aespub.h"
 #if defined(__arm__)
-#include "arch/arm/biosargs.h"
+#include "biosargs.h"
 #endif
 #include "ikbd.h"
 #include "mouse.h"

--- a/bios/xbios.c
+++ b/bios/xbios.c
@@ -37,6 +37,9 @@
 #include "asm.h"
 #include "vectors.h"
 #include "xbios.h"
+#if defined(__arm__)
+#include "arch/arm/biosargs.h"
+#endif
 
 #define DBG_XBIOS        0
 
@@ -200,6 +203,19 @@ static LONG xbios_8(UBYTE *buf, LONG filler, WORD devno, WORD sectno,
 }
 #endif
 
+#if defined(__arm__)
+/*
+ * ARM's trap entry only delivers 4 real arguments in registers; floprd()
+ * needs 7, so it's called through the vec table via this trampoline
+ * instead, unpacking a struct pointer. See arch/arm/biosargs.h.
+ */
+static LONG xbios_8_arm(struct xbios_flop_io_args *a)
+{
+    return floprd((UBYTE *)a->buf, a->filler, (WORD)a->dev, (WORD)a->sect,
+                  (WORD)a->track, (WORD)a->side, (WORD)a->count);
+}
+#endif
+
 
 
 /*
@@ -220,6 +236,15 @@ static LONG xbios_9(const UBYTE *buf, LONG filler, WORD devno, WORD sectno,
 {
     kprintf("XBIOS: Flopwr()\n");
     return flopwr(buf, filler, devno, sectno, trackno, sideno, count);
+}
+#endif
+
+#if defined(__arm__)
+/* See xbios_8_arm above. */
+static LONG xbios_9_arm(struct xbios_flop_io_args *a)
+{
+    return flopwr((const UBYTE *)a->buf, a->filler, (WORD)a->dev, (WORD)a->sect,
+                  (WORD)a->track, (WORD)a->side, (WORD)a->count);
 }
 #endif
 
@@ -265,6 +290,20 @@ static LONG xbios_a(UBYTE *buf, WORD *skew, WORD devno, WORD spt,
     kprintf("XBIOS: flopfmt()\n");
     return flopfmt(buf, skew, devno, spt, trackno, sideno, interlv,
                    virgin, magic);
+}
+#endif
+
+#if defined(__arm__)
+/*
+ * ARM's trap entry only delivers 4 real arguments in registers; flopfmt()
+ * needs 9, so it's called through the vec table via this trampoline
+ * instead, unpacking a struct pointer. See arch/arm/biosargs.h.
+ */
+static LONG xbios_a_arm(struct xbios_flopfmt_args *a)
+{
+    return flopfmt((UBYTE *)a->buf, (WORD *)a->skew, (WORD)a->dev, (WORD)a->spt,
+                   (WORD)a->track, (WORD)a->side, (WORD)a->interlv,
+                   (ULONG)a->magic, (WORD)a->virgin);
 }
 #endif
 
@@ -371,6 +410,19 @@ static ULONG xbios_f(WORD speed, WORD flowctl, WORD ucr, WORD rsr, WORD tsr, WOR
 }
 #endif
 
+#if defined(__arm__)
+/*
+ * ARM's trap entry only delivers 4 real arguments in registers; rsconf()
+ * needs 6, so it's called through the vec table via this trampoline
+ * instead, unpacking a struct pointer. See arch/arm/biosargs.h.
+ */
+static ULONG xbios_f_arm(struct xbios_rsconf_args *a)
+{
+    return rsconf((WORD)a->baud, (WORD)a->ctrl, (WORD)a->ucr, (WORD)a->rsr,
+                  (WORD)a->tsr, (WORD)a->scr);
+}
+#endif
+
 
 
 /*
@@ -463,6 +515,15 @@ static LONG xbios_13(WORD *buf, LONG filler, WORD devno, WORD sectno,
 {
     kprintf("XBIOS: Flopver()\n");
     return flopver(buf, filler, devno, sectno, trackno, sideno, count);
+}
+#endif
+
+#if defined(__arm__)
+/* See xbios_8_arm above. */
+static LONG xbios_13_arm(struct xbios_flop_io_args *a)
+{
+    return flopver((WORD *)a->buf, a->filler, (WORD)a->dev, (WORD)a->sect,
+                   (WORD)a->track, (WORD)a->side, (WORD)a->count);
 }
 #endif
 
@@ -1093,9 +1154,15 @@ const PFLONG xbios_vecs[] = {
     VEC(xbios_5, setscreen),
     VEC(xbios_6, setpalette),
     VEC(xbios_7, setcolor),
+#if defined(__arm__)
+    (PFLONG) xbios_8_arm,
+    (PFLONG) xbios_9_arm,
+    (PFLONG) xbios_a_arm,
+#else
     VEC(xbios_8, floprd),
     VEC(xbios_9, flopwr),
     VEC(xbios_a, flopfmt),
+#endif
     xbios_unimpl,   /*  b used_by_bios */
     VEC(xbios_c, midiws),
 #if CONF_WITH_MFP
@@ -1104,11 +1171,19 @@ const PFLONG xbios_vecs[] = {
     xbios_unimpl,   /* d */
 #endif
     VEC(xbios_e, iorec),
+#if defined(__arm__)
+    (PFLONG) xbios_f_arm,
+#else
     VEC(xbios_f, rsconf),
+#endif
     VEC(xbios_10, keytbl),
     VEC(xbios_11, random),
     VEC(xbios_12, protobt),
+#if defined(__arm__)
+    (PFLONG) xbios_13_arm,
+#else
     VEC(xbios_13, flopver),
+#endif
     xbios_unimpl,   /* 14 scrdmp */
     VEC(xbios_15, cursconf),
     VEC(xbios_16, settime),

--- a/bios/xbios.c
+++ b/bios/xbios.c
@@ -38,7 +38,7 @@
 #include "vectors.h"
 #include "xbios.h"
 #if defined(__arm__)
-#include "arch/arm/biosargs.h"
+#include "biosargs.h"
 #endif
 
 #define DBG_XBIOS        0

--- a/include/arch/arm/biosargs.h
+++ b/include/arch/arm/biosargs.h
@@ -13,16 +13,24 @@
 #include "portab.h"
 
 /*
- * _biostrap/_xbiostrap (vectorsasm.S) call the vectored handler with at
- * most 4 real arguments in r0-r3 -- that's all _arm_dispatch_svc's callers
- * put in registers, and nothing marshals a 5th+ argument to the stack.
- * The handful of BIOS/XBIOS functions that need more than that (Rwabs/
- * Lrwabs, Floprd/Flopwr/Flopver, Flopfmt, Rsconf) take a pointer to one of
- * these structs as their single real argument instead, on ARM only.
+ * _biostrap/_xbiostrap (bios/arch/arm/vectorsasm.S) call the vectored
+ * handler with at most 4 real arguments in r0-r3 -- that's all
+ * _arm_dispatch_svc's callers put in registers, and nothing marshals a
+ * 5th+ argument to the stack. The handful of BIOS/XBIOS functions that
+ * need more than that (Rwabs/Lrwabs, Floprd/Flopwr/Flopver, Flopfmt,
+ * Rsconf) take a pointer to one of these structs as their single real
+ * argument instead, on ARM only.
  *
- * This is part of the trap ABI shared with libcmini's ARM osbind.h
+ * Used on both ends of that call: the ARM trampolines in bios/bios.c and
+ * bios/xbios.c (the callee, unpacking the struct) and the ARM branches of
+ * include/biosbind.h and include/xbiosbind.h's own bios_l_wlwwwl/
+ * xbios_w_llwwwww/xbios_w_llwwwwwlw/xbios_v_wwwwww (the caller, for
+ * pTOS-internal code that invokes BIOS/XBIOS via the trap rather than
+ * calling the handler directly).
+ *
+ * This is also part of the trap ABI shared with libcmini's ARM osbind.h
  * (include/mint/arch/arm/biosargs.h in the libcmini repo) -- keep the
- * field order and types in sync between the two.
+ * field order and types in sync across all three.
  */
 
 struct bios_lrwabs_args         /* Rwabs/Lrwabs -- BIOS function 0x04 */

--- a/include/biosbind.h
+++ b/include/biosbind.h
@@ -16,6 +16,10 @@
 #ifndef BIOSBIND_H
 #define BIOSBIND_H
 
+#ifdef __arm__
+#include "biosargs.h"
+#endif
+
 #define Getmpb(a) bios_v_l(0x0,a)
 #define Bconstat(a) bios_w_w(0x1,a)
 #define Bconin(a) bios_l_w(0x2,a)
@@ -241,19 +245,28 @@ static __inline__ long
 bios_l_wlwwwl(int op, short a, long b, short c, short d, short e, long f)
 {
 #ifdef __arm__
+    /*
+     * lrwabs() needs 6 real arguments; _biostrap only delivers 4 in
+     * registers, so pass them via a bios_lrwabs_args struct instead
+     * (biosargs.h). See kelihlodversson/pTOS#217.
+     */
+    struct bios_lrwabs_args args;
     register long _r0 __asm__("r0")=(long)(op);
-    register long _r1 __asm__("r1")=(long)(a);
-    register long _r2 __asm__("r2")=(long)(b);
-    register long _r3 __asm__("r3")=(long)(c);
-    register long _r4 __asm__("r4")=(long)(d);
-    register long _r5 __asm__("r5")=(long)(e);
+    register long _r1 __asm__("r1");
+
+    args.r_w = a;
+    args.adr = (void *)b;
+    args.numb = c;
+    args.first = d;
+    args.drive = e;
+    args.lfirst = f;
+    _r1 = (long)&args;
+
     __asm__ volatile (
         "svc 13"
-        : "=r"(_r0),
-          /* r1-r3 are marked as output, as they are clobbered, but since they are used for input, we can't put them in the clobber list */
-          "=r"(_r1), "=r"(_r2), "=r"(_r3)
-        : "r"(_r0), "r"(_r1), "r"(_r2), "r"(_r3), "r"(_r4), "r"(_r5)
-        : "r12", "lr",  "memory", "cc"
+        : "=r"(_r0)
+        : "r"(_r0), "r"(_r1)
+        : "r2", "r3", "r4", "r12", "lr",  "memory", "cc"
     );
     return _r0;
 #else

--- a/include/xbiosbind.h
+++ b/include/xbiosbind.h
@@ -16,6 +16,10 @@
 #ifndef XBIOSBIND_H
 #define XBIOSBIND_H
 
+#ifdef __arm__
+#include "biosargs.h"
+#endif
+
 #define Initmous(a,b,c) xbios_v_wll(0,a,(long)(b),(long)(c))
 #define Ssbrk(a) xbios_l_w(1,a)
 #define Physbase() xbios_l_v(2)
@@ -234,18 +238,28 @@ static __inline__ void
 xbios_v_wwwwww(int op, short a, short b, short c, short d, short e, short f)
 {
 #ifdef __arm__
+    /*
+     * rsconf() needs 6 real arguments; _xbiostrap only delivers 4 in
+     * registers, so pass them via a xbios_rsconf_args struct instead
+     * (biosargs.h). See kelihlodversson/pTOS#217.
+     */
+    struct xbios_rsconf_args args;
     register long _r0 __asm__("r0")=(long)(op);
-    register long _r1 __asm__("r1")=(long)(a);
-    register long _r2 __asm__("r2")=(long)(b);
-    register long _r3 __asm__("r3")=(long)(c);
-    register long _r4 __asm__("r4")=(long)(d);
-    register long _r5 __asm__("r5")=(long)(e);
-    register long _r6 __asm__("r6")=(long)(f);
+    register long _r1 __asm__("r1");
+
+    args.baud = a;
+    args.ctrl = b;
+    args.ucr = c;
+    args.rsr = d;
+    args.tsr = e;
+    args.scr = f;
+    _r1 = (long)&args;
+
     __asm__ volatile (
         "svc 14"
         :
-        : "r"(_r0), "r"(_r1), "r"(_r2), "r"(_r3), "r"(_r4), "r"(_r5), "r"(_r6)
-        : "r12", "lr",  "memory", "cc"
+        : "r"(_r0), "r"(_r1)
+        : "r2", "r3", "r4", "r12", "lr",  "memory", "cc"
     );
 #else
     __asm__ volatile (
@@ -436,19 +450,29 @@ static __inline__ short xbios_w_llwwwww(int op,
     long a, long b, short c, short d, short e, short f, short g)
 {
 #ifdef __arm__
+    /*
+     * floprd()/flopwr()/flopver() need 7 real arguments; _xbiostrap only
+     * delivers 4 in registers, so pass them via a xbios_flop_io_args
+     * struct instead (biosargs.h). See kelihlodversson/pTOS#217.
+     */
+    struct xbios_flop_io_args args;
     register long _r0 __asm__("r0")=(long)(op);
-    register long _r1 __asm__("r1")=(long)(a);
-    register long _r2 __asm__("r2")=(long)(b);
-    register long _r3 __asm__("r3")=(long)(c);
-    register long _r4 __asm__("r4")=(long)(d);
-    register long _r5 __asm__("r5")=(long)(e);
-    register long _r6 __asm__("r6")=(long)(f);
-    register long _r7 __asm__("r7")=(long)(g);
+    register long _r1 __asm__("r1");
+
+    args.buf = (void *)a;
+    args.filler = b;
+    args.dev = c;
+    args.sect = d;
+    args.track = e;
+    args.side = f;
+    args.count = g;
+    _r1 = (long)&args;
+
     __asm__ volatile (
         "svc 14"
         : "=r"(_r0)
-        : "r"(_r0), "r"(_r1), "r"(_r2), "r"(_r3), "r"(_r4), "r"(_r5), "r"(_r6), "r"(_r7)
-        : "r12", "lr",  "memory", "cc"
+        : "r"(_r0), "r"(_r1)
+        : "r2", "r3", "r4", "r12", "lr",  "memory", "cc"
     );
     return _r0;
 #else
@@ -478,21 +502,31 @@ static __inline__ short xbios_w_llwwwwwlw(int op,
     long a, long b, short c, short d, short e, short f, short g, long h, short i)
 {
 #ifdef __arm__
+    /*
+     * flopfmt() needs 9 real arguments; _xbiostrap only delivers 4 in
+     * registers, so pass them via a xbios_flopfmt_args struct instead
+     * (biosargs.h). See kelihlodversson/pTOS#217.
+     */
+    struct xbios_flopfmt_args args;
     register long _r0 __asm__("r0")=(long)(op);
-    register long _r1 __asm__("r1")=(long)(a);
-    register long _r2 __asm__("r2")=(long)(b);
-    register long _r3 __asm__("r3")=(long)(c);
-    register long _r4 __asm__("r4")=(long)(d);
-    register long _r5 __asm__("r5")=(long)(e);
-    register long _r6 __asm__("r6")=(long)(f);
-    register long _r7 __asm__("r7")=(long)(g);
-    register long _r8 __asm__("r8")=(long)(h);
-    register long _r9 __asm__("r9")=(long)(i);
+    register long _r1 __asm__("r1");
+
+    args.buf = (void *)a;
+    args.skew = (void *)b;
+    args.dev = c;
+    args.spt = d;
+    args.track = e;
+    args.side = f;
+    args.interlv = g;
+    args.magic = h;
+    args.virgin = i;
+    _r1 = (long)&args;
+
     __asm__ volatile (
         "svc 14"
         : "=r"(_r0)
-        : "r"(_r0), "r"(_r1), "r"(_r2), "r"(_r3), "r"(_r4), "r"(_r5), "r"(_r6), "r"(_r7), "r"(_r8), "r"(_r9)
-        : "r12", "lr",  "memory", "cc"
+        : "r"(_r0), "r"(_r1)
+        : "r2", "r3", "r4", "r12", "lr",  "memory", "cc"
     );
     return _r0;
 #else


### PR DESCRIPTION
Fixes #217

## Summary

`_biostrap`/`_xbiostrap` (`bios/arch/arm/vectorsasm.S`) only deliver 4 real arguments in registers to the vectored handler. `lrwabs` (`Rwabs`/`Lrwabs`), `floprd`/`flopwr`/`flopver`, `flopfmt` and `rsconf` need 6-9 real parameters, so calling any of them through the trap table today would have the callee read whatever `_biostrap` happened to have pushed for its own register preservation, not caller-supplied data — see #217 for the full analysis.

## Fix

Cap the ARM BIOS/XBIOS trap ABI at 4 real arguments (matching what `_biostrap`/`_xbiostrap` already deliver correctly) and give the five affected calls an ARM-only trampoline that takes a single pointer to a packed argument struct (`bios/arch/arm/biosargs.h`) instead of their normal parameter list. Each trampoline just unpacks the struct and calls the existing, unmodified handler (`lrwabs`/`floprd`/`flopwr`/`flopfmt`/`flopver`/`rsconf`) — those functions, and every other BIOS/XBIOS handler, are untouched. Only the six affected `bios_vecs[]`/`xbios_vecs[]` entries differ between ARM and m68k; everything else keeps using the same `VEC()` macro as before.

`_biostrap`/`_xbiostrap` themselves needed no changes — the fix stays entirely within the 4-register mechanism that already works.

This is a deliberate, ARM-specific deviation from the scalar-argument convention real 68k TOS/EmuTOS uses for these calls, since this is pTOS's own new ARM ABI rather than something bound to 68k binary compatibility.

## Not in this PR

Pointer validation for the struct address (or any other user pointer) once pTOS gets proper memory protection — same class of future work as every other pointer argument these calls already take.

## Verification

- ARM (`virt-arm_defconfig`): full image builds cleanly with the real `arm-none-eabi` toolchain; `bios.o`/`xbios.o` rebuilt in isolation produce no new warnings (only the pre-existing, unrelated `-Warray-bounds` false positives on fixed low-memory vector addresses).
- m68k (`atari512_defconfig`): full image builds cleanly with the real `m68k-atari-mintelf` toolchain; `bios.o`/`xbios.o` produce zero warnings — confirms no regression, since the changed files are shared between architectures.
- Cross-checked the register layout against `kelihlodversson/libcmini#6`, which implements the matching caller-side primitives and disassembles to the expected struct-build + `svc` sequence with the struct pointer landing in the exact register `_biostrap`/`_xbiostrap`'s shift delivers as the callee's first argument.
