### PR TITLE
Add Raspberry Pi 4 PCI interrupt routing

### DIFF
--- a/bios/machine/raspi/raspi_pci.c
+++ b/bios/machine/raspi/raspi_pci.c
@@ -95,26 +95,36 @@
  * generically by raspi_gic_handle_irq() -- there is nothing extra to
  * mask or ack at the PCIe RC itself.
  *
- * Only one PCI function may be hooked per INTx line: the RPi4 exposes a
- * single root port with one downstream device (the VL805 xHCI) and pTOS
- * does not yet enumerate PCI-PCI bridges/switches, so pin sharing between
- * sibling functions cannot occur today. A second hook_interrupt() call
- * for a pin already in use returns PCI_GENERAL_ERROR rather than chaining
- * handlers.
+ * A GIC SPI line may be shared: the RPi4 exposes a single root port, but
+ * a multi-function device sitting in that one slot can have several
+ * functions asserting the same INTx pin (interrupt-map-mask wildcards
+ * the device/function fields, matching on pin alone), and pTOS already
+ * enumerates every function of a device. Each line therefore fans out to
+ * up to RASPI_PCIE_INTX_MAX_SHARERS hooked handlers, called unconditionally
+ * on every event -- same as any shared level-triggered PCI INTx line, each
+ * driver is expected to check its own device and no-op if it is not the
+ * source. The GIC line is enabled while any sharer is hooked and disabled
+ * once the last one unhooks.
  */
 #define RASPI_PCIE_INTX_LINES  4U
+#define RASPI_PCIE_INTX_MAX_SHARERS 8U
 #define RASPI_PCIE_INTX_GIC_IRQ(pin) (175U + ((pin) - 1U))
 
 static struct {
     PCI_HANDLE handle;
     pci_interrupt_handler_t handler;
     void *param;
-} raspi_pci_intx_hooks[RASPI_PCIE_INTX_LINES];
+} raspi_pci_intx_hooks[RASPI_PCIE_INTX_LINES][RASPI_PCIE_INTX_MAX_SHARERS];
 
 static void raspi_pci_intx_dispatch(UWORD slot)
 {
-    if (raspi_pci_intx_hooks[slot].handler)
-        raspi_pci_intx_hooks[slot].handler(raspi_pci_intx_hooks[slot].param);
+    UWORD i;
+
+    for (i = 0; i < RASPI_PCIE_INTX_MAX_SHARERS; i++)
+    {
+        if (raspi_pci_intx_hooks[slot][i].handler)
+            raspi_pci_intx_hooks[slot][i].handler(raspi_pci_intx_hooks[slot][i].param);
+    }
 }
 
 static void raspi_pci_intx_isr_a(void) { raspi_pci_intx_dispatch(0); }
