### PR TITLE
raspi_emmc.c: recover from SD card removal on the next insertion

### DIFF
--- a/bios/raspi_emmc.c
+++ b/bios/raspi_emmc.c
@@ -516,6 +516,7 @@ struct cardinfo
     ULONG base_clock;
 
     int report_mediach;
+    int needs_reinit;
 };
 
 static struct cardinfo card;
@@ -1153,31 +1154,21 @@ static void handle_interrupts(void)
     EMMC_INTERRUPT = reset_mask;
 
     /*
-     * card_init() is otherwise only called once, from raspi_emmc_init() at
-     * boot: without this, a single SD_CARD_REMOVAL interrupt latches
-     * card.card_removal permanently (nothing else ever clears it), so
-     * raspi_emmc_rw()/raspi_emmc_ioctl() short-circuit to E_CHNG/
-     * MEDIACHANGE forever, even after a new card is inserted. Re-running
-     * it here recovers as soon as the controller reports the new card,
-     * before anything above this driver even tries to use it again.
-     *
-     * Safe to call from here: the SD_CARD_INSERTION bit is already
-     * cleared in hardware by the EMMC_INTERRUPT write above, so
-     * card_init() -> card_reset()'s own issue_command() calls -- which
-     * each re-enter handle_interrupts() at the top of issue_command() --
-     * see a status register without that bit still pending, so this
-     * cannot recurse back into another card_init() call.
-     *
-     * card_init()/card_reset() never touch card.report_mediach -- set it
-     * explicitly here (regardless of whether card_init() succeeds) so a
-     * poll-driven Mediach() (as opposed to a failed read/write reaching
-     * E_CHNG) also notices the swap.
+     * Just latch the event here -- do NOT call card_init() from this
+     * function. handle_interrupts() runs at the top of issue_command(),
+     * which do_data_command() calls *after* already setting
+     * card.buf/card.blocks_to_transfer for an in-flight, possibly
+     * multi-block transfer; card_reset() (via card_init()) zeroes those
+     * same fields as part of its state reset. Calling it here would
+     * therefore silently corrupt an already-in-progress transfer's state
+     * even on a single, correctly-detected insertion event -- not just on
+     * some theoretical re-entrant loop. ensure_data_mode() -- the one
+     * choke point both raspi_emmc_rw() (via do_rw()) and
+     * raspi_emmc_ioctl() already call before touching any transfer state
+     * -- is where it's actually safe to run it.
      */
     if (card_inserted)
-    {
-        card_init();
-        card.report_mediach = 1;
-    }
+        card.needs_reinit = 1;
 }
 
 static BOOL issue_command(ULONG command, ULONG argument, int timeout)
