### PR TITLE
Default regression image build to enabled

### DIFF
--- a/.claude/skills/ptos-smoketest/SKILL.md
+++ b/.claude/skills/ptos-smoketest/SKILL.md
@@ -308,13 +308,13 @@ kernel7.img`; the size restriction and pass signals are identical.
 
 ### Running the regression test suite (`make test-hd`)
 
-The regression test harness (`CONF_WITH_REGRESSION_TESTS`) builds against
-libcmini (submodule at `lib/libcmini`), producing a standalone `runtests.tos`
-that is packaged into a raw HD image (`test-hd.img`, MBR + FAT16 via
-`tools/mkhdisk.sh`) together with `emudesk.inf`. The `emudesk.inf` autorun
-line (`#Z 00 C:\RUNTESTS.TOS@`) is meant to launch the harness on boot, which
-runs every test suite in `tests/<name>/<name>.c` and prints results via
-libcmini's `Cconws()`.
+The regression test harness (`CONF_WITH_REGRESSION_TESTS`) is enabled by
+default. It builds against libcmini (submodule at `lib/libcmini`), producing a
+standalone `runtests.tos` that is packaged into a raw HD image (`test-hd.img`,
+MBR + FAT16 via `tools/mkhdisk.sh`) together with `emudesk.inf`. The
+`emudesk.inf` autorun line (`#Z 00 C:\RUNTESTS.TOS@`) is meant to launch the
+harness on boot, which runs every test suite in `tests/<name>/<name>.c` and
+prints results via libcmini's `Cconws()`.
 
 Build the HD image (requires the normal kernel build first):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,10 @@ them.
 `make clean` keeps `.config`; `make distclean` removes it too. Changing
 `.config` rebuilds everything, which is intended.
 
+Built-in regression tests are enabled by default. After building a configured
+kernel, `make test-hd` creates `runtests.tos` and `test-hd.img`; use the
+`ptos-smoketest` skill to run the image under an emulator.
+
 To smoke-test a build, use the `ptos-smoketest` skill
 (`.claude/skills/ptos-smoketest/SKILL.md`). It has the verified QEMU
 invocations for the raspi1 (QEMU machine `raspi1ap`), raspi2 (QEMU machine

--- a/readme.md
+++ b/readme.md
@@ -159,11 +159,10 @@ pip3 install kconfiglib
 ## Running the regression tests
 
 A small built-in regression test suite runs the same way across every
-target. Enable it, build the test image, and boot it:
+target. It is enabled by default; build the test image and boot it:
 
 ```sh
-make menuconfig   # Debugging -> Regression tests -> Include built-in regression tests
-make
+make rpi2_defconfig && make   # or any other config
 make test-hd      # builds runtests.tos + test-hd.img
 ```
 

--- a/tests/Kconfig
+++ b/tests/Kconfig
@@ -2,7 +2,7 @@ menu "Regression tests"
 
 config CONF_WITH_REGRESSION_TESTS
     bool "Include built-in regression tests"
-    default n
+    default y
     help
       Build the regression test harness into a separate HD image.
       When enabled, 'make test-hd' produces a raw disk image that

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -8,8 +8,8 @@ on m68k and ARM.
 ## Building
 
 The harness is enabled by default (`CONF_WITH_REGRESSION_TESTS`). To omit it
-from a configuration, disable **Regression tests → Include built-in regression
-tests** in `make menuconfig` (or `make guiconfig`).
+from a configuration, disable **Debugging → Regression tests → Include
+built-in regression tests** in `make menuconfig` (or `make guiconfig`).
 
 Build the kernel as usual, then build the test image:
 

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -5,11 +5,11 @@ plain C, run inside a real (emulated) pTOS boot, and are cross-compiled
 for every architecture pTOS targets — the same test source runs unmodified
 on m68k and ARM.
 
-## Enabling and building
+## Building
 
-The harness is off by default. Turn it on with `make menuconfig` (or
-`make guiconfig` for a graphical window), under **Debugging → Regression
-tests → Include built-in regression tests** (`CONF_WITH_REGRESSION_TESTS`).
+The harness is enabled by default (`CONF_WITH_REGRESSION_TESTS`). To omit it
+from a configuration, disable **Regression tests → Include built-in regression
+tests** in `make menuconfig` (or `make guiconfig`).
 
 Build the kernel as usual, then build the test image:
 


### PR DESCRIPTION
## Summary

- Enable built-in regression tests by default so standard configurations produce the regression HD image.
- Update build, test, and smoke-test guidance to describe the new default.

## Verification

- `gmake rpi1_defconfig`
- `gmake gitready`
- `git diff --check`

Fixes #274