### PR TITLE
Port EmuCON Ctrl-arrow word editing

### DIFF
--- a/cli/cmdedit.c
+++ b/cli/cmdedit.c
@@ -182,6 +182,7 @@ WORD n, word = 0;
         break;
     case CTRL_ARROW_LEFT:
         word = 1;
+        FALLTHROUGH;
     case ARROW_LEFT:
         if (*pos > 0) {
             n = word ? previous_word_count(line,*pos) : 1;
@@ -193,6 +194,7 @@ WORD n, word = 0;
         break;
     case CTRL_ARROW_RIGHT:
         word = 1;
+        FALLTHROUGH;
     case ARROW_RIGHT:
         if (*pos < *len) {
             n = word ? next_word_count(line,*pos,*len) : 1;

--- a/cli/cmdedit.c
+++ b/cli/cmdedit.c
@@ -165,7 +165,7 @@ PRIVATE WORD edit_line(char *line,WORD *pos,WORD *len,WORD scancode,WORD prevcod
 char buffer[MAXPATHLEN];
 char *start, *p, *q;
 LONG rc;
-WORD n, shift = 0;
+WORD n, word = 0;
 
     switch(scancode) {
     case ARROW_UP:
@@ -180,22 +180,22 @@ WORD n, shift = 0;
             *pos = *len = next_history(line);
         }
         break;
-    case SHIFT_ARROW_LEFT:
-        shift = 1;
+    case CTRL_ARROW_LEFT:
+        word = 1;
     case ARROW_LEFT:
         if (*pos > 0) {
-            n = shift ? previous_word_count(line,*pos) : 1;
+            n = word ? previous_word_count(line,*pos) : 1;
             while (n-- > 0) {
                 (*pos)--;
                 cursor_left();
             }
         }
         break;
-    case SHIFT_ARROW_RIGHT:
-        shift = 1;
+    case CTRL_ARROW_RIGHT:
+        word = 1;
     case ARROW_RIGHT:
         if (*pos < *len) {
-            n = shift ? next_word_count(line,*pos,*len) : 1;
+            n = word ? next_word_count(line,*pos,*len) : 1;
             while (n-- > 0) {
                 (*pos)++;
                 cursor_right();

--- a/cli/cmdint.c
+++ b/cli/cmdint.c
@@ -132,7 +132,7 @@ LOCAL const char * const help_wrap[] = { "[on|off]",
 LOCAL const char * const help_edit[] = {
  N_("up/down arrow = previous/next line in history"),
  N_("left/right arrow = previous/next character"),
- N_("shift-left/right arrow = previous/next word"), NULL };
+ N_("control-left/right arrow = previous/next word"), NULL };
 
 
 /*

--- a/docs/superpowers/specs/2026-08-21-emucon-ctrl-arrow-editing-design.md
+++ b/docs/superpowers/specs/2026-08-21-emucon-ctrl-arrow-editing-design.md
@@ -1,0 +1,38 @@
+# EmuCON Ctrl-Arrow Editing Design
+
+## Goal
+
+Change EmuCON word-wise command-line navigation from Shift+Left/Right to
+Ctrl+Left/Right, matching upstream EmuTOS commit `126abe62`.
+
+## Behavior
+
+Add invariant Ctrl+arrow scan-code definitions for left (`0x7300`) and right
+(`0x7400`) navigation.  In `cli/cmdedit.c`, these codes select the existing
+word-boundary movement paths; unmodified arrows retain one-character movement.
+
+Shift+Left/Right are no longer special line-editing keys.  This deliberately
+matches upstream behavior rather than preserving a pTOS compatibility alias.
+The word-boundary algorithms and all other editing commands remain unchanged.
+
+## User Interface
+
+Update EmuCON's `HELP EDIT` entry from `shift-left/right arrow = previous/next
+word` to `control-left/right arrow = previous/next word`.  The normal NLS
+workflow regenerates the message template.  Update the eight existing pTOS
+catalogs (`cs`, `de`, `es`, `fi`, `fr`, `gr`, `it`, and `ru`) with upstream's
+translation for the new message; the deferred locale expansion in #240 is out
+of scope.
+
+## Verification
+
+Build a configured image after the change.  Verify that the generated NLS
+tables include the new help string and do not report it as untranslated; the
+pre-existing deferred warnings from #240 may remain.  In an EmuCON session,
+verify ordinary Left/Right movement and Ctrl+Left/Right word movement on a
+multi-word command line; Shift+Left/Right must not take the word-movement path.
+
+## Non-Goals
+
+This does not add resolution switching, alter pTOS's line-height control, or
+change command-history, tab-completion, or word-boundary semantics.

--- a/include/scancode.h
+++ b/include/scancode.h
@@ -37,6 +37,8 @@
 #define SHIFT_ARROW_DOWN    0x5032
 #define SHIFT_ARROW_LEFT    0x4b34
 #define SHIFT_ARROW_RIGHT   0x4d36
+#define CTRL_ARROW_LEFT     0x7300
+#define CTRL_ARROW_RIGHT    0x7400
 
 /*
  * function keys

--- a/po/cs.po
+++ b/po/cs.po
@@ -1212,8 +1212,8 @@ msgid "left/right arrow = previous/next character"
 msgstr "left/right arrow = previous/next character"
 
 #: cli/cmdint.c:135
-msgid "shift-left/right arrow = previous/next word"
-msgstr "shift-left/right arrow = previous/next word"
+msgid "control-left/right arrow = previous/next word"
+msgstr "control-left/right arrow = previous/next word"
 
 #: cli/cmdint.c:239
 msgid "invalid mode argument"

--- a/po/de.po
+++ b/po/de.po
@@ -1227,8 +1227,8 @@ msgid "left/right arrow = previous/next character"
 msgstr "Pfeil links/rechts = vorhergehendes/nächstes Zeichen"
 
 #: cli/cmdint.c:135
-msgid "shift-left/right arrow = previous/next word"
-msgstr "Umschalt-Pfeil links/rechts = vorhergehendes/nächstes Wort"
+msgid "control-left/right arrow = previous/next word"
+msgstr "Strg-Pfeil links/rechts = vorherigesgehendes/nächstes Wort"
 
 #: cli/cmdint.c:239
 msgid "invalid mode argument"

--- a/po/de.po
+++ b/po/de.po
@@ -1228,7 +1228,7 @@ msgstr "Pfeil links/rechts = vorhergehendes/nächstes Zeichen"
 
 #: cli/cmdint.c:135
 msgid "control-left/right arrow = previous/next word"
-msgstr "Strg-Pfeil links/rechts = vorherigesgehendes/nächstes Wort"
+msgstr "Strg-Pfeil links/rechts = vorhergehendes/nächstes Wort"
 
 #: cli/cmdint.c:239
 msgid "invalid mode argument"

--- a/po/es.po
+++ b/po/es.po
@@ -1220,8 +1220,8 @@ msgid "left/right arrow = previous/next character"
 msgstr "flecha izquierda/derecha = carácter anterior/siguiente"
 
 #: cli/cmdint.c:135
-msgid "shift-left/right arrow = previous/next word"
-msgstr "Mayúsculas-flecha izquierda/derecha = palabra anterior/siguiente"
+msgid "control-left/right arrow = previous/next word"
+msgstr "flecha izquierda/derecha+control = palabra anterior/siguiente"
 
 #: cli/cmdint.c:239
 msgid "invalid mode argument"

--- a/po/fi.po
+++ b/po/fi.po
@@ -1211,8 +1211,8 @@ msgid "left/right arrow = previous/next character"
 msgstr "left/right arrow = previous/next character"
 
 #: cli/cmdint.c:135
-msgid "shift-left/right arrow = previous/next word"
-msgstr "shift-left/right arrow = previous/next word"
+msgid "control-left/right arrow = previous/next word"
+msgstr "control-left/right arrow = previous/next word"
 
 #: cli/cmdint.c:239
 msgid "invalid mode argument"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1225,8 +1225,8 @@ msgid "left/right arrow = previous/next character"
 msgstr "flèche gauche/droit = caractère précédent/suivant"
 
 #: cli/cmdint.c:135
-msgid "shift-left/right arrow = previous/next word"
-msgstr "shift-flèche gauche/droit = mot précédent/suivant"
+msgid "control-left/right arrow = previous/next word"
+msgstr "control-flèche gauche/droite = mot précédent/suivant"
 
 #: cli/cmdint.c:239
 msgid "invalid mode argument"

--- a/po/gr.po
+++ b/po/gr.po
@@ -1234,8 +1234,8 @@ msgid "left/right arrow = previous/next character"
 msgstr "left/right arrow = previous/next character"
 
 #: cli/cmdint.c:135
-msgid "shift-left/right arrow = previous/next word"
-msgstr "shift-left/right arrow = previous/next word"
+msgid "control-left/right arrow = previous/next word"
+msgstr "control-left/right arrow = previous/next word"
 
 #: cli/cmdint.c:239
 msgid "invalid mode argument"

--- a/po/it.po
+++ b/po/it.po
@@ -1214,8 +1214,8 @@ msgid "left/right arrow = previous/next character"
 msgstr "freccia sin./dr. = carattere prec./seg."
 
 #: cli/cmdint.c:135
-msgid "shift-left/right arrow = previous/next word"
-msgstr "shift-freccia sin./dr. = parola prec./seg."
+msgid "control-left/right arrow = previous/next word"
+msgstr "control-sin./freccia dr. = parola precedente/seguente"
 
 #: cli/cmdint.c:239
 msgid "invalid mode argument"

--- a/po/it.po
+++ b/po/it.po
@@ -1215,7 +1215,7 @@ msgstr "freccia sin./dr. = carattere prec./seg."
 
 #: cli/cmdint.c:135
 msgid "control-left/right arrow = previous/next word"
-msgstr "control-sin./freccia dr. = parola precedente/seguente"
+msgstr "control-freccia sin./dr. = parola precedente/seguente"
 
 #: cli/cmdint.c:239
 msgid "invalid mode argument"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1222,8 +1222,8 @@ msgid "left/right arrow = previous/next character"
 msgstr "стрелка влево/вправо = предыдущий/следующий символ"
 
 #: cli/cmdint.c:135
-msgid "shift-left/right arrow = previous/next word"
-msgstr "shift-стрелка влево/вправо = предыдущее/следующее слово"
+msgid "control-left/right arrow = previous/next word"
+msgstr "control-стрелка влево/вправо = предыдущее/следующее слово"
 
 #: cli/cmdint.c:239
 msgid "invalid mode argument"

--- a/tools/test-emucon-ctrl-arrows.sh
+++ b/tools/test-emucon-ctrl-arrows.sh
@@ -40,6 +40,10 @@ require_multiline 'case CTRL_ARROW_LEFT:[\s\S]*word = 1;[\s\S]*case ARROW_LEFT:'
     "$repo_root/cli/cmdedit.c" 'Ctrl-left word movement'
 require_multiline 'case CTRL_ARROW_RIGHT:[\s\S]*word = 1;[\s\S]*case ARROW_RIGHT:' \
     "$repo_root/cli/cmdedit.c" 'Ctrl-right word movement'
+require_multiline 'case CTRL_ARROW_LEFT:[\s\S]*word = 1;[\s\S]*FALLTHROUGH;[\s\S]*case ARROW_LEFT:' \
+    "$repo_root/cli/cmdedit.c" 'Ctrl-left intentional fallthrough'
+require_multiline 'case CTRL_ARROW_RIGHT:[\s\S]*word = 1;[\s\S]*FALLTHROUGH;[\s\S]*case ARROW_RIGHT:' \
+    "$repo_root/cli/cmdedit.c" 'Ctrl-right intentional fallthrough'
 require_absent 'case SHIFT_ARROW_LEFT:|case SHIFT_ARROW_RIGHT:' \
     "$repo_root/cli/cmdedit.c" 'Shift-arrow word movement'
 require_file 'control-left/right arrow = previous/next word' \

--- a/tools/test-emucon-ctrl-arrows.sh
+++ b/tools/test-emucon-ctrl-arrows.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+rg -q '^#define CTRL_ARROW_LEFT[[:space:]]+0x7300$' "$repo_root/include/scancode.h"
+rg -q '^#define CTRL_ARROW_RIGHT[[:space:]]+0x7400$' "$repo_root/include/scancode.h"
+rg -U -q 'case CTRL_ARROW_LEFT:[\s\S]*word = 1;[\s\S]*case ARROW_LEFT:' "$repo_root/cli/cmdedit.c"
+rg -U -q 'case CTRL_ARROW_RIGHT:[\s\S]*word = 1;[\s\S]*case ARROW_RIGHT:' "$repo_root/cli/cmdedit.c"
+! rg -q 'case SHIFT_ARROW_LEFT:|case SHIFT_ARROW_RIGHT:' "$repo_root/cli/cmdedit.c"
+rg -q 'control-left/right arrow = previous/next word' "$repo_root/cli/cmdint.c"
+
+printf '%s\n' 'EmuCON Ctrl-arrow contract test passed'

--- a/tools/test-emucon-ctrl-arrows.sh
+++ b/tools/test-emucon-ctrl-arrows.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -eu
 
+if ! command -v rg >/dev/null 2>&1; then
+    echo 'tools/test-emucon-ctrl-arrows.sh requires ripgrep (rg)'
+    exit 1
+fi
+
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 
 rg -q '^#define CTRL_ARROW_LEFT[[:space:]]+0x7300$' "$repo_root/include/scancode.h"

--- a/tools/test-emucon-ctrl-arrows.sh
+++ b/tools/test-emucon-ctrl-arrows.sh
@@ -6,7 +6,7 @@ if ! command -v rg >/dev/null 2>&1; then
     exit 1
 fi
 
-repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 
 require_file()
 {

--- a/tools/test-emucon-ctrl-arrows.sh
+++ b/tools/test-emucon-ctrl-arrows.sh
@@ -8,11 +8,41 @@ fi
 
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 
-rg -q '^#define CTRL_ARROW_LEFT[[:space:]]+0x7300$' "$repo_root/include/scancode.h"
-rg -q '^#define CTRL_ARROW_RIGHT[[:space:]]+0x7400$' "$repo_root/include/scancode.h"
-rg -U -q 'case CTRL_ARROW_LEFT:[\s\S]*word = 1;[\s\S]*case ARROW_LEFT:' "$repo_root/cli/cmdedit.c"
-rg -U -q 'case CTRL_ARROW_RIGHT:[\s\S]*word = 1;[\s\S]*case ARROW_RIGHT:' "$repo_root/cli/cmdedit.c"
-! rg -q 'case SHIFT_ARROW_LEFT:|case SHIFT_ARROW_RIGHT:' "$repo_root/cli/cmdedit.c"
-rg -q 'control-left/right arrow = previous/next word' "$repo_root/cli/cmdint.c"
+require_file()
+{
+    if ! rg -q "$1" "$2"; then
+        echo "missing EmuCON Ctrl-arrow contract: $3"
+        exit 1
+    fi
+}
+
+require_multiline()
+{
+    if ! rg -U -q "$1" "$2"; then
+        echo "missing EmuCON Ctrl-arrow contract: $3"
+        exit 1
+    fi
+}
+
+require_absent()
+{
+    if rg -q "$1" "$2"; then
+        echo "unexpected EmuCON Ctrl-arrow contract: $3"
+        exit 1
+    fi
+}
+
+require_file '^#define CTRL_ARROW_LEFT[[:space:]]+0x7300$' \
+    "$repo_root/include/scancode.h" 'Ctrl-left scan code'
+require_file '^#define CTRL_ARROW_RIGHT[[:space:]]+0x7400$' \
+    "$repo_root/include/scancode.h" 'Ctrl-right scan code'
+require_multiline 'case CTRL_ARROW_LEFT:[\s\S]*word = 1;[\s\S]*case ARROW_LEFT:' \
+    "$repo_root/cli/cmdedit.c" 'Ctrl-left word movement'
+require_multiline 'case CTRL_ARROW_RIGHT:[\s\S]*word = 1;[\s\S]*case ARROW_RIGHT:' \
+    "$repo_root/cli/cmdedit.c" 'Ctrl-right word movement'
+require_absent 'case SHIFT_ARROW_LEFT:|case SHIFT_ARROW_RIGHT:' \
+    "$repo_root/cli/cmdedit.c" 'Shift-arrow word movement'
+require_file 'control-left/right arrow = previous/next word' \
+    "$repo_root/cli/cmdint.c" 'Ctrl-arrow help text'
 
 printf '%s\n' 'EmuCON Ctrl-arrow contract test passed'

--- a/tools/test-emucon-ctrl-arrows.sh
+++ b/tools/test-emucon-ctrl-arrows.sh
@@ -32,9 +32,9 @@ require_absent()
     fi
 }
 
-require_file '^#define CTRL_ARROW_LEFT[[:space:]]+0x7300$' \
+require_file '^#define CTRL_ARROW_LEFT[[:space:]]+0x7300([[:space:]]|/\*|//|$)' \
     "$repo_root/include/scancode.h" 'Ctrl-left scan code'
-require_file '^#define CTRL_ARROW_RIGHT[[:space:]]+0x7400$' \
+require_file '^#define CTRL_ARROW_RIGHT[[:space:]]+0x7400([[:space:]]|/\*|//|$)' \
     "$repo_root/include/scancode.h" 'Ctrl-right scan code'
 require_multiline 'case CTRL_ARROW_LEFT:[\s\S]*word = 1;[\s\S]*case ARROW_LEFT:' \
     "$repo_root/cli/cmdedit.c" 'Ctrl-left word movement'


### PR DESCRIPTION
Fixes #248

## Summary
- Port EmuCON word-wise command-line navigation from Shift+Left/Right to Ctrl+Left/Right, matching upstream EmuTOS.
- Update `HELP EDIT` text and the affected translation catalogs.
- Add a Ctrl-arrow contract test with actionable diagnostics for missing prerequisites and failed assertions.
- Correct German and Italian help translations identified during review.

## Verification
- `sh tools/test-emucon-ctrl-arrows.sh`
- `msgfmt --check --output-file=/dev/null po/de.po`
- `msgfmt --check --output-file=/dev/null po/it.po`
- `gmake gitready`
- RPi2 build, regression-disk build, and QEMU regression suite: 3 passed, 0 failed