### PR TITLE
Makefile: detect libcmini defconfig content changes, not just name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1213,6 +1213,16 @@ endif
 # mismatch. The stamp file's mtime -- and therefore whether it forces
 # $(LIBCMINI_LIB) to rebuild -- only changes when that comparison finds a
 # real mismatch, not on every invocation.
+#
+# The comparison is against the defconfig *file's content*, not just its
+# name: comparing names alone would miss a defconfig whose content changed
+# underneath an unchanged selection (e.g. a submodule bump that edits
+# configs/ptos_arm_defconfig without touching any sources/*.c or
+# sources/arch/$(ARCH)/*.S -- $(LIBCMINI_LIB)'s own prerequisites, so
+# nothing else would notice either). Reproduced directly: with the name
+# comparison alone, editing that file's content and rebuilding without
+# touching LIBCMINI_DEFCONFIG left lib/libcmini/.config -- and therefore
+# libcmini.a -- silently built from the stale content.
 .PHONY: FORCE
 FORCE:
 
@@ -1229,13 +1239,13 @@ $(LIBCMINI_DIR)/Makefile:
 
 $(LIBCMINI_STAMP): FORCE | obj $(LIBCMINI_DIR)/Makefile
 	@mkdir -p $(dir $@)
-	@want='$(LIBCMINI_DEFCONFIG)'; \
+	@want="$(LIBCMINI_DEFCONFIG):$$(cat $(LIBCMINI_DIR)/configs/$(LIBCMINI_DEFCONFIG))"; \
 	have=$$(cat $@ 2>/dev/null || true); \
 	if [ "$$want" != "$$have" ]; then \
-	    echo "  LIBCMINI-CONFIG $$want"; \
+	    echo "  LIBCMINI-CONFIG $(LIBCMINI_DEFCONFIG)"; \
 	    $(LIBCMINI_MAKE) clean; \
-	    $(LIBCMINI_MAKE) $$want; \
-	    echo "$$want" > $@; \
+	    $(LIBCMINI_MAKE) $(LIBCMINI_DEFCONFIG); \
+	    printf '%s' "$$want" > $@; \
 	fi
 
 $(LIBCMINI_LIB): $(LIBCMINI_STAMP) $(wildcard $(LIBCMINI_DIR)/sources/*.c $(LIBCMINI_DIR)/sources/arch/$(ARCH)/*.S) | obj $(LIBCMINI_DIR)/Makefile


### PR DESCRIPTION
Fixes #227

`$(LIBCMINI_STAMP)` decided whether to reconfigure/rebuild the `lib/libcmini` submodule by comparing only the *name* of the desired defconfig against the name last applied. Switching between names (`ptos_arm_defconfig` / `mintelf_defconfig`) works correctly, but a defconfig *file's own content* changing — e.g. a submodule bump editing `configs/ptos_arm_defconfig` — while the selected name stays the same was invisible to that comparison, so `lib/libcmini/.config` (and the resulting `libcmini.a`) could stay silently built from stale content.

Compares the full `name:content` string instead of just the name, so a content-only change is detected exactly like a name change is.

## Test plan

- Reproduced directly: appended `STDIO_WITH_LONG_LONG=y` to `configs/ptos_arm_defconfig` without touching `LIBCMINI_DEFCONFIG`. Before the fix, `make test-hd` did nothing and `lib/libcmini/.config` stayed stale. After the fix, it correctly reconfigures and picks up the new setting. Reverted the test-only edit and confirmed the revert is likewise detected.
- Confirmed the existing "nothing changed" fast path still skips reconfiguring.
- Confirmed the original name-switch case (rpi2 ⟷ atari512) still triggers correctly in both directions.
- Full clean rebuild + boot test on this branch (rpi2, QEMU raspi2): `pie_load` and `stack_alignment` both PASS, no `guest_errors`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTuNetWHteMyj6PN8rBxig)_