### PR TITLE
Port EmuCON MODE CON resolution switching

### DIFF
--- a/cli/cmd.h
+++ b/cli/cmd.h
@@ -13,6 +13,10 @@
  #include "config.h"
  #include <nls.h>
  #include <portab.h>
+ /* the ROM build shares cli/ across every machine, so gate resolution
+    switching on the Atari video hardware actually configured in */
+ #define CLI_WITH_RESOLUTION    CONF_WITH_ATARI_VIDEO
+ #define CLI_WITH_TT_RESOLUTION CONF_WITH_TT_SHIFTER
 #else
  #define _(a) a
  #define N_(a) a
@@ -28,6 +32,9 @@
  #define HIWORD(x) ((UWORD)((ULONG)(x) >> 16))
  #define LOBYTE(x) ((UBYTE)(UWORD)(x))
  #define HIBYTE(x) ((UBYTE)((UWORD)(x) >> 8))
+ /* the standalone tool only ever targets real Atari hardware */
+ #define CLI_WITH_RESOLUTION    1
+ #define CLI_WITH_TT_RESOLUTION 1
 #endif
 
 
@@ -55,6 +62,7 @@ extern LONG jmp_xbios(WORD, ...);
 #define jmp_gemdos_wppp(a,b,c,d,e)  jmp_gemdos((WORD)(a),(WORD)(b),(void *)(c),(void *)(d),(void *)(e))
 #define jmp_bios_w(a,b)         jmp_bios((WORD)(a),(WORD)(b))
 #define jmp_bios_ww(a,b,c)      jmp_bios((WORD)(a),(WORD)(b),(WORD)(c))
+#define jmp_xbios_v(a)          jmp_xbios((WORD)(a))
 #define jmp_xbios_l(a,b)        jmp_xbios((WORD)(a),(LONG)(b))
 #define jmp_xbios_llww(a,b,c,d,e)   jmp_xbios((WORD)a,(LONG)b,(LONG)c,(WORD)d,(WORD)e)
 #define jmp_xbios_ww(a,b,c)     jmp_xbios((WORD)(a),(WORD)(b),(WORD)(c))
@@ -123,6 +131,7 @@ static __inline__ long cli_supexec_(long a)
 
 #ifdef STANDALONE_CONSOLE
 /* ROM build gets these from xbiosbind.h included above */
+#define Getrez()            jmp_xbios_v(0x04)
 #define Setscreen(a,b,c,d)  jmp_xbios_llww(0x05,a,b,c,d)
 #define Cursconf(a,b)       jmp_xbios_ww(0x15,a,b)
 #define Kbrate(a,b)         jmp_xbios_ww(0x23,a,b)
@@ -158,6 +167,20 @@ static __inline__ long cli_supexec_(long a)
 
 #define DEFAULT_DT_SEPARATOR    '/'
 #define DEFAULT_DT_FORMAT   ((_IDT_12H<<12) + (_IDT_YMD<<8) + DEFAULT_DT_SEPARATOR)
+
+/*
+ * video stuff
+ */
+#define _VDO_COOKIE     0x5f56444fL     /* '_VDO' */
+#define _VDO_ST         0x00000000L     /* ST */
+#define _VDO_TT         0x00020000L     /* TT */
+#define _VDO_VIDEL      0x00030000L     /* Falcon videl */
+#define ST_LOW          0               /* from Getrez() */
+#define ST_MEDIUM       1
+#define ST_HIGH         2
+#define TT_MEDIUM       4
+#define TT_HIGH         6
+#define TT_LOW          7
 
 /*
  *  typedefs
@@ -198,6 +221,7 @@ typedef LONG FUNC(WORD argc,char **argv);
 #define CMDLINE_LENGTH  -103
 #define DIR_NOT_EMPTY   -104        /* translated from EACCDN for folders */
 #define CANT_DELETE     -105        /* translated from EACCDN for files */
