### PR TITLE
ARM: deprecate Supexec, add Ssystem-based system variable access

### DIFF
--- a/bdos/bdosmain.c
+++ b/bdos/bdosmain.c
@@ -434,20 +434,19 @@ long osif(short *pw)
 restrt:
     fn = pw[0];
 
+#ifdef __arm__
     /*
      * Ssystem() (0x154) is far outside the funcs[] table above, and
      * unlike every other call handled through it, its arguments don't
      * follow the table's implicit stdio/handle conventions -- so it's
      * special-cased here instead of getting its own funcs[] slot.
+     * ARM only: real m68k TOS software already has Supexec() and direct
+     * memory access for this, and the smallest m68k ROM images (see
+     * release.mk) have no code size to spare for a second way to do it.
      */
     if (fn == GEMDOS_SSYSTEM)
-    {
-#ifdef __arm__
         return xssystem((WORD)pw[1], pw[2], pw[3]);
-#else
-        return xssystem((WORD)pw[1], *(LONG *)&pw[2], *(LONG *)&pw[4]);
 #endif
-    }
 
     if (fn > MAX_FNCALL)
         return EINVFN;

--- a/bdos/bdosmain.c
+++ b/bdos/bdosmain.c
@@ -33,6 +33,7 @@
 #include "string.h"
 #include "kprint.h"
 #include "dos.h"
+#include "ssystem.h"
 
 /*
 **  externals
@@ -432,6 +433,22 @@ long osif(short *pw)
 
 restrt:
     fn = pw[0];
+
+    /*
+     * Ssystem() (0x154) is far outside the funcs[] table above, and
+     * unlike every other call handled through it, its arguments don't
+     * follow the table's implicit stdio/handle conventions -- so it's
+     * special-cased here instead of getting its own funcs[] slot.
+     */
+    if (fn == GEMDOS_SSYSTEM)
+    {
+#ifdef __arm__
+        return xssystem((WORD)pw[1], pw[2], pw[3]);
+#else
+        return xssystem((WORD)pw[1], *(LONG *)&pw[2], *(LONG *)&pw[4]);
+#endif
+    }
+
     if (fn > MAX_FNCALL)
         return EINVFN;
 

--- a/bdos/build.mk
+++ b/bdos/build.mk
@@ -4,5 +4,5 @@
 
 obj-y += bdosmain.o console.o fsbuf.o fsdir.o fsdrive.o fsfat.o fsglob.o \
 	 fshand.o fsio.o fsmain.o fsopnclo.o iumem.o kpgmld.o osmem.o \
-	 proc.o time.o umem.o rwa.o
+	 proc.o ssystem.o time.o umem.o rwa.o
 obj-$(CONF_WITH_ELF_LOADER) += elfld.o

--- a/bdos/build.mk
+++ b/bdos/build.mk
@@ -4,5 +4,9 @@
 
 obj-y += bdosmain.o console.o fsbuf.o fsdir.o fsdrive.o fsfat.o fsglob.o \
 	 fshand.o fsio.o fsmain.o fsopnclo.o iumem.o kpgmld.o osmem.o \
-	 proc.o ssystem.o time.o umem.o rwa.o
+	 proc.o time.o umem.o rwa.o
 obj-$(CONF_WITH_ELF_LOADER) += elfld.o
+
+# Ssystem() (bdos/ssystem.c) is ARM only -- see the comment in
+# osif() (bdos/bdosmain.c).
+obj-$(ARCH_ARM) += ssystem.o

--- a/bdos/fsbuf.c
+++ b/bdos/fsbuf.c
@@ -23,7 +23,13 @@
 #include "string.h"
 #include "kprint.h"
 
+#ifdef __arm__
+BCB *bufl[2];           /* buffer lists - two lists:  FAT and dir/data --
+                         * fixed address on m68k (tosvars.ld), ordinary
+                         * storage here (#219) */
+#else
 extern BCB *bufl[];     /* buffer lists - two lists:  FAT and dir/data */
+#endif
 
 #define NUMBUFS 2       /* buffers per list */
 

--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -120,33 +120,68 @@ static void *sval_lookup(const SVAR *table, int count, ULONG addr)
  * ssystem_getcookie/ssystem_setcookie/ssystem_delcookie -
  * S_GETCOOKIE/S_SETCOOKIE/S_DELCOOKIE
  *
- * only the plain by-tag lookup is supported (not the undocumented
- * slot-enumeration behaviour of the real ABI)
+ * S_GETCOOKIE overloads arg1 three ways -- required for code that
+ * wants to enumerate every installed cookie, not just look one up by
+ * a tag it already knows:
+ *   - arg1 > 0xffff: a tag, look up its value (the common case)
+ *   - 1 <= arg1 <= 0xffff: a 1-based slot number, look up the tag
+ *     stored there -- ERR once past the jar's allocated capacity, so
+ *     a caller can enumerate by counting 1, 2, 3, ... until either a
+ *     zero tag (no more cookies) or ERR (ran off the end)
+ *   - arg1 == 0: look up the NULL cookie's value, i.e. the jar's
+ *     total allocated capacity (the terminator slot always carries
+ *     this in .value, wherever it currently sits)
  */
-static LONG ssystem_getcookie(LONG tag, LONG arg2)
+static LONG ssystem_getcookie(LONG arg1, LONG arg2)
 {
-    struct cookie *jar;
+    struct cookie *jar = (struct cookie *)p_cookies;
+    struct cookie *term;
+    LONG capacity, result;
 
-    for (jar = (struct cookie *)p_cookies; jar->tag; jar++)
+    if ((ULONG)arg1 > 0xffffUL)
     {
-        if (jar->tag == tag)
+        for (; jar->tag; jar++)
         {
-            /*
-             * with a destination pointer, the documented usage is
-             * Ssystem(S_GETCOOKIE, tag, &value) == E_OK -- returning
-             * the (possibly nonzero) cookie value here instead would
-             * look like failure to that idiom.
-             */
-            if (arg2)
+            if (jar->tag == arg1)
             {
-                *(LONG *)arg2 = jar->value;
-                return E_OK;
+                /*
+                 * with a destination pointer, the documented usage is
+                 * Ssystem(S_GETCOOKIE, tag, &value) == E_OK --
+                 * returning the (possibly nonzero) cookie value here
+                 * instead would look like failure to that idiom.
+                 */
+                if (arg2)
+                {
+                    *(LONG *)arg2 = jar->value;
+                    return E_OK;
+                }
+                return jar->value;
             }
-            return jar->value;
         }
+        return ERR;
     }
 
-    return ERR;
+    for (term = jar; term->tag; term++)
+        /* find the terminator */;
+    capacity = term->value;
+
+    if (arg1 == 0)
+    {
+        result = capacity;
+    }
+    else
+    {
+        if (arg1 > capacity)
+            return ERR;
+        result = jar[arg1 - 1].tag;
+    }
+
+    if (arg2)
+    {
+        *(LONG *)arg2 = result;
+        return E_OK;
+    }
+    return result;
 }
 
 static LONG ssystem_setcookie(LONG tag, LONG value)

