### PR TITLE
bdos: add Ssystem(S_CONSOLE_DIM) for portable console dimensions

### DIFF
--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -11,6 +11,9 @@
  * Supexec() (the usual way real TOS programs would do this) isn't
  * supported.
  *
+ * S_CONSOLE_DIM is the one mode here that isn't part of that MiNT
+ * protocol -- see its own comment in ssystem.h and issue #235.
+ *
  * The *VAL modes never touch raw memory: the "address" argument is the
  * documented TOS address of the variable, looked up in one of three
  * width-specific tables that map it to wherever pTOS actually stores
@@ -28,6 +31,7 @@
 #include "gemerror.h"
 #include "../bios/tosvars.h"
 #include "../bios/cookie.h"
+#include "../bios/lineavars.h"
 #include "ahdi.h"
 #include "string.h"
 
@@ -350,6 +354,27 @@ static LONG ssystem_osversion(void)
 
 
 /*
+ * ssystem_console_dim - S_CONSOLE_DIM (pTOS extension, see ssystem.h)
+ *
+ * v_cel_mx/v_cel_my (bios/lineavars.h) hold the screen's last valid
+ * column/row index, i.e. one less than the actual width/height -- add 1
+ * to report the usable count a caller like getwh()/getht() actually
+ * wants.
+ */
+static LONG ssystem_console_dim(LONG arg2)
+{
+    LONG dim;
+
+    if (!arg2)
+        return EINVFN;
+
+    dim = ((LONG)(linea_vars.v_cel_my + 1) << 16) | (linea_vars.v_cel_mx + 1);
+    svar_copy((void *)arg2, &dim, sizeof(dim));
+    return E_OK;
+}
+
+
+/*
  * xssystem - implements GEMDOS Ssystem(), see ssystem.h
  */
 LONG xssystem(WORD mode, LONG arg1, LONG arg2)
@@ -389,6 +414,9 @@ LONG xssystem(WORD mode, LONG arg1, LONG arg2)
         return ssystem_setwval(arg1, arg2);
     case S_SETBVAL:
         return ssystem_setbval(arg1, arg2);
+
+    case S_CONSOLE_DIM:
+        return ssystem_console_dim(arg2);
 
     default:
         return EINVFN;

--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -365,12 +365,16 @@ static LONG ssystem_osversion(void)
  * min(arg2, sizeof(our struct)) bytes are copied, so a caller's struct
  * that's smaller (built against an older pTOS) or larger (built against
  * a newer one than this kernel implements) than ours is both handled
- * correctly; see ssystem.h.
+ * correctly; see ssystem.h. arg2 == -1 queries sizeof(our struct)
+ * without writing anything (arg1 is ignored).
  */
 static LONG ssystem_console_dim(LONG arg1, LONG arg2)
 {
     struct console_dim dim;
     LONG n;
+
+    if (arg2 == -1)
+        return (LONG)sizeof(dim);
 
     if (!arg1 || arg2 <= 0)
         return EINVFN;

--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -360,17 +360,27 @@ static LONG ssystem_osversion(void)
  * column/row index, i.e. one less than the actual width/height -- add 1
  * to report the usable count a caller like getwh()/getht() actually
  * wants.
+ *
+ * arg1 is the caller's struct console_dim*, arg2 its sizeof() -- only
+ * min(arg2, sizeof(our struct)) bytes are copied, so a caller's struct
+ * that's smaller (built against an older pTOS) or larger (built against
+ * a newer one than this kernel implements) than ours is both handled
+ * correctly; see ssystem.h.
  */
-static LONG ssystem_console_dim(LONG arg2)
+static LONG ssystem_console_dim(LONG arg1, LONG arg2)
 {
-    LONG dim;
+    struct console_dim dim;
+    LONG n;
 
-    if (!arg2)
+    if (!arg1 || arg2 <= 0)
         return EINVFN;
 
-    dim = ((LONG)(linea_vars.v_cel_my + 1) << 16) | (linea_vars.v_cel_mx + 1);
-    svar_copy((void *)arg2, &dim, sizeof(dim));
-    return E_OK;
+    dim.width = linea_vars.v_cel_mx + 1;
+    dim.height = linea_vars.v_cel_my + 1;
+
+    n = arg2 < (LONG)sizeof(dim) ? arg2 : (LONG)sizeof(dim);
+    svar_copy((void *)arg1, &dim, n);
+    return n;
 }
 
 
