### PR TITLE
bdos: extend Ssystem(S_CONSOLE_DIM) with the font's pixel cell size

### DIFF
--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -358,8 +358,9 @@ static LONG ssystem_osversion(void)
  *
  * v_cel_mx/v_cel_my (bios/lineavars.h) hold the screen's last valid
  * column/row index, i.e. one less than the actual width/height -- add 1
- * to report the usable count a caller like getwh()/getht() actually
- * wants.
+ * to report the usable count a caller like getwh() actually wants.
+ * v_cel_ht is already the cell height itself (in pixels), not an index,
+ * so it's copied as is.
  *
  * arg1 is the caller's struct console_dim*, arg2 its sizeof() -- only
  * min(arg2, sizeof(our struct)) bytes are copied, so a caller's struct
@@ -381,6 +382,7 @@ static LONG ssystem_console_dim(LONG arg1, LONG arg2)
 
     dim.width = linea_vars.v_cel_mx + 1;
     dim.height = linea_vars.v_cel_my + 1;
+    dim.cell_height = linea_vars.v_cel_ht;
 
     n = arg2 < (LONG)sizeof(dim) ? arg2 : (LONG)sizeof(dim);
     svar_copy((void *)arg1, &dim, n);

--- a/bdos/ssystem.c
+++ b/bdos/ssystem.c
@@ -360,7 +360,9 @@ static LONG ssystem_osversion(void)
  * column/row index, i.e. one less than the actual width/height -- add 1
  * to report the usable count a caller like getwh() actually wants.
  * v_cel_ht is already the cell height itself (in pixels), not an index,
- * so it's copied as is.
+ * so it's copied as is. There's no v_cel_wd to match it: cell width is
+ * a fixed 8 pixels everywhere pTOS runs (see v_cel_ht's own comment in
+ * bios/lineavars.h), not a stored variable.
  *
  * arg1 is the caller's struct console_dim*, arg2 its sizeof() -- only
  * min(arg2, sizeof(our struct)) bytes are copied, so a caller's struct
@@ -382,6 +384,7 @@ static LONG ssystem_console_dim(LONG arg1, LONG arg2)
 
     dim.width = linea_vars.v_cel_mx + 1;
     dim.height = linea_vars.v_cel_my + 1;
+    dim.cell_width = 8;
     dim.cell_height = linea_vars.v_cel_ht;
 
     n = arg2 < (LONG)sizeof(dim) ? arg2 : (LONG)sizeof(dim);

--- a/bdos/ssystem.h
+++ b/bdos/ssystem.h
@@ -75,6 +75,8 @@
 struct console_dim {
     UWORD width;        /* columns */
     UWORD height;       /* rows */
+    UWORD cell_width;   /* font cell width, in pixels -- always 8 (see
+                          * bios/lineavars.h's v_cel_ht comment) */
     UWORD cell_height;  /* font cell height, in pixels (v_cel_ht) */
 };
 

--- a/bdos/ssystem.h
+++ b/bdos/ssystem.h
@@ -73,8 +73,9 @@
 #define S_CONSOLE_DIM   ((WORD)0xfffe)
 
 struct console_dim {
-    UWORD width;    /* columns */
-    UWORD height;   /* rows */
+    UWORD width;        /* columns */
+    UWORD height;       /* rows */
+    UWORD cell_height;  /* font cell height, in pixels (v_cel_ht) */
 };
 
 LONG xssystem(WORD mode, LONG arg1, LONG arg2);

--- a/tests/console_dim/console_dim.c
+++ b/tests/console_dim/console_dim.c
@@ -32,6 +32,7 @@ void test_console_dim(void);
 struct console_dim {
     unsigned short width;        /* columns */
     unsigned short height;       /* rows */
+    unsigned short cell_width;   /* font cell width, in pixels -- always 8 */
     unsigned short cell_height;  /* font cell height, in pixels */
 };
 