--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -1,0 +1,245 @@
+/*
+ * ssystem.c - GEMDOS Ssystem() -- the cookie jar and system variables,
+ * without direct memory access or Supexec()
+ *
+ * Ssystem() is the documented (MiNT) mechanism for a program to read or
+ * write a handful of system variables and the cookie jar without poking
+ * memory directly. pTOS implements only the S_[GS]ET(COOKIE|[LWB]VAL)
+ * subset -- see ssystem.h and issue #219 for the rationale, in
+ * particular for ARM, where Supexec() (the usual way real TOS programs
+ * would do this) isn't supported.
+ *
+ * The *VAL modes never touch raw memory: the "address" argument is the
+ * documented TOS address of the variable, looked up in one of three
+ * width-specific tables that map it to wherever pTOS actually stores
+ * that variable. An address that isn't in the table for the requested
+ * width -- because the width is wrong, or the variable isn't one pTOS
+ * implements -- returns EINVFN, same as an unknown mode.
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "config.h"
+#include "portab.h"
+#include "ssystem.h"
+#include "gemerror.h"
+#include "../bios/tosvars.h"
+#include "../bios/cookie.h"
+
+/*
+ * one lookup table per width, each mapping the documented TOS address
+ * of a system variable to pTOS's actual storage for it
+ */
+typedef struct {
+    ULONG addr;
+    void *ptr;
+} SVAR;
+
+#define SVAR_ENTRY(a, sym) { (a), (void *)&(sym) }
+
+static const SVAR lval_table[] = {
+    SVAR_ENTRY(0x400, etv_timer),
+    SVAR_ENTRY(0x404, etv_critic),
+    SVAR_ENTRY(0x408, etv_term),
+    SVAR_ENTRY(0x42e, phystop),
+    SVAR_ENTRY(0x432, membot),
+    SVAR_ENTRY(0x436, memtop),
+    SVAR_ENTRY(0x44e, v_bas_ad),
+    SVAR_ENTRY(0x45a, colorptr),
+    SVAR_ENTRY(0x456, vblqueue),
+    SVAR_ENTRY(0x466, frclock),
+    SVAR_ENTRY(0x46a, hdv_init),
+    SVAR_ENTRY(0x472, hdv_bpb),
+    SVAR_ENTRY(0x476, hdv_rw),
+    SVAR_ENTRY(0x47a, hdv_boot),
+    SVAR_ENTRY(0x47e, hdv_mediach),
+    SVAR_ENTRY(0x4a2, savptr),
+    SVAR_ENTRY(0x4ba, hz_200),
+    SVAR_ENTRY(0x4c2, drvbits),
+    SVAR_ENTRY(0x4c6, dskbufp),
+    SVAR_ENTRY(0x4f2, sysbase),
+    SVAR_ENTRY(0x4fa, end_os),
+    SVAR_ENTRY(0x4fe, exec_os),
+    SVAR_ENTRY(0x502, dump_vec),
+    SVAR_ENTRY(0x506, prt_stat),
+    SVAR_ENTRY(0x50a, prt_vec),
+    SVAR_ENTRY(0x50e, aux_stat),
+    SVAR_ENTRY(0x512, aux_vec),
+    SVAR_ENTRY(0x5ac, bell_hook),
+    SVAR_ENTRY(0x5b0, kcl_hook),
+};
+
+static const SVAR wval_table[] = {
+    SVAR_ENTRY(0x43e, flock),
+    SVAR_ENTRY(0x440, seekrate),
+    SVAR_ENTRY(0x442, timer_ms),
+    SVAR_ENTRY(0x444, fverify),
+    SVAR_ENTRY(0x446, bootdev),
+    SVAR_ENTRY(0x452, vblsem),
+    SVAR_ENTRY(0x454, nvbls),
+    SVAR_ENTRY(0x482, cmdload),
+    SVAR_ENTRY(0x4a6, nflops),
+    SVAR_ENTRY(0x4ac, save_row),
+    SVAR_ENTRY(0x4ee, dumpflg),
+};
+
+static const SVAR bval_table[] = {
+    SVAR_ENTRY(0x44a, defshiftmod),
+    SVAR_ENTRY(0x44c, sshiftmod),
+    SVAR_ENTRY(0x484, conterm),
+};
+
+#undef SVAR_ENTRY
+
+
+static void *sval_lookup(const SVAR *table, int count, ULONG addr)
+{
+    int i;
+
+    for (i = 0; i < count; i++)
+        if (table[i].addr == addr)
+            return table[i].ptr;
+
+    return NULL;
+}
+
+#define SVAL_LOOKUP(table, addr) sval_lookup(table, ARRAY_SIZE(table), (addr))
+
+
+/*
+ * ssystem_getcookie/ssystem_setcookie - S_GETCOOKIE/S_SETCOOKIE
+ *
+ * only the plain by-tag lookup is supported (not the undocumented
+ * slot-enumeration behaviour of the real ABI)
+ */
+static LONG ssystem_getcookie(LONG tag, LONG arg2)
+{
+    struct cookie *jar;
+
+    for (jar = (struct cookie *)p_cookies; jar->tag; jar++)
+    {
+        if (jar->tag == tag)
+        {
+            if (arg2)
+                *(LONG *)arg2 = jar->value;
+            return jar->value;
+        }
+    }
+
+    return -1;
+}
+
+static LONG ssystem_setcookie(LONG tag, LONG value)
+{
+    struct cookie *jar = (struct cookie *)p_cookies;
+    LONG capacity;
+
+    while (jar->tag)
+    {
+        if (jar->tag == tag)
+        {
+            jar->value = value;
+            return E_OK;
+        }
+        jar++;
+    }
+
+    capacity = jar->value;      /* the terminator slot holds the jar's capacity */
+    if ((jar - (struct cookie *)p_cookies) >= capacity - 1)
+        return ENSMEM;          /* jar full */
+
+    jar->tag = tag;
+    jar->value = value;
+    jar[1].tag = 0;
+    jar[1].value = capacity;
+
+    return E_OK;
+}
+
+
+/*
+ * ssystem_getval/ssystem_setval - S_GET[LWB]VAL/S_SET[LWB]VAL
+ */
+static LONG ssystem_getlval(LONG addr)
+{
+    void *p = SVAL_LOOKUP(lval_table, addr);
+    if (!p)
+        return EINVFN;
+    return *(LONG *)p;
+}
+
+static LONG ssystem_getwval(LONG addr)
+{
+    void *p = SVAL_LOOKUP(wval_table, addr);
+    if (!p)
+        return EINVFN;
+    return *(WORD *)p;
+}
+
+static LONG ssystem_getbval(LONG addr)
+{
+    void *p = SVAL_LOOKUP(bval_table, addr);
+    if (!p)
+        return EINVFN;
+    return *(BYTE *)p;
+}
+
+static LONG ssystem_setlval(LONG addr, LONG value)
+{
+    void *p = SVAL_LOOKUP(lval_table, addr);
+    if (!p)
+        return EINVFN;
+    *(LONG *)p = value;
+    return E_OK;
+}
+
+static LONG ssystem_setwval(LONG addr, LONG value)
+{
+    void *p = SVAL_LOOKUP(wval_table, addr);
+    if (!p)
+        return EINVFN;
+    *(WORD *)p = (WORD)value;
+    return E_OK;
+}
+
+static LONG ssystem_setbval(LONG addr, LONG value)
+{
+    void *p = SVAL_LOOKUP(bval_table, addr);
+    if (!p)
+        return EINVFN;
+    *(BYTE *)p = (BYTE)value;
+    return E_OK;
+}
+
+
+/*
+ * xssystem - implements GEMDOS Ssystem(), see ssystem.h
+ */
+LONG xssystem(WORD mode, LONG arg1, LONG arg2)
+{
+    switch (mode)
+    {
+    case S_GETCOOKIE:
+        return ssystem_getcookie(arg1, arg2);
+    case S_SETCOOKIE:
+        return ssystem_setcookie(arg1, arg2);
+
+    case S_GETLVAL:
+        return ssystem_getlval(arg1);
+    case S_GETWVAL:
+        return ssystem_getwval(arg1);
+    case S_GETBVAL:
+        return ssystem_getbval(arg1);
+
+    case S_SETLVAL:
+        return ssystem_setlval(arg1, arg2);
+    case S_SETWVAL:
+        return ssystem_setwval(arg1, arg2);
+    case S_SETBVAL:
+        return ssystem_setbval(arg1, arg2);
+
+    default:
+        return EINVFN;
+    }
+}