+#define CHANGE_RES      -125        /* returned by mode command */
 #define INVALID_PARAM   -126        /* for builtin commands */
 #define WRONG_NUM_ARGS  -127        /* for builtin commands */
 
@@ -230,18 +254,21 @@ extern WORD linewrap;
 extern DTA *dta;
 extern LONG redir_handle;
 extern char user_path[MAXPATHLEN];     /* from PATH command */
+extern WORD current_res, requested_res;
 
 /*
  *  function prototypes
  */
 /* cmdmain.c */
 void outlong(ULONG n,WORD width,char filler);
+int valid_res(WORD res);
 
 /* cmdedit.c */
 WORD init_cmdedit(void);
 void insert_char(char *line,WORD pos,WORD len,char c);
 WORD read_line(char *line);
 void save_history(const char *line);
+void term_cmdedit(void);
 
 /* cmdexec.c */
 LONG exec_program(WORD argc,char **argv,char *redir_name);

--- a/cli/cmdedit.c
+++ b/cli/cmdedit.c
@@ -144,6 +144,17 @@ WORD i;
 }
 
 /*
+ *  cleanup command editing globals
+ */
+void term_cmdedit(void)
+{
+    if (history_num >= 0)
+        Mfree(history_line[0]);
+
+    history_num = -1;       /* history not available */
+}
+
+/*
  *  save a line in the history
  */
 void save_history(const char *line)

--- a/cli/cmdint.c
+++ b/cli/cmdint.c
@@ -99,10 +99,18 @@ LOCAL const char * const help_ls[] = { "[-l] <path>",
     N_("Specify -l for detailed list"), NULL };
 LOCAL const char * const help_mkdir[] = { "<dir>",
     N_("Create directory <dir>"), NULL };
+#if CLI_WITH_RESOLUTION
+LOCAL const char * const help_mode[] = { "con[:] [res=<r>] [delay=<m>] [rate=<n>] [height=<h>]",
+    N_("Set or display console settings:"),
+    N_("res for screen resolution (0,1)[ST] (0,1,2,4,7)[TT];"),
+    N_("delay/rate for the keyboard;"),
+    N_("line height (8,16) for the display"), NULL };
+#else
 LOCAL const char * const help_mode[] = { "con[:] [delay=<m>] [rate=<n>] [height=<h>]",
     N_("Set or display console settings:"),
     N_("delay/rate for the keyboard;"),
     N_("line height (8,16) for the display"), NULL };
+#endif
 LOCAL const char * const help_more[] = { "<filespec>",
     N_("Copy <filespec> to standard output,"),
     N_("pausing every screenful"), NULL };