@@ -427,6 +437,7 @@ static LONG raspi_pci_hook_interrupt(PCI_HANDLE handle, UBYTE line, pci_interrup
 {
     UBYTE pin;
     UWORD slot;
+    UWORD i;
     LONG ret;
 
     (void)line;
@@ -438,12 +449,17 @@ static LONG raspi_pci_hook_interrupt(PCI_HANDLE handle, UBYTE line, pci_interrup
         return PCI_FUNC_NOT_SUPPORTED;
 
     slot = pin - 1U;
-    if (raspi_pci_intx_hooks[slot].handler)
+    for (i = 0; i < RASPI_PCIE_INTX_MAX_SHARERS; i++)
+    {
+        if (raspi_pci_intx_hooks[slot][i].handler == 0)
+            break;
+    }
+    if (i == RASPI_PCIE_INTX_MAX_SHARERS)
         return PCI_GENERAL_ERROR;
 
-    raspi_pci_intx_hooks[slot].handle = handle;
-    raspi_pci_intx_hooks[slot].handler = handler;
-    raspi_pci_intx_hooks[slot].param = param;
+    raspi_pci_intx_hooks[slot][i].handle = handle;
+    raspi_pci_intx_hooks[slot][i].handler = handler;
+    raspi_pci_intx_hooks[slot][i].param = param;
     raspi_gic_connect_irq(RASPI_PCIE_INTX_GIC_IRQ(pin), raspi_pci_intx_isr[slot]);
 
     return PCI_SUCCESSFUL;
@@ -453,6 +469,8 @@ static LONG raspi_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
 {
     UBYTE pin;
     UWORD slot;
+    UWORD i;
+    BOOL any_left;
     LONG ret;
 
     (void)line;
@@ -464,13 +482,29 @@ static LONG raspi_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
         return PCI_FUNC_NOT_SUPPORTED;
 
     slot = pin - 1U;
-    if (raspi_pci_intx_hooks[slot].handle != handle)
+    for (i = 0; i < RASPI_PCIE_INTX_MAX_SHARERS; i++)
+    {
+        if (raspi_pci_intx_hooks[slot][i].handle == handle)
+            break;
+    }
+    if (i == RASPI_PCIE_INTX_MAX_SHARERS)
         return PCI_BAD_HANDLE;
 
-    raspi_gic_connect_irq(RASPI_PCIE_INTX_GIC_IRQ(pin), 0);
-    raspi_pci_intx_hooks[slot].handle = PCI_HANDLE_NONE;
-    raspi_pci_intx_hooks[slot].handler = 0;
-    raspi_pci_intx_hooks[slot].param = 0;
+    raspi_pci_intx_hooks[slot][i].handle = PCI_HANDLE_NONE;
+    raspi_pci_intx_hooks[slot][i].handler = 0;
+    raspi_pci_intx_hooks[slot][i].param = 0;
+
+    any_left = FALSE;
+    for (i = 0; i < RASPI_PCIE_INTX_MAX_SHARERS; i++)
+    {
+        if (raspi_pci_intx_hooks[slot][i].handler)
+        {
+            any_left = TRUE;
+            break;
+        }
+    }
+    if (!any_left)
+        raspi_gic_connect_irq(RASPI_PCIE_INTX_GIC_IRQ(pin), 0);
 
     return PCI_SUCCESSFUL;
 }

--- a/bios/machine/raspi/raspi_pci.c
+++ b/bios/machine/raspi/raspi_pci.c
@@ -116,14 +116,14 @@ static struct {
     void *param;
 } raspi_pci_intx_hooks[RASPI_PCIE_INTX_LINES][RASPI_PCIE_INTX_MAX_SHARERS];
 
-static void raspi_pci_intx_dispatch(UWORD slot)
+static void raspi_pci_intx_dispatch(UWORD line_idx)
 {
     UWORD i;
 
     for (i = 0; i < RASPI_PCIE_INTX_MAX_SHARERS; i++)
     {
-        if (raspi_pci_intx_hooks[slot][i].handler)
-            raspi_pci_intx_hooks[slot][i].handler(raspi_pci_intx_hooks[slot][i].param);
+        if (raspi_pci_intx_hooks[line_idx][i].handler)
+            raspi_pci_intx_hooks[line_idx][i].handler(raspi_pci_intx_hooks[line_idx][i].param);
     }
 }
 
@@ -436,7 +436,7 @@ static LONG raspi_pci_phys_to_bus(ULONG phys_address, BOOL io, ULONG *bus_addres
 static LONG raspi_pci_hook_interrupt(PCI_HANDLE handle, UBYTE line, pci_interrupt_handler_t handler, void *param)
 {
     UBYTE pin;
-    UWORD slot;
+    UWORD line_idx;
     UWORD i;
     LONG ret;
 
@@ -448,15 +448,15 @@ static LONG raspi_pci_hook_interrupt(PCI_HANDLE handle, UBYTE line, pci_interrup
     if ((pin < 1U) || (pin > RASPI_PCIE_INTX_LINES))
         return PCI_FUNC_NOT_SUPPORTED;
 
-    slot = pin - 1U;
+    line_idx = pin - 1U;
     for (i = 0; i < RASPI_PCIE_INTX_MAX_SHARERS; i++)
     {
-        if (raspi_pci_intx_hooks[slot][i].handle == handle)
+        if (raspi_pci_intx_hooks[line_idx][i].handle == handle)
             return PCI_GENERAL_ERROR;
     }
     for (i = 0; i < RASPI_PCIE_INTX_MAX_SHARERS; i++)
     {
-        if (raspi_pci_intx_hooks[slot][i].handler == 0)
+        if (raspi_pci_intx_hooks[line_idx][i].handler == 0)
             break;
     }
     if (i == RASPI_PCIE_INTX_MAX_SHARERS)
@@ -468,10 +468,10 @@ static LONG raspi_pci_hook_interrupt(PCI_HANDLE handle, UBYTE line, pci_interrup
      * on an already-enabled shared line never observes a hooked entry
      * with a stale param.
      */
-    raspi_pci_intx_hooks[slot][i].handle = handle;
-    raspi_pci_intx_hooks[slot][i].param = param;
-    raspi_pci_intx_hooks[slot][i].handler = handler;
-    raspi_gic_connect_irq(RASPI_PCIE_INTX_GIC_IRQ(pin), raspi_pci_intx_isr[slot]);
+    raspi_pci_intx_hooks[line_idx][i].handle = handle;
+    raspi_pci_intx_hooks[line_idx][i].param = param;
+    raspi_pci_intx_hooks[line_idx][i].handler = handler;
+    raspi_gic_connect_irq(RASPI_PCIE_INTX_GIC_IRQ(pin), raspi_pci_intx_isr[line_idx]);
 
     return PCI_SUCCESSFUL;
 }
@@ -479,7 +479,7 @@ static LONG raspi_pci_hook_interrupt(PCI_HANDLE handle, UBYTE line, pci_interrup
 static LONG raspi_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
 {
     UBYTE pin;
-    UWORD slot;
+    UWORD line_idx;
     UWORD i;
     UWORD j;
     BOOL any_left;
@@ -493,10 +493,10 @@ static LONG raspi_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
     if ((pin < 1U) || (pin > RASPI_PCIE_INTX_LINES))
         return PCI_FUNC_NOT_SUPPORTED;
 
-    slot = pin - 1U;
+    line_idx = pin - 1U;
     for (i = 0; i < RASPI_PCIE_INTX_MAX_SHARERS; i++)
     {
-        if (raspi_pci_intx_hooks[slot][i].handle == handle)
+        if (raspi_pci_intx_hooks[line_idx][i].handle == handle)
             break;
     }
     if (i == RASPI_PCIE_INTX_MAX_SHARERS)
@@ -511,7 +511,7 @@ static LONG raspi_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
     any_left = FALSE;
     for (j = 0; j < RASPI_PCIE_INTX_MAX_SHARERS; j++)
     {
-        if ((j != i) && raspi_pci_intx_hooks[slot][j].handler)
+        if ((j != i) && raspi_pci_intx_hooks[line_idx][j].handler)
         {
             any_left = TRUE;
             break;
@@ -520,9 +520,9 @@ static LONG raspi_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
     if (!any_left)
         raspi_gic_connect_irq(RASPI_PCIE_INTX_GIC_IRQ(pin), 0);
 
-    raspi_pci_intx_hooks[slot][i].handle = PCI_HANDLE_NONE;
-    raspi_pci_intx_hooks[slot][i].handler = 0;
-    raspi_pci_intx_hooks[slot][i].param = 0;
+    raspi_pci_intx_hooks[line_idx][i].handle = PCI_HANDLE_NONE;
+    raspi_pci_intx_hooks[line_idx][i].handler = 0;
+    raspi_pci_intx_hooks[line_idx][i].param = 0;
 
     return PCI_SUCCESSFUL;
 }

--- a/bios/machine/raspi/raspi_pci.c
+++ b/bios/machine/raspi/raspi_pci.c
@@ -95,19 +95,21 @@
  * generically by raspi_gic_handle_irq() -- there is nothing extra to
  * mask or ack at the PCIe RC itself.
  *
- * A GIC SPI line may be shared: the RPi4 exposes a single root port, but
- * a multi-function device sitting in that one slot can have several
- * functions asserting the same INTx pin (interrupt-map-mask wildcards
- * the device/function fields, matching on pin alone), and pTOS already
- * enumerates every function of a device. Each line therefore fans out to
- * up to RASPI_PCIE_INTX_MAX_SHARERS hooked handlers, called unconditionally
- * on every event -- same as any shared level-triggered PCI INTx line, each
+ * A GIC SPI line may be shared: interrupt-map-mask wildcards the
+ * device/function fields, matching on pin alone, so every function that
+ * asserts the same INTx pin lands on the same one of the four SPIs --
+ * whether they are functions of one multi-function device in the RPi4's
+ * single root port slot, or separate devices pci_core.c's bridge scan
+ * (pci_scan_bridge()/PCI_MAX_BUSES) enumerates behind a downstream
+ * switch. Each line therefore fans out to up to
+ * RASPI_PCIE_INTX_MAX_SHARERS hooked handlers, called unconditionally on
+ * every event -- same as any shared level-triggered PCI INTx line, each
  * driver is expected to check its own device and no-op if it is not the
- * source. The GIC line is enabled while any sharer is hooked and disabled
- * once the last one unhooks.
+ * source. The GIC line is enabled while any sharer is hooked and
+ * disabled before the last one is cleared.
  */
 #define RASPI_PCIE_INTX_LINES  4U
-#define RASPI_PCIE_INTX_MAX_SHARERS 8U
+#define RASPI_PCIE_INTX_MAX_SHARERS 32U
 #define RASPI_PCIE_INTX_GIC_IRQ(pin) (175U + ((pin) - 1U))
 
 static struct {

--- a/bios/machine/raspi/raspi_pci.c
+++ b/bios/machine/raspi/raspi_pci.c
@@ -76,6 +76,59 @@
 #define PCI_ECAM_OFFSET(bus, dev, func, reg) \
     (((ULONG)(bus) << 20) | ((ULONG)(dev) << 15) | ((ULONG)(func) << 12) | PCI_ECAM_REG(reg))
 
+/*
+ * BCM2711 PCIe INTx routing.
+ *
+ * Unlike the MSI path (PCIE_MSI_INTR2_BASE, unused here), the RC has no
+ * software INTx status/mask/ack register block: each of the four INTx
+ * pins is wired to its own dedicated GIC SPI, fixed by the SoC's
+ * interrupt-map (see Linux's arch/arm/boot/dts/broadcom/bcm2711.dtsi,
+ * the pcie0 node):
+ *
+ *   INTA -> GIC SPI 143   INTB -> GIC SPI 144
+ *   INTC -> GIC SPI 145   INTD -> GIC SPI 146
+ *
+ * raspi_gic_connect_irq() takes GICD interrupt IDs, which are SPI number
+ * + 32, so INTA..INTD are GIC IDs 175..178. Masking is the GIC's own
+ * GICD_ISENABLER/ICENABLER (done inside raspi_gic_connect_irq), and
+ * acknowledgement is the standard GICC_IAR/EOIR cycle already performed
+ * generically by raspi_gic_handle_irq() -- there is nothing extra to
+ * mask or ack at the PCIe RC itself.
+ *
+ * Only one PCI function may be hooked per INTx line: the RPi4 exposes a
+ * single root port with one downstream device (the VL805 xHCI) and pTOS
+ * does not yet enumerate PCI-PCI bridges/switches, so pin sharing between
+ * sibling functions cannot occur today. A second hook_interrupt() call
+ * for a pin already in use returns PCI_GENERAL_ERROR rather than chaining
+ * handlers.
+ */
+#define RASPI_PCIE_INTX_LINES  4U
+#define RASPI_PCIE_INTX_GIC_IRQ(pin) (175U + ((pin) - 1U))
+
+static struct {
+    PCI_HANDLE handle;
+    pci_interrupt_handler_t handler;
+    void *param;
+} raspi_pci_intx_hooks[RASPI_PCIE_INTX_LINES];
+
+static void raspi_pci_intx_dispatch(UWORD slot)
+{
+    if (raspi_pci_intx_hooks[slot].handler)
+        raspi_pci_intx_hooks[slot].handler(raspi_pci_intx_hooks[slot].param);
+}
+
+static void raspi_pci_intx_isr_a(void) { raspi_pci_intx_dispatch(0); }
+static void raspi_pci_intx_isr_b(void) { raspi_pci_intx_dispatch(1); }
+static void raspi_pci_intx_isr_c(void) { raspi_pci_intx_dispatch(2); }
+static void raspi_pci_intx_isr_d(void) { raspi_pci_intx_dispatch(3); }
+
+static const PFVOID raspi_pci_intx_isr[RASPI_PCIE_INTX_LINES] = {
+    raspi_pci_intx_isr_a,
+    raspi_pci_intx_isr_b,
+    raspi_pci_intx_isr_c,
+    raspi_pci_intx_isr_d
+};
+
 static BOOL raspi_pci_link_ready;
 
 static volatile UBYTE *raspi_pci_reg_ptr(ULONG offset)
@@ -372,18 +425,54 @@ static LONG raspi_pci_phys_to_bus(ULONG phys_address, BOOL io, ULONG *bus_addres
 
 static LONG raspi_pci_hook_interrupt(PCI_HANDLE handle, UBYTE line, pci_interrupt_handler_t handler, void *param)
 {
-    (void)handle;
+    UBYTE pin;
+    UWORD slot;
+    LONG ret;
+
     (void)line;
-    (void)handler;
-    (void)param;
-    return PCI_FUNC_NOT_SUPPORTED;
+
+    ret = pci_read_config_byte(handle, PCI_CONFIG_INTERRUPT_PIN, &pin);
+    if (ret != PCI_SUCCESSFUL)
+        return ret;
+    if ((pin < 1U) || (pin > RASPI_PCIE_INTX_LINES))
+        return PCI_FUNC_NOT_SUPPORTED;
+
+    slot = pin - 1U;
+    if (raspi_pci_intx_hooks[slot].handler)
+        return PCI_GENERAL_ERROR;
+
+    raspi_pci_intx_hooks[slot].handle = handle;
+    raspi_pci_intx_hooks[slot].handler = handler;
+    raspi_pci_intx_hooks[slot].param = param;
+    raspi_gic_connect_irq(RASPI_PCIE_INTX_GIC_IRQ(pin), raspi_pci_intx_isr[slot]);
+
+    return PCI_SUCCESSFUL;
 }
 
 static LONG raspi_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
 {
-    (void)handle;
+    UBYTE pin;
+    UWORD slot;
+    LONG ret;
+
     (void)line;
-    return PCI_FUNC_NOT_SUPPORTED;
+
+    ret = pci_read_config_byte(handle, PCI_CONFIG_INTERRUPT_PIN, &pin);
+    if (ret != PCI_SUCCESSFUL)
+        return ret;
+    if ((pin < 1U) || (pin > RASPI_PCIE_INTX_LINES))
+        return PCI_FUNC_NOT_SUPPORTED;
+
+    slot = pin - 1U;
+    if (raspi_pci_intx_hooks[slot].handle != handle)
+        return PCI_BAD_HANDLE;
+
+    raspi_gic_connect_irq(RASPI_PCIE_INTX_GIC_IRQ(pin), 0);
+    raspi_pci_intx_hooks[slot].handle = PCI_HANDLE_NONE;
+    raspi_pci_intx_hooks[slot].handler = 0;
+    raspi_pci_intx_hooks[slot].param = 0;
+
+    return PCI_SUCCESSFUL;
 }
 
 static pci_backend_t raspi_pci_backend_ops = {

--- a/bios/machine/raspi/raspi_pci.c
+++ b/bios/machine/raspi/raspi_pci.c
@@ -481,6 +481,7 @@ static LONG raspi_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
     UBYTE pin;
     UWORD slot;
     UWORD i;
+    UWORD j;
     BOOL any_left;
     LONG ret;
 
@@ -501,14 +502,16 @@ static LONG raspi_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
     if (i == RASPI_PCIE_INTX_MAX_SHARERS)
         return PCI_GENERAL_ERROR;
 
-    raspi_pci_intx_hooks[slot][i].handle = PCI_HANDLE_NONE;
-    raspi_pci_intx_hooks[slot][i].handler = 0;
-    raspi_pci_intx_hooks[slot][i].param = 0;
-
+    /*
+     * PCI INTx is level-triggered: if this is the last sharer, disable
+     * the GIC line before clearing its entry, not after, so a line
+     * asserted right at unhook time can never retrigger the ISR against
+     * an already-empty hook table.
+     */
     any_left = FALSE;
-    for (i = 0; i < RASPI_PCIE_INTX_MAX_SHARERS; i++)
+    for (j = 0; j < RASPI_PCIE_INTX_MAX_SHARERS; j++)
     {
-        if (raspi_pci_intx_hooks[slot][i].handler)
+        if ((j != i) && raspi_pci_intx_hooks[slot][j].handler)
         {
             any_left = TRUE;
             break;
@@ -516,6 +519,10 @@ static LONG raspi_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
     }
     if (!any_left)
         raspi_gic_connect_irq(RASPI_PCIE_INTX_GIC_IRQ(pin), 0);
+
+    raspi_pci_intx_hooks[slot][i].handle = PCI_HANDLE_NONE;
+    raspi_pci_intx_hooks[slot][i].handler = 0;
+    raspi_pci_intx_hooks[slot][i].param = 0;
 
     return PCI_SUCCESSFUL;
 }

--- a/bios/machine/raspi/raspi_pci.c
+++ b/bios/machine/raspi/raspi_pci.c
@@ -462,9 +462,15 @@ static LONG raspi_pci_hook_interrupt(PCI_HANDLE handle, UBYTE line, pci_interrup
     if (i == RASPI_PCIE_INTX_MAX_SHARERS)
         return PCI_GENERAL_ERROR;
 
+    /*
+     * handler is the field the ISR dispatcher gates on (see
+     * raspi_pci_intx_dispatch); write it last so a concurrent interrupt
+     * on an already-enabled shared line never observes a hooked entry
+     * with a stale param.
+     */
     raspi_pci_intx_hooks[slot][i].handle = handle;
-    raspi_pci_intx_hooks[slot][i].handler = handler;
     raspi_pci_intx_hooks[slot][i].param = param;
+    raspi_pci_intx_hooks[slot][i].handler = handler;
     raspi_gic_connect_irq(RASPI_PCIE_INTX_GIC_IRQ(pin), raspi_pci_intx_isr[slot]);
 
     return PCI_SUCCESSFUL;

--- a/bios/machine/raspi/raspi_pci.c
+++ b/bios/machine/raspi/raspi_pci.c
@@ -451,6 +451,11 @@ static LONG raspi_pci_hook_interrupt(PCI_HANDLE handle, UBYTE line, pci_interrup
     slot = pin - 1U;
     for (i = 0; i < RASPI_PCIE_INTX_MAX_SHARERS; i++)
     {
+        if (raspi_pci_intx_hooks[slot][i].handle == handle)
+            return PCI_GENERAL_ERROR;
+    }
+    for (i = 0; i < RASPI_PCIE_INTX_MAX_SHARERS; i++)
+    {
         if (raspi_pci_intx_hooks[slot][i].handler == 0)
             break;
     }
@@ -488,7 +493,7 @@ static LONG raspi_pci_unhook_interrupt(PCI_HANDLE handle, UBYTE line)
             break;
     }
     if (i == RASPI_PCIE_INTX_MAX_SHARERS)
-        return PCI_BAD_HANDLE;
+        return PCI_GENERAL_ERROR;
 
     raspi_pci_intx_hooks[slot][i].handle = PCI_HANDLE_NONE;
     raspi_pci_intx_hooks[slot][i].handler = 0;


### PR DESCRIPTION
Fixes #63

Wires INTx routing for the Raspberry Pi 4 PCIe backend by implementing `pci_hook_interrupt()`/`pci_unhook_interrupt()` in `bios/machine/raspi/raspi_pci.c`, which currently stub to `PCI_FUNC_NOT_SUPPORTED` (deferred there by #57).

Each INTx pin (A/B/C/D) routes to its own dedicated BCM2711 GIC SPI (143-146, per mainline Linux's `bcm2711.dtsi`), hooked via the existing `raspi_gic_connect_irq()`. MSI/MSI-X stay out of scope.