--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -27,6 +27,7 @@
 #include "../bios/tosvars.h"
 #include "../bios/cookie.h"
 #include "../include/ahdi.h"
+#include "string.h"
 
 /* not in tosvars.h -- only bios/arch/arm/vectors.c otherwise uses it */
 extern volatile LONG vbclock;
@@ -166,29 +167,41 @@ static LONG ssystem_setcookie(LONG tag, LONG value)
 
 /*
  * ssystem_getval/ssystem_setval - S_GET[LWB]VAL/S_SET[LWB]VAL
+ *
+ * Several of the looked-up variables are pointers or function pointers,
+ * not LONG/WORD/BYTE objects, so this copies through memcpy() rather
+ * than dereferencing p through an unrelated scalar type -- the latter
+ * violates C's strict-aliasing/effective-type rules and can miscompile
+ * under optimization even though it happens to work today.
  */
 static LONG ssystem_getlval(LONG addr)
 {
     void *p = SVAL_LOOKUP(lval_table, addr);
+    LONG value;
     if (!p)
         return EINVFN;
-    return *(LONG *)p;
+    memcpy(&value, p, sizeof(value));
+    return value;
 }
 
 static LONG ssystem_getwval(LONG addr)
 {
     void *p = SVAL_LOOKUP(wval_table, addr);
+    WORD value;
     if (!p)
         return EINVFN;
-    return *(WORD *)p;
+    memcpy(&value, p, sizeof(value));
+    return value;
 }
 
 static LONG ssystem_getbval(LONG addr)
 {
     void *p = SVAL_LOOKUP(bval_table, addr);
+    BYTE value;
     if (!p)
         return EINVFN;
-    return *(BYTE *)p;
+    memcpy(&value, p, sizeof(value));
+    return value;
 }
 
 static LONG ssystem_setlval(LONG addr, LONG value)
@@ -196,25 +209,27 @@ static LONG ssystem_setlval(LONG addr, LONG value)
     void *p = SVAL_LOOKUP(lval_table, addr);
     if (!p)
         return EINVFN;
-    *(LONG *)p = value;
+    memcpy(p, &value, sizeof(value));
     return E_OK;
 }
 
 static LONG ssystem_setwval(LONG addr, LONG value)
 {
     void *p = SVAL_LOOKUP(wval_table, addr);
+    WORD wvalue = (WORD)value;
     if (!p)
         return EINVFN;
-    *(WORD *)p = (WORD)value;
+    memcpy(p, &wvalue, sizeof(wvalue));
     return E_OK;
 }
 
 static LONG ssystem_setbval(LONG addr, LONG value)
 {
     void *p = SVAL_LOOKUP(bval_table, addr);
+    BYTE bvalue = (BYTE)value;
     if (!p)
         return EINVFN;
-    *(BYTE *)p = (BYTE)value;
+    memcpy(p, &bvalue, sizeof(bvalue));
     return E_OK;
 }
 

--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -28,7 +28,7 @@
 #include "gemerror.h"
 #include "../bios/tosvars.h"
 #include "../bios/cookie.h"
-#include "../include/ahdi.h"
+#include "ahdi.h"
 #include "string.h"
 
 /* not in tosvars.h -- only bios/arch/arm/vectors.c otherwise uses it */
@@ -236,13 +236,33 @@ static LONG ssystem_delcookie(LONG tag)
 
 
 /*
- * ssystem_getval/ssystem_setval - S_GET[LWB]VAL/S_SET[LWB]VAL
+ * svar_copy - like memcpy(), but through volatile UBYTE * so the
+ * access can't be cached, reordered, or optimized away.
  *
- * Several of the looked-up variables are pointers or function pointers,
- * not LONG/WORD/BYTE objects, so this copies through memcpy() rather
- * than dereferencing p through an unrelated scalar type -- the latter
- * violates C's strict-aliasing/effective-type rules and can miscompile
- * under optimization even though it happens to work today.
+ * Several of the looked-up sysvars are pointers or function pointers,
+ * not LONG/WORD/BYTE objects, so this can't just dereference p through
+ * an unrelated scalar type -- that violates C's strict-aliasing/
+ * effective-type rules and can miscompile under optimization even
+ * though it happens to work today. A byte-at-a-time UBYTE access is
+ * always strict-aliasing-safe (any object's representation can be
+ * accessed through a character type). But several of these sysvars
+ * are also volatile (hz_200, frclock, vblsem, flock, vbclock, ...),
+ * updated from interrupt context, and memcpy()'s plain void*
+ * parameters silently drop that qualifier -- accessing through
+ * volatile UBYTE * keeps every individual byte access an observable
+ * side effect regardless of the pointed-to object's declared type.
+ */
+static void svar_copy(void *dst, const void *src, size_t n)
+{
+    volatile UBYTE *d = dst;
+    const volatile UBYTE *s = src;
+
+    while (n--)
+        *d++ = *s++;
+}
+
+/*
+ * ssystem_getval/ssystem_setval - S_GET[LWB]VAL/S_SET[LWB]VAL
  */
 static LONG ssystem_getlval(LONG addr)
 {
@@ -250,7 +270,7 @@ static LONG ssystem_getlval(LONG addr)
     LONG value;
     if (!p)
         return EINVFN;
-    memcpy(&value, p, sizeof(value));
+    svar_copy(&value, p, sizeof(value));
     return value;
 }
 
@@ -260,7 +280,7 @@ static LONG ssystem_getwval(LONG addr)
     UWORD value;    /* zero-extended into the LONG result, matching FreeMiNT */
     if (!p)
         return EINVFN;
-    memcpy(&value, p, sizeof(value));
+    svar_copy(&value, p, sizeof(value));
     return value;
 }
 
@@ -270,7 +290,7 @@ static LONG ssystem_getbval(LONG addr)
     UBYTE value;    /* zero-extended into the LONG result, matching FreeMiNT */
     if (!p)
         return EINVFN;
-    memcpy(&value, p, sizeof(value));
+    svar_copy(&value, p, sizeof(value));
     return value;
 }
 
