### PR TITLE
Fix data abort on Save Desktop and corrupted FAT file length on ARM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ endif
 # EmuTOS requires C90 with some GNU extensions.
 CSTANDARD = -std=gnu90
 
-OTHERFLAGS = -fomit-frame-pointer -fno-common
+OTHERFLAGS = -fomit-frame-pointer -fno-common -fno-builtin
 DEBUGFLAGS = $(if $(DEBUG_INFO),-g)
 
 WARNFLAGS = -Wall -Wundef -Wmissing-prototypes -Wstrict-prototypes

--- a/Makefile
+++ b/Makefile
@@ -211,8 +211,14 @@ CSTANDARD = -std=gnu90
 # data during boot with a sufficiently long string (issue #223).  Disabling
 # the pass (rather than -fno-builtin, which also drops inlining the 192/256
 # KB ROM budgets depend on) removes the substitution without the code-size
-# cost.
-OTHERFLAGS = -fomit-frame-pointer -fno-common -fno-tree-loop-distribute-patterns
+# cost.  -fno-builtin-strlen is added too, belt-and-suspenders: it targets a
+# different GCC mechanism (explicit-call recognition rather than loop-body
+# rewriting) and is confirmed *not* sufficient by itself against this
+# specific rewrite (disassembly still showed a self-call with only this
+# flag set), but costs nothing to keep alongside the pass-disabling flag in
+# case a future compiler version narrows what the pass flag covers.
+OTHERFLAGS = -fomit-frame-pointer -fno-common \
+             -fno-tree-loop-distribute-patterns -fno-builtin-strlen
 DEBUGFLAGS = $(if $(DEBUG_INFO),-g)
 
 WARNFLAGS = -Wall -Wundef -Wmissing-prototypes -Wstrict-prototypes

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,18 @@ endif
 # EmuTOS requires C90 with some GNU extensions.
 CSTANDARD = -std=gnu90
 
-OTHERFLAGS = -fomit-frame-pointer -fno-common -fno-builtin
+# GCC's tree-loop-distribute-patterns pass (on by default at -O2+) pattern
+# matches simple counted loops against memcpy/memset/strlen-shaped idioms
+# and rewrites the loop body as a call to that library function by name.
+# util/string.c's strlen() is exactly such a loop, so GCC rewrote its own
+# body into a call back to the symbol "strlen" -- i.e. itself -- making it
+# recursive to a depth proportional to the string length instead of the
+# loop actually written.  On ARM this overran the stack into adjacent BSS
+# data during boot with a sufficiently long string (issue #223).  Disabling
+# the pass (rather than -fno-builtin, which also drops inlining the 192/256
+# KB ROM budgets depend on) removes the substitution without the code-size
+# cost.
+OTHERFLAGS = -fomit-frame-pointer -fno-common -fno-tree-loop-distribute-patterns
 DEBUGFLAGS = $(if $(DEBUG_INFO),-g)
 
 WARNFLAGS = -Wall -Wundef -Wmissing-prototypes -Wstrict-prototypes

--- a/bdos/fs.h
+++ b/bdos/fs.h
@@ -133,7 +133,7 @@ typedef struct
     DOSTIME o_td;       /* creation time/date: little-endian!   */
     CLNO  o_strtcl;     /* starting cluster number              */
     long  o_fileln;     /* length of file in bytes              */
-} DFD;
+} OPT_PACKED DFD;
 
 
 /*

--- a/bdos/fs.h
+++ b/bdos/fs.h
@@ -27,7 +27,7 @@
 #if CONF_WITH_PLUGGABLE_FS
 #include "pfs.h"        /* PFSCOOKIE is embedded by value in FTAB below */
 #endif
-#ifdef MACHINE_RPI
+#if ARCH_ARM
 #   define OPT_PACKED  __attribute__((packed))
 #else
 #   define OPT_PACKED


### PR DESCRIPTION
Fixes #223, fixes #226

## #223: Data abort when saving desktop on ARM

### Root cause

`desk/deskapp.c`'s `app_start()` calls `strlen()` on the in-memory EMUDESK.INF buffer it builds when no config file is found on disk (e.g. no SD card present). GCC's `tree-loop-distribute-patterns` pass (on by default at `-O2+`) pattern-matches simple counted loops against memcpy/memset/strlen-shaped idioms and rewrites the loop body as a call to that library function by name. `util/string.c`'s `strlen()` is exactly such a loop, so GCC rewrote its own body into a call back to the symbol `strlen` — i.e. itself — making it recursive to a depth proportional to the string length instead of the loop actually written.

On ARM this overran the AES desktop stack into the adjacent `rs_obj[]` resource array in BSS, silently corrupting the DIALERT alert-box template's `ob_type` and `ob_spec.free_string` fields.

That corruption stayed dormant until the object was next used: clicking **Options > Save desktop** builds the "Save Desktop?" confirmation via `fm_alert()`/`fm_strbrk()`, which wrote through the now-garbage `free_string` pointer into unrelated (MMU write-protected) code memory, producing the reported data abort.

### Fix

Build with `-fno-tree-loop-distribute-patterns` globally, disabling the specific GCC pass responsible for the rewrite. `-fno-builtin-strlen` is added alongside it as defense in depth against a different GCC mechanism (explicit-call recognition), though disassembly confirms it is not sufficient by itself against this particular rewrite.

An earlier version of this fix used a blanket `-fno-builtin`, which also disables inlining the 192/256 KB ROM configs depend on and overflowed `ptos192gr.img` by 126 bytes in CI — the current flags are scoped to avoid that.

### Verification

- `strlen()` compiles to a plain iterative loop (confirmed via disassembly).
- Reproduced the crash under QEMU (`raspi2b`) with a debug build + gdb hardware watchpoint, tracing it to the recursive `strlen()` overrunning the stack into `rs_obj[]`.
- With the fix, rpi2 under QEMU repeatedly completes **Save Desktop** (including the follow-on "disk may be damaged" alert when no SD card is attached) with no corruption or crash.
- `release-192k` and `release-256k` package every language variant within their ROM budgets.

## #226: Corrupted FAT file length on close, found while re-verifying #223 with a real filesystem

### Root cause

`bdos/fsopnclo.c`'s dirty-FCB flush does `memcpy(&fcb->f_td,&dfd->o_td,10)`, relying on `DFD`'s `o_td`/`o_strtcl`/`o_fileln` trio (`bdos/fs.h`) being byte-for-byte contiguous with `FCB`'s `f_td`/`f_clust`/`f_fileln`. `FCB` is `OPT_PACKED`; `DFD` was not. On ARM, the unpacked layout inserts 2 bytes of padding before the `long o_fileln` to 4-byte-align it, so `o_fileln` actually starts 2 bytes later than the memcpy assumes — the copy grabs 2 bytes of padding into what should be `o_fileln`'s low half, and only `o_fileln`'s own low 2 bytes into the high half, dropping its real high 2 bytes. The result: a file's recorded size in its FAT directory entry has its two 16-bit halves swapped (e.g. a 480-byte file reported as 31,457,280 bytes), while the file's actual on-disk content is correct.

### Fix

Mark `DFD` `OPT_PACKED`, matching `FCB`/`DOSTIME`/`DIRTBL_ENTRY`'s existing convention.

### Verification

- rpi2 under QEMU with a real writable SD card image: Save Desktop now writes `EMUDESK.INF` with the correct 480-byte directory entry (confirmed via `mdir`) and unchanged, complete file content.
- `atari512` (m68k) still boots to the GEM desktop under Hatari; `virt-arm` and `rpi2` rebuild cleanly.

## General

- `make gitready` passes.