### PR TITLE
disk.c: remove dead, narrowly-guarded OPT_PACKED macro

### DIFF
--- a/bios/disk.c
+++ b/bios/disk.c
@@ -37,12 +37,6 @@
 
 extern LONG drvrem;                 /* bitmap of removable media drives */
 
-#ifdef MACHINE_RPI
-#   define OPT_PACKED  __attribute__((packed))
-#else
-#   define OPT_PACKED
-#endif
-
 #if BYTE_ORDER == BIG_ENDIAN
 #   define BOOTSIG_MAGIC 0x55aa
 #else


### PR DESCRIPTION
Fixes #231

Audited `bdos/fs*.c` and `bios/disk.c` for other instances of the struct-layout bug fixed in #226 (a `memcpy()` assuming two independently-declared structs shared byte-for-byte layout, one packed and the other not — silently corrupt on ARM due to inserted alignment padding, latent on m68k).

## Findings

No new live instances of that bug class:

- Every place that overlays a raw disk buffer as a typed struct (`FCB*`/`BCB*` casts in `fsdir.c`/`fsbuf.c`/`fsopnclo.c`) is already protected by that struct's `OPT_PACKED`, used consistently.
- The two remaining `-Waddress-of-packed-member` build warnings are false positives, confirmed by tracing them: `fsbuf.c:131`/`155` take the address of `BCB`'s *first* field (offset 0), numerically identical to the struct's own address; `fsdir.c:879`/`899`'s `dirscan()` macro round-trips a real `DND*` through `(FCB*)` (`scan()`'s dual-purpose return type) without ever dereferencing it as one.
- `bios/atari_rootsec.h`'s `struct rootsector`/`partition_info` already had this exact bug and was already fixed with `packed, aligned(2)` and a thorough comment, apparently in an earlier pass.

## Fix

One piece of actual cruft found along the way: `bios/disk.c` defines its own `OPT_PACKED` macro, gated on the narrower `MACHINE_RPI` rather than `ARCH_ARM` (missed when `bdos/fs.h`'s copy of the same macro was broadened to `ARCH_ARM` in #226's follow-up, ba35042). Nothing in `disk.c` references it — `MBR`/`PARTENTRY` use a hardcoded, unconditional `__attribute__((packed))` directly and correctly, since they represent a fixed on-disk wire format on every architecture, not something that should only be packed on ARM. Removed.

## Testing

Clean rebuild + `make gitready` pass. Boot-tested under QEMU raspi2 with `make test-hd`: MBR still parses correctly (`fda: MBR at 0 $0e`), both regression suites (`pie_load`, `stack_alignment`) PASS, no `guest_errors`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTuNetWHteMyj6PN8rBxig)_