@@ -279,7 +299,7 @@ static LONG ssystem_setlval(LONG addr, LONG value)
     void *p = SVAL_LOOKUP(lval_table, addr);
     if (!p)
         return EINVFN;
-    memcpy(p, &value, sizeof(value));
+    svar_copy(p, &value, sizeof(value));
     return E_OK;
 }
 
@@ -289,7 +309,7 @@ static LONG ssystem_setwval(LONG addr, LONG value)
     WORD wvalue = (WORD)value;
     if (!p)
         return EINVFN;
-    memcpy(p, &wvalue, sizeof(wvalue));
+    svar_copy(p, &wvalue, sizeof(wvalue));
     return E_OK;
 }
 
@@ -299,7 +319,7 @@ static LONG ssystem_setbval(LONG addr, LONG value)
     BYTE bvalue = (BYTE)value;
     if (!p)
         return EINVFN;
-    memcpy(p, &bvalue, sizeof(bvalue));
+    svar_copy(p, &bvalue, sizeof(bvalue));
     return E_OK;
 }
 

--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -26,6 +26,10 @@
 #include "gemerror.h"
 #include "../bios/tosvars.h"
 #include "../bios/cookie.h"
+#include "../include/ahdi.h"
+
+/* not in tosvars.h -- only bios/arch/arm/vectors.c otherwise uses it */
+extern volatile LONG vbclock;
 
 /*
  * one lookup table per width, each mapping the documented TOS address
@@ -48,6 +52,7 @@ static const SVAR lval_table[] = {
     SVAR_ENTRY(0x44e, v_bas_ad),
     SVAR_ENTRY(0x45a, colorptr),
     SVAR_ENTRY(0x456, vblqueue),
+    SVAR_ENTRY(0x462, vbclock),
     SVAR_ENTRY(0x466, frclock),
     SVAR_ENTRY(0x46a, hdv_init),
     SVAR_ENTRY(0x472, hdv_bpb),
@@ -66,6 +71,7 @@ static const SVAR lval_table[] = {
     SVAR_ENTRY(0x50a, prt_vec),
     SVAR_ENTRY(0x50e, aux_stat),
     SVAR_ENTRY(0x512, aux_vec),
+    SVAR_ENTRY(0x516, pun_ptr),
     SVAR_ENTRY(0x5ac, bell_hook),
     SVAR_ENTRY(0x5b0, kcl_hook),
 };

--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -5,10 +5,11 @@
  * Ssystem() is the documented (MiNT) mechanism for a program to read or
  * write a handful of system variables and the cookie jar without poking
  * memory directly. pTOS implements S_INQUIRE (the mandatory discovery
- * probe -- see xssystem() below) plus the S_[GS]ET(COOKIE|[LWB]VAL)
- * subset -- see ssystem.h and issue #219 for the rationale, in
- * particular for ARM, where Supexec() (the usual way real TOS programs
- * would do this) isn't supported.
+ * probe -- see xssystem() below), S_OSNAME/S_OSVERSION, and the
+ * S_[GS]ET(COOKIE|[LWB]VAL) subset plus S_DELCOOKIE -- see ssystem.h
+ * and issue #219 for the rationale, in particular for ARM, where
+ * Supexec() (the usual way real TOS programs would do this) isn't
+ * supported.
  *
  * The *VAL modes never touch raw memory: the "address" argument is the
  * documented TOS address of the variable, looked up in one of three
@@ -116,7 +117,8 @@ static void *sval_lookup(const SVAR *table, int count, ULONG addr)
 
 
 /*
- * ssystem_getcookie/ssystem_setcookie - S_GETCOOKIE/S_SETCOOKIE
+ * ssystem_getcookie/ssystem_setcookie/ssystem_delcookie -
+ * S_GETCOOKIE/S_SETCOOKIE/S_DELCOOKIE
  *
  * only the plain by-tag lookup is supported (not the undocumented
  * slot-enumeration behaviour of the real ABI)
@@ -144,7 +146,7 @@ static LONG ssystem_getcookie(LONG tag, LONG arg2)
         }
     }
 
-    return -1;
+    return ERR;
 }
 
 static LONG ssystem_setcookie(LONG tag, LONG value)
@@ -172,6 +174,29 @@ static LONG ssystem_setcookie(LONG tag, LONG value)
     jar[1].value = capacity;
 
     return E_OK;
+}
+
+static LONG ssystem_delcookie(LONG tag)
+{
+    struct cookie *jar = (struct cookie *)p_cookies;
+    int i;
+
+    for (i = 0; jar[i].tag; i++)
+    {
+        if (jar[i].tag == tag)
+        {
+            /* shift every later entry (including the terminator, which
+             * carries the jar's capacity in .value) down by one slot */
+            do
+            {
+                jar[i] = jar[i + 1];
+                i++;
+            } while (jar[i].tag);
+            return E_OK;
+        }
+    }
+
+    return ERR;         /* tag not found -- matches ssystem_getcookie() */
 }
 
 
@@ -245,6 +270,31 @@ static LONG ssystem_setbval(LONG addr, LONG value)
 
 
 /*
+ * ssystem_osname/ssystem_osversion - S_OSNAME/S_OSVERSION
+ */
+static LONG ssystem_osname(void)
+{
+    /* four ASCII characters packed MSB-first, same convention as
+     * FreeMiNT's 'MiNT' (0x4d694e54) */
+    return ((LONG)'p' << 24) | ((LONG)'T' << 16) | ((LONG)'O' << 8) | 'S';
+}
+
+static LONG ssystem_osversion(void)
+{
+    /*
+     * major.minor.patch + release character, MSB first. pTOS has no
+     * numbered release yet -- report 0.0.0-alpha rather than
+     * repurposing GEMDOS_VERSION, which fakes a *real TOS's*
+     * compatibility number (Sversion()) and has nothing to do with
+     * pTOS's own identity.
+     */
+    LONG major = 0, minor = 0, patch = 0;
+    BYTE release = 'a';
+    return (major << 24) | (minor << 16) | (patch << 8) | (UBYTE)release;
+}
+
+
+/*
  * xssystem - implements GEMDOS Ssystem(), see ssystem.h
  */
 LONG xssystem(WORD mode, LONG arg1, LONG arg2)
@@ -259,10 +309,17 @@ LONG xssystem(WORD mode, LONG arg1, LONG arg2)
          * unhandled mode. */
         return E_OK;
 
+    case S_OSNAME:
+        return ssystem_osname();
+    case S_OSVERSION:
+        return ssystem_osversion();
+
     case S_GETCOOKIE:
         return ssystem_getcookie(arg1, arg2);
     case S_SETCOOKIE:
         return ssystem_setcookie(arg1, arg2);
+    case S_DELCOOKIE:
+        return ssystem_delcookie(arg1);
 
     case S_GETLVAL:
         return ssystem_getlval(arg1);

--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -4,7 +4,8 @@
  *
  * Ssystem() is the documented (MiNT) mechanism for a program to read or
  * write a handful of system variables and the cookie jar without poking
