### PR TITLE
Fix BDOS media-change cleanup corruption

### DIFF
--- a/bdos/console.c
+++ b/bdos/console.c
@@ -23,6 +23,7 @@
 #include "console.h"
 #include "biosbind.h"
 #include "bdosstub.h"
+#include "string.h"
 
 /*
  * The following structure is used for the typeahead buffer
@@ -107,6 +108,8 @@ static int backsp(int h, char *cbuf, int retlen, int col);
 void stdhdl_init(void)
 {
     WORD i;
+
+    bzero(sft, OPNFILES * sizeof(FTAB));
 
     for (i = 0; i < NUMSTD; i++)
         run->p_uft[i] = default_handle[i];

--- a/bdos/fsbuf.c
+++ b/bdos/fsbuf.c
@@ -20,6 +20,7 @@
 #include "ahdi.h"
 #include "mem.h"
 #include "string.h"
+#include "biosext.h"
 #include "kprint.h"
 
 #ifdef __arm__
@@ -44,7 +45,7 @@ static void *create_chain(UBYTE *p,LONG n)
         if (i < NUMBUFS-1)                  /* chain to next */
             bcbptr->b_link = (BCB *)(p + n);
         bcbptr->b_bufdrv = -1;              /* mark as invalid */
-        bcbptr->b_bufr = p + sizeof(BCB);
+        bcbptr->b_bufr = (char *)p + sizeof(BCB);
     }
 
     return p;
@@ -238,5 +239,5 @@ UBYTE *getrec(RECNO recn, OFD *of, int wrtflg)
     if (wrtflg)
         b->b_dirty = 1;
 
-    return b->b_bufr;
+    return (UBYTE *)b->b_bufr;
 }

--- a/bdos/osmem.c
+++ b/bdos/osmem.c
@@ -405,8 +405,13 @@ void xmfreblk(void *m)
  */
 void osmem_init(void)
 {
+    WORD i;
+
+    osmptr = 0;
     osmlen = LENOSM;
     mdbroot = NULL;
+    for (i = 0; i < MAXQUICK; i++)
+        root[i] = NULL;
     dbgfreblk = 0;
     dbggtosm = 0;
     dbggtblk = 0;

--- a/bdos/osmem.c
+++ b/bdos/osmem.c
@@ -405,13 +405,8 @@ void xmfreblk(void *m)
  */
 void osmem_init(void)
 {
-    WORD i;
-
-    osmptr = 0;
     osmlen = LENOSM;
     mdbroot = NULL;
-    for (i = 0; i < MAXQUICK; i++)
-        root[i] = NULL;
     dbgfreblk = 0;
     dbggtosm = 0;
     dbggtblk = 0;


### PR DESCRIPTION
Fixes #277

## Summary

- Clear the system file table during standard-handle initialization so media-change cleanup cannot traverse stale descriptors.
- Include the `balloc_stram()` declaration in `fsbuf.c`, preventing its m68k return value from being implicitly truncated to a 16-bit `int`.
- Add the required pointer-sign casts for the BCB buffer interface.

## Root cause

Without the `balloc_stram()` prototype, the m68k build truncated the allocated BCB address. The misplaced BCB chain overlapped the system file table; clearing stale file entries then zeroed a live buffer pointer, causing disk DMA to address zero and corrupt exception vectors.

A separate post-test desktop corruption was traced to the disk `units[]` array overlap fixed by #285, which is now present on the base branch.

## Verification

- `gmake gitready`
- STE/ACSI: 2/2 regression tests passed and the desktop rendered correctly afterward
- TT/SCSI: 2/2 regression tests passed and the desktop rendered correctly afterward