@@ -416,7 +426,7 @@ LONG xssystem(WORD mode, LONG arg1, LONG arg2)
         return ssystem_setbval(arg1, arg2);
 
     case S_CONSOLE_DIM:
-        return ssystem_console_dim(arg2);
+        return ssystem_console_dim(arg1, arg2);
 
     default:
         return EINVFN;

--- a/bdos/ssystem.h
+++ b/bdos/ssystem.h
@@ -36,6 +36,25 @@
 #define S_SETBVAL       0x000f
 #define S_DELCOOKIE     0x001a
 
+/*
+ * S_CONSOLE_DIM - pTOS-only extension, NOT part of MiNT's Ssystem()
+ * protocol. Deliberately given a mode value outside the documented MiNT
+ * range (a negative WORD, the same idiom S_INQUIRE already uses) so it
+ * can never collide with a real MiNT mode.
+ *
+ * Returns the console's text-cell dimensions without Line-A: on m68k
+ * that's a genuine CPU trap, but it doesn't exist at all on ARM (see
+ * kelihlodversson/pTOS#235), where the only other way to read
+ * v_cel_mx/v_cel_my (bios/lineavars.h) is compiling straight into the
+ * kernel's own address space -- not usable from a standalone userland
+ * program.
+ *
+ * arg1 is unused (reserved, pass 0). arg2 is a LONG* the call writes the
+ * dimensions to: width (columns) in the lower 16 bits, height (rows) in
+ * the upper 16. Returns E_OK on success, or EINVFN if arg2 is NULL.
+ */
+#define S_CONSOLE_DIM   ((WORD)0xfffe)
+
 LONG xssystem(WORD mode, LONG arg1, LONG arg2);
 
 #endif /* SSYSTEM_H */

--- a/bdos/ssystem.h
+++ b/bdos/ssystem.h
@@ -49,11 +49,24 @@
  * kernel's own address space -- not usable from a standalone userland
  * program.
  *
- * arg1 is unused (reserved, pass 0). arg2 is a LONG* the call writes the
- * dimensions to: width (columns) in the lower 16 bits, height (rows) in
- * the upper 16. Returns E_OK on success, or EINVFN if arg2 is NULL.
+ * arg1 is a struct console_dim*, arg2 is sizeof(*arg1) as the caller
+ * knows it -- not a fixed size, so the struct can grow in a later pTOS
+ * version without breaking callers built against an older one. Exactly
+ * min(arg2, sizeof(struct console_dim)) bytes are copied from the
+ * kernel's own struct into the caller's, so an old caller passing a
+ * smaller sizeof() only gets the fields that existed when it was built,
+ * and a caller built against a newer, larger struct than the running
+ * kernel implements only gets however many bytes that kernel actually
+ * has to give -- compare the return value against the caller's own
+ * sizeof() to tell which happened. Returns the number of bytes copied
+ * (>= 0), or EINVFN if arg1 is NULL or arg2 <= 0.
  */
 #define S_CONSOLE_DIM   ((WORD)0xfffe)
+
+struct console_dim {
+    UWORD width;    /* columns */
+    UWORD height;   /* rows */
+};
 
 LONG xssystem(WORD mode, LONG arg1, LONG arg2);
 

--- a/bdos/ssystem.h
+++ b/bdos/ssystem.h
@@ -61,7 +61,9 @@
  * sizeof() to tell which happened. Returns the number of bytes copied
  * (>= 0), or EINVFN if arg1 is NULL or arg2 <= 0.
  *