@@ -149,7 +157,7 @@ LOCAL const COMMAND cmdtable[] = {
     { "help", NULL, 0, 1, run_help, help_help },
     { "ls", "dir", 0, 2, run_ls, help_ls },
     { "mkdir", "md", 1, 1, run_mkdir, help_mkdir },
-    { "mode", NULL, 1, 4, run_mode, help_mode },
+    { "mode", NULL, 1, 5, run_mode, help_mode },
     { "more", NULL, 1, 1, run_more, help_more },
     { "mv", "move", 2, 2, run_mv, help_mv },
     { "path", NULL, 0, 1, run_path, help_path },
@@ -376,13 +384,18 @@ PRIVATE LONG run_mode(WORD argc,char **argv)
 {
 char buf[80];
 WORD i, old;
-WORD rate = -1, delay = -1, height = -1;
+WORD res = -1, rate = -1, delay = -1, height = -1;
 
     argv++;
     if (strequal(*argv,"con") || strequal(*argv,"con:")) {
         if (argc == 2) {    /* just status wanted */
-            old = Kbrate(-1,-1);
             outputnl(_("Status for CON:"));
+            if (current_res >= 0) {
+                output(_("  Resolution:     "));
+                convulong(buf,current_res,3,' ');
+                outputnl(buf);
+            }
+            old = Kbrate(-1,-1);
             output(_("  Keyboard delay: "));
             convulong(buf,HIBYTE(old),3,' ');
             outputnl(buf);
@@ -395,7 +408,11 @@ WORD rate = -1, delay = -1, height = -1;
             return 0;
         }
         for (i = 2, argv++; i < argc; i++, argv++) {
-            if (strncasecmp(*argv,"delay=",6) == 0) {
+            if (strncasecmp(*argv,"res=",4) == 0) {
+                res = getword(*argv+4);
+                if (!valid_res(res))
+                    return INVALID_PARAM;
+            } else if (strncasecmp(*argv,"delay=",6) == 0) {
                 delay = getword(*argv+6);
                 if (delay < 0)
                     return INVALID_PARAM;
@@ -414,6 +431,10 @@ WORD rate = -1, delay = -1, height = -1;
         if (height >= 0) {
             Setscreen(-1L,-1L,-1,height);
             enable_cursor();
+        }
+        if ((res >= 0) && (res != current_res)) {
+            requested_res = res;
+            return CHANGE_RES;
         }
         return 0;
     }

--- a/cli/cmdmain.c
+++ b/cli/cmdmain.c
@@ -30,6 +30,7 @@
 LONG idt_value;
 UWORD screen_cols, screen_rows;
 UWORD linesize;
+WORD current_res, requested_res;
 WORD linewrap;
 DTA *dta;
 char user_path[MAXPATHLEN];
@@ -41,10 +42,13 @@ LONG redir_handle;
 LOCAL char input_line[MAX_LINE_SIZE];
 LOCAL char *arglist[MAX_ARGS];
 LOCAL char redir_name[MAXPATHLEN];
+LOCAL WORD original_res;
+LOCAL LONG vdo_value;
 
 /*
  *  function prototypes
  */
+PRIVATE void change_res(WORD res);
 PRIVATE void close_redir(void);
 PRIVATE void create_redir(const char *name);
 PRIVATE WORD execute(WORD argc,char **argv,char *redir);
@@ -69,33 +73,61 @@ ULONG n;
     if (getcookie(_IDT_COOKIE,&idt_value) == 0)
         idt_value = DEFAULT_DT_FORMAT;      /* if not found, make sure it's initialised properly */
 
-    n = getwh();                            /* get max cell number for x and y */
-    screen_cols = HIWORD(n) + 1;
-    screen_rows = LOWORD(n) + 1;
-    linesize = screen_cols + 1 - 3;         /* allow for trailing NUL and prompt */
+    if (getcookie(_VDO_COOKIE,&vdo_value) == 0)
+        vdo_value = _VDO_ST;
+#if CLI_WITH_RESOLUTION
+#if CLI_WITH_TT_RESOLUTION
+    original_res = (vdo_value < _VDO_VIDEL) ? Getrez() : -1;
+#else
+    original_res = (vdo_value < _VDO_TT) ? Getrez() : -1;
+#endif
+#else
+    original_res = -1;
+#endif
 
     linewrap = 0;
     dta = (DTA *)Fgetdta();
     redir_handle = -1L;
-
-    if (init_cmdedit() < 0)
-        messagenl(_("warning: no history buffers"));
+    current_res = original_res;
 
     while(1) {
-        rc = read_line(input_line);
-        save_history(input_line);
-        if (rc < 0)         /* user cancelled line */
-            continue;
-        argc = parse_line(input_line,arglist,redir_name);
-        if (argc < 0)       /* parse error */
-            continue;
-        if (execute(argc,arglist,redir_name) < 0)
-            break;
+        n = getwh();                            /* get max cell number for x and y */
+        screen_cols = HIWORD(n) + 1;
+        screen_rows = LOWORD(n) + 1;
+        linesize = screen_cols + 1 - 3;         /* allow for trailing NUL and prompt */
+
+        if (init_cmdedit() < 0)
+            messagenl(_("warning: no history buffers"));
+
+        do {
+            rc = read_line(input_line);
+            save_history(input_line);
+            if (rc < 0)         /* user cancelled line */
+                continue;
+            argc = parse_line(input_line,arglist,redir_name);
+            if (argc < 0)       /* parse error */
+                continue;
+            rc = execute(argc,arglist,redir_name);
+            if (rc < 0) {       /* exit EmuCON */
+                change_res(original_res);
+                return 0;
+            }
+        } while (rc <= 0);      /* until resolution change requested */
+
+        term_cmdedit();     /* cleanup before re-initialising for new resolution */
+        change_res(requested_res);
     }
 
     return 0;
 }
 
+/*
+ * execute a builtin command or external program
+ *
+ * returns: -1  EmuCON should exit
+ *          0   normal
+ *          +1  EmuCON should change resolution
+ */
 PRIVATE WORD execute(WORD argc,char **argv,char *redir)
 {
 FUNC *func;
@@ -115,10 +147,61 @@ LONG rc;
         strip_quotes(argc,argv);
         rc = func(argc,argv);
         close_redir();
+        if (rc == CHANGE_RES)
+            return 1;
     }
     else rc = exec_program(argc,argv,redir);
 
     errmsg(rc);
+
+    return 0;
+}
+
+/*
+ *  change video resolution - assumes new resolution has been validated
+ */
+PRIVATE void change_res(WORD res)
+{
+#if CLI_WITH_RESOLUTION
+    if (res == current_res)
+        return;
+
+    Setscreen(-1L,-1L,res,0);
+    Setscreen(-1L,-1L,0xc000|res,0);    /* init palette regs */
+    enable_cursor();
+    current_res = res;
+#endif
+}
+
+/*
+ *  validate a requested video resolution
+ */
+int valid_res(WORD res)
+{
+#if CLI_WITH_RESOLUTION
+    if (vdo_value == _VDO_VIDEL)    /* can't change Falcon resolutions */
+        return 0;
+
+    if (current_res == TT_HIGH)     /* can't change from TT high */
+        return 0;
+
+    if ((current_res == ST_HIGH) && (vdo_value != _VDO_TT))
+        return 0;                   /* only TTs can change from ST high */
+
+    switch (res) {
+#if CLI_WITH_TT_RESOLUTION
+    case TT_LOW:
+    case TT_MEDIUM:
+    case ST_HIGH:
+        if (vdo_value != _VDO_TT)
+            return 0;
+        /* fall through */
+#endif
+    case ST_LOW:
+    case ST_MEDIUM:
+        return 1;
+    }
+#endif  /* CLI_WITH_RESOLUTION */
 
     return 0;
 }

--- a/cli/cmdmain.c
+++ b/cli/cmdmain.c
@@ -109,6 +109,7 @@ ULONG n;
                 continue;
             rc = execute(argc,arglist,redir_name);
             if (rc < 0) {       /* exit EmuCON */
+                term_cmdedit();
                 change_res(original_res);
                 return 0;
             }


### PR DESCRIPTION
Port upstream 3d48b28b/4a804898/bcfbf3d9: MODE CON gains a res= option
that lets EmuCON change the ST/STE/TT screen resolution and reports the
current one in its status display, validated against the video hardware
detected via the _VDO cookie. pTOS's own height= line-height control is
kept alongside it, as this fork's build never had EmuTOS's cartridge
ROM-space pressure to drop it.

Resolution switching itself is gated by CONF_WITH_ATARI_VIDEO/
CONF_WITH_TT_SHIFTER (via a small CLI_WITH_RESOLUTION/
CLI_WITH_TT_RESOLUTION shim in cmd.h, since the standalone emucon2.tos
build has no config.h), so it compiles away entirely on ARM, Amiga and
ColdFire targets and only ever runs on real Atari video hardware.

Fixes #247