@@ -1896,6 +1887,32 @@ static int card_init(void)
 
 static int ensure_data_mode(void)
 {
+    /*
+     * card_init() is otherwise only called once, from raspi_emmc_init()
+     * at boot: without this, a single SD_CARD_REMOVAL interrupt latches
+     * card.card_removal permanently (nothing else ever clears it -- see
+     * handle_interrupts()), so raspi_emmc_rw()/raspi_emmc_ioctl()
+     * short-circuit to E_CHNG/MEDIACHANGE forever, even after a new card
+     * is inserted. Do the actual reinit here rather than from
+     * handle_interrupts() itself: this is the one choke point both
+     * raspi_emmc_rw() (via do_rw()) and raspi_emmc_ioctl() already call
+     * before touching any transfer state, so a reinit here can't zero
+     * out card.buf/card.blocks_to_transfer out from under an in-flight
+     * multi-block transfer the way calling it from inside
+     * handle_interrupts() could.
+     *
+     * card_init()/card_reset() never touch card.report_mediach -- set it
+     * explicitly here on success, so a poll-driven Mediach() (as opposed
+     * to a failed read/write reaching E_CHNG) also notices the swap.
+     */
+    if (card.needs_reinit)
+    {
+        card.needs_reinit = 0;
+        if (card_init() != 0)
+            return -1;
+        card.report_mediach = 1;
+    }
+
     if (card.card_rca == 0)
     {
         // Try again to initialise the card

--- a/bios/raspi_emmc.c
+++ b/bios/raspi_emmc.c
@@ -131,16 +131,16 @@
 #define EMMC_SPI_INT_SPT    (*(volatile ULONG*)(ARM_EMMC_BASE + 0xF0))
 #define EMMC_SLOTISR_VER    (*(volatile ULONG*)(ARM_EMMC_BASE + 0xFC))
 
-#define ARM_GPIO_BASE		(ARM_IO_BASE + 0x200000)
-#define ARM_GPIO_GPFSEL0	(*(volatile ULONG*)(ARM_GPIO_BASE + 0x00))
-#define ARM_GPIO_GPFSEL1	(*(volatile ULONG*)(ARM_GPIO_BASE + 0x04))
-#define ARM_GPIO_GPFSEL2	(*(volatile ULONG*)(ARM_GPIO_BASE + 0x08))
-#define ARM_GPIO_GPFSEL3	(*(volatile ULONG*)(ARM_GPIO_BASE + 0x0c))
-#define ARM_GPIO_GPFSEL4	(*(volatile ULONG*)(ARM_GPIO_BASE + 0x10))
-#define ARM_GPIO_GPFSEL5	(*(volatile ULONG*)(ARM_GPIO_BASE + 0x14))
-#define ARM_GPIO_GPPUD		(*(volatile ULONG*)(ARM_GPIO_BASE + 0x94))
-#define ARM_GPIO_GPPUDCLK0	(*(volatile ULONG*)(ARM_GPIO_BASE + 0x98))
-#define ARM_GPIO_GPPUDCLK1	(*(volatile ULONG*)(ARM_GPIO_BASE + 0x9c))
+#define ARM_GPIO_BASE       (ARM_IO_BASE + 0x200000)
+#define ARM_GPIO_GPFSEL0    (*(volatile ULONG*)(ARM_GPIO_BASE + 0x00))
+#define ARM_GPIO_GPFSEL1    (*(volatile ULONG*)(ARM_GPIO_BASE + 0x04))
+#define ARM_GPIO_GPFSEL2    (*(volatile ULONG*)(ARM_GPIO_BASE + 0x08))
+#define ARM_GPIO_GPFSEL3    (*(volatile ULONG*)(ARM_GPIO_BASE + 0x0c))
+#define ARM_GPIO_GPFSEL4    (*(volatile ULONG*)(ARM_GPIO_BASE + 0x10))
+#define ARM_GPIO_GPFSEL5    (*(volatile ULONG*)(ARM_GPIO_BASE + 0x14))
+#define ARM_GPIO_GPPUD      (*(volatile ULONG*)(ARM_GPIO_BASE + 0x94))
+#define ARM_GPIO_GPPUDCLK0  (*(volatile ULONG*)(ARM_GPIO_BASE + 0x98))
+#define ARM_GPIO_GPPUDCLK1  (*(volatile ULONG*)(ARM_GPIO_BASE + 0x9c))
 
 
 #define SD_CMD_INDEX(a)          ((a) << 24)
@@ -1063,6 +1063,7 @@ static void handle_interrupts(void)
 {
     ULONG irpts = EMMC_INTERRUPT;
     ULONG reset_mask = 0;
+    BOOL card_inserted = FALSE;
 
     if (irpts & SD_COMMAND_COMPLETE)
     {
@@ -1120,6 +1121,7 @@ static void handle_interrupts(void)
         KDEBUG(("card insertion detected\n"));
 #endif
         reset_mask |= SD_CARD_INSERTION;
+        card_inserted = TRUE;
     }
 
     if (irpts & SD_CARD_REMOVAL)
@@ -1149,6 +1151,33 @@ static void handle_interrupts(void)
     }
 
     EMMC_INTERRUPT = reset_mask;
+
+    /*
+     * card_init() is otherwise only called once, from raspi_emmc_init() at
+     * boot: without this, a single SD_CARD_REMOVAL interrupt latches
+     * card.card_removal permanently (nothing else ever clears it), so
+     * raspi_emmc_rw()/raspi_emmc_ioctl() short-circuit to E_CHNG/
+     * MEDIACHANGE forever, even after a new card is inserted. Re-running
+     * it here recovers as soon as the controller reports the new card,
+     * before anything above this driver even tries to use it again.
+     *
+     * Safe to call from here: the SD_CARD_INSERTION bit is already
+     * cleared in hardware by the EMMC_INTERRUPT write above, so
+     * card_init() -> card_reset()'s own issue_command() calls -- which
+     * each re-enter handle_interrupts() at the top of issue_command() --
+     * see a status register without that bit still pending, so this
+     * cannot recurse back into another card_init() call.
+     *
+     * card_init()/card_reset() never touch card.report_mediach -- set it
+     * explicitly here (regardless of whether card_init() succeeds) so a
+     * poll-driven Mediach() (as opposed to a failed read/write reaching
+     * E_CHNG) also notices the swap.
+     */
+    if (card_inserted)
+    {
+        card_init();
+        card.report_mediach = 1;
+    }
 }
 
 static BOOL issue_command(ULONG command, ULONG argument, int timeout)

--- a/bios/raspi_emmc.c
+++ b/bios/raspi_emmc.c
@@ -1891,25 +1891,44 @@ static int ensure_data_mode(void)
      * card_init() is otherwise only called once, from raspi_emmc_init()
      * at boot: without this, a single SD_CARD_REMOVAL interrupt latches
      * card.card_removal permanently (nothing else ever clears it -- see
-     * handle_interrupts()), so raspi_emmc_rw()/raspi_emmc_ioctl()
-     * short-circuit to E_CHNG/MEDIACHANGE forever, even after a new card
-     * is inserted. Do the actual reinit here rather than from
-     * handle_interrupts() itself: this is the one choke point both
-     * raspi_emmc_rw() (via do_rw()) and raspi_emmc_ioctl() already call
-     * before touching any transfer state, so a reinit here can't zero
-     * out card.buf/card.blocks_to_transfer out from under an in-flight
+     * handle_interrupts()), so raspi_emmc_rw() keeps failing (EREADF/
+     * EWRITF) and raspi_emmc_ioctl() keeps returning E_CHNG/MEDIACHANGE
+     * forever, even after a new card is inserted. Do the actual reinit
+     * here rather than from handle_interrupts() itself: this is the one
+     * choke point both raspi_emmc_rw() (via do_rw()) and
+     * raspi_emmc_ioctl() already call before touching any transfer
+     * state, so a reinit here can't zero out
+     * card.buf/card.blocks_to_transfer out from under an in-flight
      * multi-block transfer the way calling it from inside
      * handle_interrupts() could.
      *