- * arg2 == -1 is a separate query mode: arg1 is ignored (may be NULL,
+ * arg2 == -1 is not a separate Ssystem() mode -- it's still
+ * S_CONSOLE_DIM, just called with this one reserved size value instead
+ * of a real sizeof(). Called that way, arg1 is ignored (may be NULL,
  * nothing is written) and the call instead returns sizeof(struct
  * console_dim) as the running kernel implements it -- the largest
  * arg2 a real call could ever use productively. This lets a caller

--- a/bdos/ssystem.h
+++ b/bdos/ssystem.h
@@ -60,6 +60,13 @@
  * has to give -- compare the return value against the caller's own
  * sizeof() to tell which happened. Returns the number of bytes copied
  * (>= 0), or EINVFN if arg1 is NULL or arg2 <= 0.
+ *
+ * arg2 == -1 is a separate query mode: arg1 is ignored (may be NULL,
+ * nothing is written) and the call instead returns sizeof(struct
+ * console_dim) as the running kernel implements it -- the largest
+ * arg2 a real call could ever use productively. This lets a caller
+ * discover which struct version it's talking to up front, instead of
+ * inferring it after the fact from a real call's return value.
  */
 #define S_CONSOLE_DIM   ((WORD)0xfffe)
 

--- a/tests/console_dim/console_dim.c
+++ b/tests/console_dim/console_dim.c
@@ -27,33 +27,64 @@ void test_console_dim(void);
  */
 #define S_CONSOLE_DIM ((short)0xfffe)
 
+/* Mirrors bdos/ssystem.h's struct console_dim -- not shared via a header
+ * since this is userland/libcmini code, not kernel code. */
+struct console_dim {
+    unsigned short width;   /* columns */
+    unsigned short height;  /* rows */
+};
+
 void test_console_dim(void)
 {
-    long dim = -1;
+    struct console_dim dim;
+    struct {
+        struct console_dim base;
+        unsigned char future[4];       /* simulates a newer, larger caller struct */
+    } oversized;
     long rc;
-    unsigned short width, height;
 
     ptest_begin("console_dim (#235)");
 
-    rc = Ssystem(S_CONSOLE_DIM, 0, (long)&dim);
-    ptest_assert_msg(rc == 0, "Ssystem(S_CONSOLE_DIM) did not return E_OK");
+    /*
+     * Ssystem() itself is currently ARM-only (bdos/bdosmain.c's osif(),
+     * #ifdef __arm__) -- every mode, not just this one, returns EINVFN
+     * unconditionally on m68k. Unlike stack_alignment (ARM-only only in
+     * the sense that its bug never manifested elsewhere), this is an
+     * explicit "not implemented on this architecture" the harness
+     * should skip past rather than assert success against.
+     */
+    if (Ssystem(S_INQUIRE, 0, 0) != 0) {
+        ptest_pass();
+        return;
+    }
 
-    width = (unsigned short)(dim & 0xffff);
-    height = (unsigned short)((dim >> 16) & 0xffff);
+    rc = Ssystem(S_CONSOLE_DIM, (long)&dim, (long)sizeof(dim));
+    ptest_assert_msg(rc == (long)sizeof(dim),
+                     "Ssystem(S_CONSOLE_DIM) did not report the full struct written");
 
-    /* Generous bounds: real/emulated screens run from ST low-res
-     * (40x25) up to TT high-res in a small font (213x160-ish); anything
-     * outside this range means the wrong bits ended up in the wrong
-     * half of the LONG, not a real screen. */
-    ptest_assert_msg(width > 0 && width <= 1000,
+    /* Generous bounds: real/emulated screens run from ST low-res (40x25)
+     * up to TT high-res in a small font (213x160-ish); anything outside
+     * this range means garbage, not a real screen. */
+    ptest_assert_msg(dim.width > 0 && dim.width <= 1000,
                      "console width out of plausible range");
-    ptest_assert_msg(height > 0 && height <= 500,
+    ptest_assert_msg(dim.height > 0 && dim.height <= 500,
                      "console height out of plausible range");
 
-    /* A NULL destination pointer must be rejected, not crash. */
-    rc = Ssystem(S_CONSOLE_DIM, 0, 0L);
-    ptest_assert_msg(rc < 0, "Ssystem(S_CONSOLE_DIM) with a NULL pointer "
-                              "should fail, not succeed");
+    /* A caller struct larger than the kernel's own must not overrun --
+     * only sizeof(struct console_dim) bytes get written, and the return
+     * value says so rather than claiming the whole oversized buffer. */
+    rc = Ssystem(S_CONSOLE_DIM, (long)&oversized, (long)sizeof(oversized));
+    ptest_assert_msg(rc == (long)sizeof(struct console_dim),
+                     "Ssystem(S_CONSOLE_DIM) wrote more than it knows about");
+
+    /* A NULL pointer or non-positive size must be rejected, not crash. */
+    rc = Ssystem(S_CONSOLE_DIM, 0, (long)sizeof(dim));
+    ptest_assert_msg(rc < 0,
+                     "Ssystem(S_CONSOLE_DIM) with a NULL pointer should fail");
+
+    rc = Ssystem(S_CONSOLE_DIM, (long)&dim, 0);
+    ptest_assert_msg(rc < 0,
+                     "Ssystem(S_CONSOLE_DIM) with size 0 should fail");
 
     ptest_pass();
 }

--- a/tests/console_dim/console_dim.c
+++ b/tests/console_dim/console_dim.c
@@ -1,0 +1,59 @@
+/*
+ * console_dim.c - regression test for issue #235
+ *
+ * Verifies Ssystem(S_CONSOLE_DIM, ...), a pTOS-only extension (see
+ * bdos/ssystem.h) that reports the console's text-cell dimensions
+ * without going through the m68k-only Line-A trap -- the portable
+ * replacement getwh()/getht() (cli/cmdasm.S, cli/cmdgetwh.c) need on
+ * architectures, like ARM, that have no Line-A at all.
+ *
+ * Copyright (C) 2026 The pTOS development team
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "test.h"
+#include <mint/osbind.h>
+#include <mint/mintbind.h>     /* Ssystem() */
+
+void test_console_dim(void);
+
+/*
+ * Not in libcmini's <mint/mintbind.h>: it only lists the modes that are
+ * part of MiNT's documented Ssystem() protocol, and this one deliberately
+ * isn't (see bdos/ssystem.h for why -- a negative mode value, same idiom
+ * as S_INQUIRE, so it can never collide with a real MiNT mode).
+ */
+#define S_CONSOLE_DIM ((short)0xfffe)
+
+void test_console_dim(void)
+{
+    long dim = -1;
+    long rc;
+    unsigned short width, height;
+
+    ptest_begin("console_dim (#235)");
+
+    rc = Ssystem(S_CONSOLE_DIM, 0, (long)&dim);
+    ptest_assert_msg(rc == 0, "Ssystem(S_CONSOLE_DIM) did not return E_OK");
+
+    width = (unsigned short)(dim & 0xffff);
+    height = (unsigned short)((dim >> 16) & 0xffff);
+
+    /* Generous bounds: real/emulated screens run from ST low-res
+     * (40x25) up to TT high-res in a small font (213x160-ish); anything
+     * outside this range means the wrong bits ended up in the wrong
+     * half of the LONG, not a real screen. */
+    ptest_assert_msg(width > 0 && width <= 1000,
+                     "console width out of plausible range");
+    ptest_assert_msg(height > 0 && height <= 500,
+                     "console height out of plausible range");
+
+    /* A NULL destination pointer must be rejected, not crash. */
+    rc = Ssystem(S_CONSOLE_DIM, 0, 0L);
+    ptest_assert_msg(rc < 0, "Ssystem(S_CONSOLE_DIM) with a NULL pointer "
+                              "should fail, not succeed");
+
+    ptest_pass();
+}

--- a/tests/console_dim/console_dim.c
+++ b/tests/console_dim/console_dim.c
@@ -71,13 +71,37 @@ void test_console_dim(void)
                      "console height out of plausible range");
 
     /* A caller struct larger than the kernel's own must not overrun --
-     * only sizeof(struct console_dim) bytes get written, and the return
-     * value says so rather than claiming the whole oversized buffer. */
+     * only sizeof(struct console_dim) bytes get written. Fill the
+     * trailing bytes with a sentinel first: checking just the return
+     * value wouldn't catch a kernel that overwrites them but still
+     * reports the smaller count. */
+    {
+        unsigned i;
+        for (i = 0; i < sizeof(oversized.future); i++)
+            oversized.future[i] = 0xaa;
+    }
     rc = Ssystem(S_CONSOLE_DIM, (long)&oversized, (long)sizeof(oversized));
     ptest_assert_msg(rc == (long)sizeof(struct console_dim),
                      "Ssystem(S_CONSOLE_DIM) wrote more than it knows about");
+    {
+        unsigned i;
+        for (i = 0; i < sizeof(oversized.future); i++)
+            ptest_assert_msg(oversized.future[i] == 0xaa,
+                             "Ssystem(S_CONSOLE_DIM) overran into the "
+                             "caller's trailing bytes");
+    }
 
-    /* A NULL pointer or non-positive size must be rejected, not crash. */
+    /* size == -1 queries sizeof(struct console_dim) as the running
+     * kernel implements it, without writing anything -- arg1 is
+     * ignored, so NULL is fine here. This is how a caller discovers
+     * which struct version it's talking to up front. */
+    rc = Ssystem(S_CONSOLE_DIM, 0, -1L);
+    ptest_assert_msg(rc == (long)sizeof(struct console_dim),
+                     "Ssystem(S_CONSOLE_DIM) size query did not report "
+                     "sizeof(struct console_dim)");
+
+    /* A NULL pointer or non-positive size (other than the -1 query
+     * above) must be rejected, not crash. */
     rc = Ssystem(S_CONSOLE_DIM, 0, (long)sizeof(dim));
     ptest_assert_msg(rc < 0,
                      "Ssystem(S_CONSOLE_DIM) with a NULL pointer should fail");


### PR DESCRIPTION
## Summary

Adds `Ssystem(S_CONSOLE_DIM, ...)`, a pTOS-only extension to GEMDOS `Ssystem()` (`bdos/ssystem.c`/`bdos/ssystem.h`) that reports the console's text-cell dimensions (columns/rows) without going through the m68k Line-A trap.

`getwh()`/`getht()` (`cli/cmdasm.S`, `cli/cmdgetwh.c`) currently get these dimensions via Line-A, which is m68k-specific and doesn't exist at all on ARM. ARM's own implementation instead reads `bios/lineavars.h`'s `linea_vars` struct directly, which only works compiled into the kernel's own address space — not from a standalone userland program (called out as an accepted limitation in #233/PR #234, which is m68k-only for exactly this reason).

Before adding this, checked for an existing portable mechanism and found nothing usable:
- `Ssystem(S_GETWVAL, ...)` only covers the documented, fixed-address low-memory sysvar table (per FreeMiNT's own protocol) — `v_cel_mx`/`v_cel_my` were never part of that table on real TOS.
- VDI's `vq_extnd()` only reports pixel resolution (`DEV_TAB[0]/[1]`), not character-cell dimensions.
- The VT52 console (`bios/vt52.c`) is entirely write-only — no query/report escape sequence exists.

## Interface

```c
/* bdos/ssystem.h */

/* Outside MiNT's documented mode range (a negative WORD, same idiom as
 * S_INQUIRE) -- a pTOS-only extension, never a real MiNT mode. */
#define S_CONSOLE_DIM   ((WORD)0xfffe)

struct console_dim {
    UWORD width;    /* columns */
    UWORD height;   /* rows */
};
```

Called as `Ssystem(S_CONSOLE_DIM, arg1, arg2)`:

| arg1 | arg2 | Effect |
| --- | --- | --- |
| `struct console_dim *dim` | `sizeof(*dim)` | Copies `min(arg2, sizeof(struct console_dim))` bytes from the kernel's struct into `*dim`. Returns the number of bytes copied. |
| ignored (`0`/`NULL` is fine) | `-1` | Writes nothing. Returns `sizeof(struct console_dim)` as the running kernel implements it. |
| anything | `0` or negative (other than `-1`) | Returns `EINVFN`. |
| `NULL` | positive | Returns `EINVFN`. |

Two examples:

```c
struct console_dim dim;
long n = Ssystem(S_CONSOLE_DIM, (long)&dim, (long)sizeof(dim));
/* n == sizeof(dim) on a kernel that knows this exact struct version;
 * n < sizeof(dim) (and dim only partly filled) on an older kernel that
 * implements a smaller version of the struct. */

long max = Ssystem(S_CONSOLE_DIM, 0, -1L);
/* max == sizeof(struct console_dim) as the running kernel implements
 * it -- lets a caller size a buffer, or decide whether it's worth
 * reading fields a newer struct version might add, before ever
 * touching real memory. */
```

The `min(arg2, sizeof(struct console_dim))` truncation is what makes the struct extensible in both directions without an ABI break: a caller built against an older/smaller version of the struct gets just the fields that existed then; a caller built against a newer/larger struct than the running kernel implements gets only what that kernel actually has, and can tell which happened from the return value.

## Test plan

`tests/console_dim/console_dim.c` calls the interface above directly: a normal read, plausibility bounds on `width`/`height`, the oversized-struct case (with a sentinel in the trailing bytes, so the kernel is proven not to overrun them, not just report the right count), the `-1` size query, and the `EINVFN` rejection cases.

- [x] `make rpi2_defconfig && make && make test-hd`, booted under QEMU (`raspi2b`): `console_dim (#235)`, `pie_load`, and `stack_alignment (#214)` all PASS.
- [x] `make atari512_defconfig && make && make test-hd`, booted under Hatari: `console_dim (#235)` PASSes via an `S_INQUIRE` skip path — `Ssystem()` itself is currently ARM-only (`bdos/bdosmain.c`'s `osif()`, `#ifdef __arm__`; filed #237 to track fixing that separately), so the test probes `S_INQUIRE` first and skips the rest on m68k rather than asserting against a call the running kernel never claimed to support.
- [x] `atari512_defconfig` and `rpi2_defconfig` both still build cleanly outside the regression-test config.
- [x] `make gitready`

Fixes #235