@@ -70,6 +71,10 @@ void test_console_dim(void)
                      "console width out of plausible range");
     ptest_assert_msg(dim.height > 0 && dim.height <= 500,
                      "console height out of plausible range");
+    /* Cell width is a fixed pTOS-wide constant, not derived from
+     * anything variable -- an exact match is the right check. */
+    ptest_assert_msg(dim.cell_width == 8,
+                     "console cell width was not the expected 8");
     /* pTOS fonts are 6x6, 8x8 or 8x16 (bios/font.c) -- generous bounds
      * around that rather than an exact match, in case a future font is
      * added. */

--- a/tests/console_dim/console_dim.c
+++ b/tests/console_dim/console_dim.c
@@ -30,8 +30,9 @@ void test_console_dim(void);
 /* Mirrors bdos/ssystem.h's struct console_dim -- not shared via a header
  * since this is userland/libcmini code, not kernel code. */
 struct console_dim {
-    unsigned short width;   /* columns */
-    unsigned short height;  /* rows */
+    unsigned short width;        /* columns */
+    unsigned short height;       /* rows */
+    unsigned short cell_height;  /* font cell height, in pixels */
 };
 
 void test_console_dim(void)
@@ -69,6 +70,11 @@ void test_console_dim(void)
                      "console width out of plausible range");
     ptest_assert_msg(dim.height > 0 && dim.height <= 500,
                      "console height out of plausible range");
+    /* pTOS fonts are 6x6, 8x8 or 8x16 (bios/font.c) -- generous bounds
+     * around that rather than an exact match, in case a future font is
+     * added. */
+    ptest_assert_msg(dim.cell_height > 0 && dim.cell_height <= 64,
+                     "console cell height out of plausible range");
 
     /* A caller struct larger than the kernel's own must not overrun --
      * only sizeof(struct console_dim) bytes get written. Fill the


### PR DESCRIPTION
## Summary

`struct console_dim` (`Ssystem(S_CONSOLE_DIM, ...)`, added in #235/#236) only carried `width`/`height` in text columns/rows. Adds `cell_width` and `cell_height` (the font's pixel cell dimensions), appended after `width`/`height` so the byte layout stays backward-compatible for callers built against the 2-field version — exactly the extensibility `min(arg2, sizeof(struct console_dim))` truncation contract was designed for.

Final layout: `{ width; height; cell_width; cell_height; }`.

PR #234 (the ARM standalone `emucon2.tos`) needs this: its `getht()` (`cli/cmdgetwh.c`), used by EmuCON's `MODE CON` status display, currently falls back to a fixed `8` for lack of a portable way to read `v_cel_ht` on standalone ARM. This unblocks reading the real value.

## Changes

- `bdos/ssystem.h`: `struct console_dim` gains `UWORD cell_width` and `UWORD cell_height`.
- `bdos/ssystem.c`: `ssystem_console_dim()` populates `cell_height` from `linea_vars.v_cel_ht` (already the pixel height itself, unlike `v_cel_mx`/`v_cel_my`, so no `+1`). `cell_width` has no corresponding stored variable — `bios/lineavars.h`'s own comment on `v_cel_ht` ("cell height (width is 8)") documents it as a fixed 8 pixels everywhere pTOS runs, so it's just the constant `8`.
- `tests/console_dim/console_dim.c`: mirrors both new fields — an exact-match assertion on `cell_width` (always 8) and a plausibility range on `cell_height` (pTOS fonts are 6x6/8x8/8x16, per `bios/font.c`).

Fixes #238

## Test plan

- [x] `make rpi2_defconfig && make && make test-hd`, booted under QEMU (`raspi2b`): `console_dim (#235)`, `pie_load`, and `stack_alignment (#214)` all PASS, including the new `cell_width`/`cell_height` checks.
- [x] `make atari512_defconfig && make && make test-hd`, booted under Hatari: `console_dim (#235)` still PASSes via the `S_INQUIRE` skip path.
- [x] `make gitready`