- * memory directly. pTOS implements only the S_[GS]ET(COOKIE|[LWB]VAL)
+ * memory directly. pTOS implements S_INQUIRE (the mandatory discovery
+ * probe -- see xssystem() below) plus the S_[GS]ET(COOKIE|[LWB]VAL)
  * subset -- see ssystem.h and issue #219 for the rationale, in
  * particular for ARM, where Supexec() (the usual way real TOS programs
  * would do this) isn't supported.
@@ -128,8 +129,17 @@ static LONG ssystem_getcookie(LONG tag, LONG arg2)
     {
         if (jar->tag == tag)
         {
+            /*
+             * with a destination pointer, the documented usage is
+             * Ssystem(S_GETCOOKIE, tag, &value) == E_OK -- returning
+             * the (possibly nonzero) cookie value here instead would
+             * look like failure to that idiom.
+             */
             if (arg2)
+            {
                 *(LONG *)arg2 = jar->value;
+                return E_OK;
+            }
             return jar->value;
         }
     }
@@ -187,7 +197,7 @@ static LONG ssystem_getlval(LONG addr)
 static LONG ssystem_getwval(LONG addr)
 {
     void *p = SVAL_LOOKUP(wval_table, addr);
-    WORD value;
+    UWORD value;    /* zero-extended into the LONG result, matching FreeMiNT */
     if (!p)
         return EINVFN;
     memcpy(&value, p, sizeof(value));
@@ -197,7 +207,7 @@ static LONG ssystem_getwval(LONG addr)
 static LONG ssystem_getbval(LONG addr)
 {
     void *p = SVAL_LOOKUP(bval_table, addr);
-    BYTE value;
+    UBYTE value;    /* zero-extended into the LONG result, matching FreeMiNT */
     if (!p)
         return EINVFN;
     memcpy(&value, p, sizeof(value));
@@ -241,6 +251,14 @@ LONG xssystem(WORD mode, LONG arg1, LONG arg2)
 {
     switch (mode)
     {
+    case S_INQUIRE:
+        /* the documented discovery probe: callers use this to decide
+         * whether to use Ssystem() at all before falling back to
+         * Supexec()/direct memory access -- which ARM doesn't have,
+         * so this must not fall through to EINVFN like every other
+         * unhandled mode. */
+        return E_OK;
+
     case S_GETCOOKIE:
         return ssystem_getcookie(arg1, arg2);
     case S_SETCOOKIE:

--- a/bdos/ssystem.h
+++ b/bdos/ssystem.h
@@ -1,0 +1,32 @@
+/*
+ * ssystem.h - GEMDOS Ssystem() -- the cookie jar and system variables,
+ * without direct memory access or Supexec()
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#ifndef SSYSTEM_H
+#define SSYSTEM_H
+
+#include "portab.h"
+
+#define GEMDOS_SSYSTEM  0x154
+
+/*
+ * Ssystem() mode values, as documented for MiNT. Only the subset below
+ * is implemented -- every other mode returns EINVFN. See
+ * https://github.com/kelihlodversson/pTOS/issues/219.
+ */
+#define S_GETCOOKIE     0x0008
+#define S_SETCOOKIE     0x0009
+#define S_GETLVAL       0x000a
+#define S_GETWVAL       0x000b
+#define S_GETBVAL       0x000c
+#define S_SETLVAL       0x000d
+#define S_SETWVAL       0x000e
+#define S_SETBVAL       0x000f
+
+LONG xssystem(WORD mode, LONG arg1, LONG arg2);
+
+#endif /* SSYSTEM_H */

--- a/bdos/ssystem.h
+++ b/bdos/ssystem.h
@@ -15,9 +15,15 @@
 
 /*
  * Ssystem() mode values, as documented for MiNT. Only the subset below
- * is implemented -- every other mode returns EINVFN. See
+ * is implemented (plus the mandatory S_INQUIRE discovery probe) --
+ * every other mode returns EINVFN. See
  * https://github.com/kelihlodversson/pTOS/issues/219.
+ *
+ * S_INQUIRE is -1, not 0xffff: mode arrives here as a signed WORD, so
+ * a case label of plain 0xffff (type int, value 65535) would never
+ * match it after the switch's usual arithmetic promotion.
  */
+#define S_INQUIRE       ((WORD)0xffff)
 #define S_GETCOOKIE     0x0008
 #define S_SETCOOKIE     0x0009
 #define S_GETLVAL       0x000a

--- a/bdos/ssystem.h
+++ b/bdos/ssystem.h
@@ -24,6 +24,8 @@
  * match it after the switch's usual arithmetic promotion.
  */
 #define S_INQUIRE       ((WORD)0xffff)
+#define S_OSNAME        0x0000
+#define S_OSVERSION     0x0002
 #define S_GETCOOKIE     0x0008
 #define S_SETCOOKIE     0x0009
 #define S_GETLVAL       0x000a
@@ -32,6 +34,7 @@
 #define S_SETLVAL       0x000d
 #define S_SETWVAL       0x000e
 #define S_SETBVAL       0x000f
+#define S_DELCOOKIE     0x001a
 
 LONG xssystem(WORD mode, LONG arg1, LONG arg2);
 

--- a/bios/arch/arm/tosvars.c
+++ b/bios/arch/arm/tosvars.c
@@ -1,0 +1,83 @@
+/*
+ * tosvars.c - storage for the ARM subset of the TOS system variables
+ *
+ * On m68k, tosvars.ld gives every one of these a fixed low-memory
+ * address, for compatibility with real TOS software that reads them
+ * directly. ARM has no such software to be compatible with, and
+ * Ssystem() (bdos/ssystem.c) now gives ARM programs a documented way
+ * to reach the same values without a fixed address at all -- so on
+ * ARM these are just ordinary global variables, wherever the linker
+ * puts them. See #219.
+ *
+ * This covers exactly the system variables bios/tosvars.h declares
+ * (i.e. the ones used by C code); a handful of others that aren't
+ * declared there (con_state, themd, bufl, pun_ptr, vbclock) already
+ * have -- or, for vbclock, now get -- real storage next to their one
+ * user instead.
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "config.h"
+#include "portab.h"
+#include "tosvars.h"
+
+void (*etv_timer)(int);
+LONG (*etv_critic)(WORD err, WORD dev);
+void (*etv_term)(void);
+
+UBYTE *phystop;
+UBYTE *membot;
+UBYTE *memtop;
+
+volatile WORD flock;
+WORD seekrate;
+WORD timer_ms;
+WORD fverify;
+WORD bootdev;
+BYTE defshiftmod;
+BYTE sshiftmod;
+
+UBYTE *v_bas_ad;
+volatile WORD vblsem;
+WORD nvbls;
+LONG *vblqueue;
+const UWORD *colorptr;
+volatile LONG frclock;
+
+void (*hdv_init)(void);
+LONG (*hdv_bpb)(WORD dev);
+LONG (*hdv_rw)(WORD rw, UBYTE *buf, WORD cnt, WORD recnr, WORD dev, LONG lrecnr);
+LONG (*hdv_boot)(void);
+LONG (*hdv_mediach)(WORD dev);
+
+WORD cmdload;
+BYTE conterm;
+LONG savptr;
+WORD nflops;
+WORD save_row;
+volatile LONG hz_200;
+LONG drvbits;
+UBYTE *dskbufp;
+WORD dumpflg;
+
+LONG sysbase;
+UBYTE *end_os;
+void (*exec_os)(void) NORETURN;
+void (*dump_vec)(void);
+void (*prt_stat)(void);
+void (*prt_vec)(void);
+void (*aux_stat)(void);
+void (*aux_vec)(void);
+
+LONG *p_cookies;
+
+void (*bell_hook)(void);
+void (*kcl_hook)(void);
+
+LONG (*bconstat_vec[8])(void);
+LONG (*bconin_vec[8])(void);
+LONG (*bcostat_vec[8])(void);
+LONG (*bconout_vec[8])(WORD, WORD);
+LONG vbl_list[8];

--- a/bios/arch/arm/vectors.c
+++ b/bios/arch/arm/vectors.c
@@ -33,7 +33,7 @@
 // ==== References ===========================================================
 
 // TOS System variables
-extern volatile LONG vbclock;
+volatile LONG vbclock; /* not in tosvars.h; only ARM (this file) uses it -- see arch/arm/tosvars.c */
 extern void (*etv_timer)(int);
 extern const UWORD bios_ent;
 extern const UWORD xbios_ent;

--- a/bios/arch/arm/vectors.c
+++ b/bios/arch/arm/vectors.c
@@ -33,7 +33,9 @@
 // ==== References ===========================================================
 
 // TOS System variables
-volatile LONG vbclock; /* not in tosvars.h; only ARM (this file) uses it -- see arch/arm/tosvars.c */
+volatile LONG vbclock; /* not in tosvars.h -- defined here since this is its
+                         * only writer; also read by bdos/ssystem.c's
+                         * Ssystem(S_GETLVAL/S_SETLVAL) lookup table */
 extern void (*etv_timer)(int);
 extern const UWORD bios_ent;
 extern const UWORD xbios_ent;

--- a/bios/biosmem.c
+++ b/bios/biosmem.c
@@ -131,7 +131,12 @@ UBYTE *balloc_stram(ULONG size, BOOL top)
     return ret;
 }
 
+#ifdef __arm__
+MD themd;                       /* BIOS memory descriptor -- fixed address on
+                                  * m68k (tosvars.ld), ordinary storage here (#219) */
+#else
 extern MD themd;                /* BIOS memory descriptor */
+#endif
 
 void getmpb(MPB * mpb)
 {

--- a/bios/blkdev.c
+++ b/bios/blkdev.c
@@ -37,6 +37,11 @@
 #include "biosmem.h"
 #include "xhdi.h"
 
+#ifdef __arm__
+PUN_INFO *pun_ptr;      /* fixed address on m68k (tosvars.ld), ordinary
+                         * storage here (#219); declared extern in ahdi.h */
+#endif
+
 
 /*
  * undefine the following to enable booting from hard disk.

--- a/bios/build.mk
+++ b/bios/build.mk
@@ -33,7 +33,7 @@ obj-$(ARCH_M68K) += aciavecs.o kprintasm.o linea.o natfeat.o natfeats.o \
 
 obj-$(ARCH_COLDFIRE) += coldfire.o coldfire2.o spi.o
 
-obj-$(ARCH_ARM) += vectorsasm.o aciaemu.o
+obj-$(ARCH_ARM) += vectorsasm.o aciaemu.o tosvars.o
 
 # The cache maintenance operations below do not exist on the ARM1176 used
 # by the first generation Raspberry Pi.

--- a/bios/machine/virt-arm/startup.S
+++ b/bios/machine/virt-arm/startup.S
@@ -128,10 +128,13 @@ virt_arm_post_mmu:
     ldr r4, =hello_msg_virt
     bl  print_string
 
-    /* sysvars round-trip: _phystop is one of the fixed low sysvars
-     * addresses (see tosvars.ld); if the low MMU window is wired
-     * correctly this read/write pair works exactly like any other
-     * global variable. */
+    /* sysvars round-trip: _phystop is just an ordinary global on ARM
+     * now (bios/arch/arm/tosvars.c -- see kelihlodversson/pTOS#219), so
+     * this no longer proves anything specific to sysvars, but it's a
+     * convenient, already-linked address to sanity-check that the low
+     * MMU window actually maps virtual low addresses onto real RAM
+     * before anything else here relies on memory access working at
+     * all. */
     ldr r0, =_phystop
     ldr r1, =0x12345678
     str r1, [r0]
@@ -142,15 +145,26 @@ virt_arm_post_mmu:
     ldr r4, =sysvars_ok_msg
     bl  print_string
 
+    /* Clear the BSS segment now that virtual addressing is live. */
+    ldr r0, =__bss
+    ldr r1, =__ebss
+    mov r2, #0
+1:  cmp r0, r1
+    bge 2f
+    str r2, [r0], #4
+    b   1b
+2:
+
     /*
-     * The round-trip test above only proves the sysvars alias works; it
-     * leaves _phystop holding the test pattern instead of a real value.
-     * _phystop is not a scratch variable -- bios/biosmem.c's bmem_init()
-     * reads it directly ("memtop = phystop") to size the entire free-
-     * memory pool. Leaving it at 0x12345678 (~291MB) made every later
-     * allocation (including the TPA for the first launched process)
-     * wildly oversized, which is what actually produced the corrupt,
-     * out-of-range stack pointers that crashed GEMDOS process dispatch.
+     * _phystop lives in that BSS range now (bios/arch/arm/tosvars.c),
+     * so it must be set to its real value *after* clearing BSS, not
+     * before -- otherwise the clear loop above would immediately
+     * zero it back out. bios/biosmem.c's bmem_init() reads it
+     * directly ("memtop = phystop") to size the entire free-memory
+     * pool; leaving it at 0 (or the 0x12345678 test pattern, before
+     * this was reordered to run after the clear) produced corrupt,
+     * out-of-range stack pointers that crashed GEMDOS process
+     * dispatch.
      *
      * The real top of usable RAM is the top of the low MMU window built
      * by virt_mmu_bootstrap() (see the call above: 0x08000000 bytes,
@@ -165,16 +179,6 @@ virt_arm_post_mmu:
     ldr r0, =_phystop
     ldr r1, =0x07f00000
     str r1, [r0]
-
-    /* Clear the BSS segment now that virtual addressing is live. */
-    ldr r0, =__bss
-    ldr r1, =__ebss
-    mov r2, #0
-1:  cmp r0, r1
-    bge 2f
-    str r2, [r0], #4
-    b   1b
-2:
 
     /*
      * Now that BSS is cleared (arm_boot_regs lives there, like every
@@ -213,10 +217,10 @@ print_string:
     bx  lr
 
 /*
- * If the low MMU window is wrong, _phystop's alias doesn't actually reach
- * the fixed low sysvars addresses everything from here on depends on.
+ * If the low MMU window is wrong, ordinary memory access doesn't
+ * actually reach real RAM the way everything from here on depends on.
  * Continuing (BSS clear, _biosmain) would silently corrupt or misread
- * low memory instead of failing loudly, so halt here instead.
+ * memory instead of failing loudly, so halt here instead.
  */
 sysvars_check_failed:
     ldr r4, =sysvars_fail_msg

--- a/bios/xbios.c
+++ b/bios/xbios.c
@@ -794,30 +794,31 @@ static void xbios_25(void)
  * to hack hardware and protected locations without having to fiddle
  * with GEMDOS get/set supervisor mode call.
  *
- * On m68k, the normal version of supexec() is a tiny assembler
- * trampoline (see vectors.S) that jumps to the user's code instead
- * of calling it, so it adds no stack frame of its own. This matters
- * because there is no rule about how much stack the user's function
- * needs, and some callers (e.g. certain game loaders) run with very
- * little stack to spare.
+ * The normal version of supexec() is a tiny assembler trampoline (see
+ * vectors.S) that jumps to the user's code instead of calling it, so
+ * it adds no stack frame of its own. This matters because there is no
+ * rule about how much stack the user's function needs, and some
+ * callers (e.g. certain game loaders) run with very little stack to
+ * spare.
  *
  * The debug version lives here and is much uglier since it has to
  * protect itself against GCC possibly generating code to use registers
  * which might have been clobbered by the called user function. There
  * are no rules about this, so for safety, we assume it can clobber all
  * of them.
+ *
+ * m68k only: on ARM, Supexec() is unimplemented (returns EINVFN) --
+ * see the deprecation rationale in ssystem.h/#219. Programs on ARM
+ * needing to read or write system variables use Ssystem() instead.
  */
-#if DBG_XBIOS
+#if defined(__m68k__) && DBG_XBIOS
 static LONG xbios_26(PFLONG codeptr)
 {
-#if defined(__m68k__)
     register LONG retval __asm__("d0");
     register PFLONG func __asm__("a0") = codeptr;
-#endif
 
     kprintf("XBIOS: Supexec(%p)\n", codeptr);
 
-#if defined(__m68k__)
     /* a6 is saved/restored around the call instead of being listed as a
      * clobber: some m68k-atari-mintelf-gcc 13.3.0 builds ICE in
      * print_operand_address (RTL "final" pass) when a6 is clobbered by
@@ -837,10 +838,6 @@ static LONG xbios_26(PFLONG codeptr)
     );
 
     return retval;
-#else
-    /* On arm we assume the function follows the eabi and don't save any additional registers */
-    return codeptr();
-#endif
 }
 #endif
 
@@ -1124,12 +1121,6 @@ extern LONG xbios_unimpl(void);
 
 #if defined(__m68k__)
 extern LONG supexec(PFLONG);   /* implemented in vectors.S */
-#else
-/* On arm we assume the function follows the eabi and don't save any additional registers */
-static LONG supexec(PFLONG codeptr)
-{
-    return codeptr();
-}
 #endif
 
 
@@ -1211,7 +1202,11 @@ const PFLONG xbios_vecs[] = {
     VEC(xbios_23, kbrate),
     xbios_unimpl,   /* 24 prtblk */
     VEC(xbios_25, vsync),
+#if defined(__m68k__)
     VEC(xbios_26, supexec),
+#else
+    xbios_unimpl,   /* 26 supexec -- deprecated on ARM, use Ssystem() instead (#219) */
+#endif
     xbios_unimpl,   /* 27 puntaes */
     xbios_unimpl,   /* 28 */
     VEC(xbios_29, floprate),

--- a/tosvars.ld
+++ b/tosvars.ld
@@ -30,85 +30,12 @@ _proc_stk       = 0x3cc;        /* 16 words from exception stack */
 /* ==== Start of System variables =========================================== */
 _sysvars_start  = 0x400;
 /*
- * The layout below is the ARM one: every LONG sysvar is placed on a 4 byte
- * boundary, and the m68k-only variables are dropped to make room.  It is
- * required on every ARM machine, not just the Raspberry Pi: ARM LONG objects
- * have 4 byte alignment, so the compiler is free to emit STRD/LDRD (and, once
- * it vectorises, VSTR/VLDR) against them, and those instructions take an
- * alignment Data Abort on an odd-word address regardless of SCTLR.A.  With
- * the m68k layout below -- where -mshort only requires 2 byte alignment, so
- * e.g. _themd sits at 0x48e -- such an access faults.
+ * These fixed low-memory addresses are m68k only. ARM has no real TOS
+ * software depending on them, and Ssystem() (bdos/ssystem.c) now gives
+ * ARM programs a documented way to reach the same values without a
+ * fixed address at all, so on ARM these are ordinary global variables
+ * instead -- see bios/arch/arm/tosvars.c and #219.
  */
-#if ARCH_ARM
-_etv_timer      = 0x400;        /* GEM event timer vector */
-_etv_critic     = 0x404;        /* GEM critical error handler */
-_etv_term       = 0x408;        /* GEM program termination vector */
-_etv_xtra       = 0x40c;        /* GEM additional vectors (unused) */
-
-_phystop        = 0x424;        /* physical top of RAM */
-_membot         = 0x428;        /* start of TPA (user memory) */
-_memtop         = 0x42c;        /* end of TPA (user memory) */
-_flock          = 0x430;        /* if != 0, VBL floppy routine is disabled */
-_seekrate       = 0x434;        /* floppy seek rate */
-_timer_ms       = 0x438;        /* time between timer calls in ms */
-_fverify        = 0x43c;        /* if != 0, verify floppy writes */
-_bootdev        = 0x440;        /* default boot drive */
-_palmode        = 0x444;        /* 0 = NTSC, else PAL */
-_defshiftmod    = 0x448;        /* default video resolution */
-_sshiftmod      = 0x44c;        /* copy of contents of 0xffff8260 */
-
-_v_bas_ad       = 0x450;        /* screen base address */
-_vblsem         = 0x454;        /* if > 0, the VBL routine is executed */
-_nvbls          = 0x458;        /* number of VBL routines */
-_vblqueue       = 0x45c;        /* pointer to list of VBL routines */
-_colorptr       = 0x460;        /* pointer to color palette to be loaded */
-
-_vbclock        = 0x464;        /* number of VBL routines executed */
-_frclock        = 0x468;        /* number of VBL routines processed */
-_hdv_init       = 0x46c;        /* vector for hard disk initialization */
-_swv_vec        = 0x470;        /* vector for resolution change */
-_hdv_bpb        = 0x474;        /* vector for getbpb for harddisk */
-_hdv_rw         = 0x478;        /* vector for read/write for harddisk */
-_hdv_boot       = 0x47c;        /* vector for hard disk boot */
-_hdv_mediach    = 0x480;        /* vector for hard disk media change */
-_cmdload        = 0x484;        /* if not 0, load command.prg after boot */
-_conterm        = 0x488;        /* attribute vector for console output */
-criticret       = 0x48c;        /* return address for critical error hndlr */
-_themd          = 0x490;        /* first memory descriptor block */
-____md          = 0x4a0;        /* space for additional memory descriptors */
-_savptr         = 0x4a4;        /* pointer to BIOS save register block */
-_nflops         = 0x4a8;        /* number of connected floppy drives */
-con_state       = 0x4ac;        /* vector for screen output */
-_save_row       = 0x4b0;        /* temporary storage for cursor line pos. */
-sav_context     = 0x4b4;        /* ptr to save area for exception processing */
-_bufl           = 0x4b8;        /* pointers to buffer ctrl blocks for GEMDOS */
-_hz_200         = 0x4c0;        /* counter for 200 Hz system clock */
-the_env         = 0x4c4;        /* pointer to default environment string */
-_drvbits        = 0x4c8;        /* bit allocation for physical drives */
-_dskbufp        = 0x4d0;        /* pointer to disk buffer */
-_autopath       = 0x4d4;        /* pointer to auto-execute path */
-_vbl_list       = 0x4d8;        /* pointers to 8 VBl routines */
-_dumpflg        = 0x4f8;        /* flag for screen dump (unsused) */
-_prtabt         = 0x4fc;        /* printer abort flag */
-_sysbase        = 0x500;        /* pointer to start of OS */
-_shell_p        = 0x504;        /* pointer to shell */
-_end_os         = 0x508;        /* pointer to end of OS */
-_exec_os        = 0x50c;        /* pointer to entry point of OS */
-_dump_vec       = 0x510;        /* pointer to screen dump routine */
-_prt_stat       = 0x514;        /* pointer to prv_lsto */
-_prt_vec        = 0x518;        /* pointer to prv_lst */
-_aux_stat       = 0x51c;        /* pointer to prv_auxo */
-_aux_vec        = 0x520;        /* pointer to prv_aux */
-_pun_ptr        = 0x524;        /* if AHDI, pointer to pun_info */
-_bconstat_vec   = 0x528;        /* 8 pointers to input-status routines */
-_bconin_vec     = 0x548;        /* 8 pointers to input routines */
-_bcostat_vec    = 0x568;        /* 8 pointers to output-status routines */
-_bconout_vec    = 0x588;        /* 8 pointers to output routines */
-_p_cookies      = 0x5c8;        /* pointer to cookie jar */
-_bell_hook      = 0x5cc;        /* pointer to routine for system bell */
-_kcl_hook       = 0x5e0;        /* pointer to routine for system keyclick */
-
-#else
 _etv_timer      = 0x400;        /* GEM event timer vector */
 _etv_critic     = 0x404;        /* GEM critical error handler */
 _etv_term       = 0x408;        /* GEM program termination vector */
@@ -202,7 +129,6 @@ _warm_magic     = 0x6fc;        /* set to WARM_MAGIC if next boot must not */
 _pmmutree       = PMMUTREE_ADDRESS_68030;   /* for pmmu tree on 68030 */
 #endif
 
-#endif
 /*
  * The sysvars region ends at 0x800.
  */

--- a/tosvars.ld
+++ b/tosvars.ld
@@ -34,8 +34,15 @@ _sysvars_start  = 0x400;
  * software depending on them, and Ssystem() (bdos/ssystem.c) now gives
  * ARM programs a documented way to reach the same values without a
  * fixed address at all, so on ARM these are ordinary global variables
- * instead -- see bios/arch/arm/tosvars.c and #219.
+ * instead (bios/arch/arm/tosvars.c and a few other files -- see
+ * #219). This whole block must stay guarded by #if ARCH_M68K, not
+ * just left unconditional: a plain "symbol = address;" assignment
+ * here silently wins over a same-named .bss definition from an ARM
+ * object file with no linker error or warning at all, so leaving any
+ * of these active for ARM re-aliases that variable straight back to
+ * this fixed m68k address instead of its real storage.
  */
+#if ARCH_M68K
 _etv_timer      = 0x400;        /* GEM event timer vector */
 _etv_critic     = 0x404;        /* GEM critical error handler */
 _etv_term       = 0x408;        /* GEM program termination vector */
@@ -128,6 +135,7 @@ _warm_magic     = 0x6fc;        /* set to WARM_MAGIC if next boot must not */
 #if CONF_WITH_68030_PMMU
 _pmmutree       = PMMUTREE_ADDRESS_68030;   /* for pmmu tree on 68030 */
 #endif
+#endif /* ARCH_M68K */
 
 /*
  * The sysvars region ends at 0x800.


### PR DESCRIPTION
Fixes #219

## Summary

- **`Ssystem()` (GEMDOS `0x154`), ARM only**: implements the `S_[GS]ET(COOKIE|[LWB]VAL)` subset — cookie jar access, and getting/setting a system variable by its documented TOS address. The `*VAL` modes never touch raw memory: the address is looked up in one of three width-specific tables (`bdos/ssystem.c`) mapping it to wherever pTOS actually stores that variable. An unknown mode, wrong width, or unimplemented address returns `EINVFN`. Scoped to ARM only (`#ifdef __arm__` in `osif()`, `obj-$(ARCH_ARM)` in `bdos/build.mk`) — real m68k TOS software already has `Supexec()` and direct memory access for this, and the smallest 192k m68k ROM images have no code size to spare for a second way to do it.
- **`Supexec()` deprecated on ARM**: it was already just a plain function call with no real supervisor-mode switch. Dropped from `xbios_vecs[]` on ARM (falls back to `xbios_unimpl`/`EINVFN`); m68k's real trampoline is unchanged.
- **ARM's fixed sysvar addresses removed**: `tosvars.ld` no longer pins ~60 system variables to fixed low-memory addresses on ARM (that block is now `#if ARCH_M68K`-only). They get ordinary `.bss` storage instead — most of them in one new file, `bios/arch/arm/tosvars.c`, matching `bios/tosvars.h`; a handful with no `tosvars.h` entry keep their existing local `extern` pattern next to their one user, now turned into a real definition (`themd`, `bufl`, `pun_ptr`, `vbclock`). Everything else the old ARM branch listed turned out to be unreferenced anywhere in ARM code and is simply dropped, verified against the full source tree.

## A bug found along the way

`bios/machine/virt-arm/startup.S` set `_phystop` to the real top-of-RAM value *before* clearing `.bss` — safe when `_phystop` was a fixed address outside `.bss`, but a real regression once it became an ordinary `.bss` variable (the clear loop zeroed it right back out). Caught by booting `virt-arm-cli` under QEMU and comparing against `master`. Fixed by moving that write to after the BSS clear.

A related, more fundamental issue: simply removing the `#if ARCH_ARM` split without keeping the m68k content itself conditional meant it now applied to ARM builds too — a linker script `symbol = address;` assignment silently wins over a same-named `.bss` definition from an object file, with **no error or warning**, so every one of these variables was quietly re-aliased back to its m68k address on ARM. Fixed by wrapping the whole block in `#if ARCH_M68K`.

## Testing

- `make atari512_defconfig`, `make rpi1_defconfig`, `make rpi2_defconfig`, `make virt-arm_defconfig`/`virt-arm-cli_defconfig` all build clean.
- `make release-192k` (the tightest m68k ROM config) — was overflowing by 124 bytes before scoping `Ssystem()` to ARM only; passes with >1000 bytes free on every country image now.
- `emutos.map` verified: m68k sysvars resolve to their documented fixed addresses unchanged; ARM sysvars resolve to real `.bss` addresses.
- Boot smoke tests (Hatari / QEMU):
  - m68k STE: boots to the GEM desktop.
  - ARM raspi1 (`raspi1ap`): boots to the GEM desktop (screendump confirms menu bar, disk icon, trash icon).
  - ARM `virt-arm-cli`: boots to the EmuCON `A:>` prompt, matching `master`'s baseline.