-     * card_init()/card_reset() never touch card.report_mediach -- set it
-     * explicitly here on success, so a poll-driven Mediach() (as opposed
-     * to a failed read/write reaching E_CHNG) also notices the swap.
+     * Drain any pending interrupt status first: without this, a
+     * SD_CARD_INSERTION that arrived since the last issue_command() call
+     * wouldn't be observed (and card.needs_reinit set) until the
+     * issue_command(SEND_STATUS...) call below runs handle_interrupts()
+     * itself -- too late to avoid that same call also seeing the
+     * still-set card.card_removal and aborting, failing this attempt
+     * once before the next one recovers. Handling it up front lets a
+     * fresh insertion recover within this same call instead.
      */
+    handle_interrupts();
+
     if (card.needs_reinit)
     {
-        card.needs_reinit = 0;
+        /*
+         * Only clear the flag once card_init() actually succeeds: on a
+         * transient failure (e.g. hardware not ready yet), leaving it
+         * set means the next call retries the reinit instead of being
+         * permanently stuck never attempting it again.
+         */
         if (card_init() != 0)
             return -1;
+        card.needs_reinit = 0;
+        /*
+         * card_init()/card_reset() never touch card.report_mediach --
+         * set it explicitly here so a poll-driven Mediach() (as opposed
+         * to a failed read/write reaching E_CHNG) also notices the swap.
+         */
         card.report_mediach = 1;
     }
 


### PR DESCRIPTION
Fixes #229

Found while auditing the filesystem/block-device layer for staleness bugs of the same shape as #227: a cached/derived state ("is the media still valid") that isn't actually invalidated when the real-world condition changes.

A real `SD_CARD_REMOVAL` hardware interrupt sets `card.card_removal = 1` (`handle_interrupts()`). Once set, `raspi_emmc_rw()` fails (`EREADF`/`EWRITF`) and `raspi_emmc_ioctl()` returns `E_CHNG`/`MEDIACHANGE` on every call. The only code that ever clears `card.card_removal` back to `0` is `card_reset()` (called by `card_init()`), and `card_init()` was only ever called once, from `raspi_emmc_init()` at boot — the `SD_CARD_INSERTION` interrupt handler just logged a debug message and did nothing else. So a single card removal permanently wedged the driver: every later access failed with "media changed" forever, even after a new card was inserted, until reboot.

## Fix

`handle_interrupts()` only *latches* the event (`card.needs_reinit = 1`) when `SD_CARD_INSERTION` fires — it does not call `card_init()` itself. The actual reinit happens in `ensure_data_mode()`, the one choke point both `raspi_emmc_rw()` (via `do_rw()`) and `raspi_emmc_ioctl()` already call before touching any transfer state:

- `ensure_data_mode()` first drains any pending interrupt status (`handle_interrupts()`), so an insertion detected during *this* call is handled within the same call rather than only being picked up on the next one.
- If `card.needs_reinit` is set, it calls `card_init()` there — safe because at that point no transfer state (`card.buf`/`card.blocks_to_transfer`) has been set up yet for the current top-level call, so a reinit can't clobber an in-flight multi-block transfer's state the way calling it from inside `handle_interrupts()` could have (an earlier version of this PR did that and was corrected in review — see thread history).
- The flag is only cleared once `card_init()` actually succeeds, so a transient failure doesn't leave the driver permanently unable to retry.
- `card.report_mediach = 1` is also set there on success, since `card_init()`/`card_reset()` never touch it and it was otherwise dead code (declared, checked, reset to 0, but never set to 1 anywhere) — a poll-driven `Mediach()` now notices the swap too, not just a failed read/write reaching `E_CHNG`.

Also fixed 10 pre-existing tab-indented GPIO register `#define`s in this same file (unrelated to this change, but `make gitready` scans the whole file once it's touched) to spaces, matching the surrounding EMMC register defines' style.

## Testing

- Full clean rebuild + boot test (QEMU raspi2) after each revision: no regression, `pie_load` and `stack_alignment` both PASS, no `guest_errors`.
- Traced the state-safety of the current design by reading the exact code (see above).
- **Not verified live**: I wasn't able to reliably drive a full remove → access → reinsert → access cycle through QEMU's SD-card hot-plug monitor commands in this environment — the interrupt is only polled inside `issue_command()`, so exercising it needs a real guest-side I/O attempt after each state change, and scripting that end-to-end wasn't practical here. Worth confirming on real hardware or with a more deliberate QEMU hot-plug test harness before merging.