### PR TITLE
VDI: avoid planar shortcuts on truecolor

### DIFF
--- a/vdi/vdi_line.c
+++ b/vdi/vdi_line.c
@@ -2386,7 +2386,7 @@ void abline(const Line *line, const WORD wrt_mode, UWORD color)
     /*
      * optimize drawing of vertical lines
      */
-    if (line->x1 == line->x2) {
+    if ((line->x1 == line->x2) && !vdi_screen_is_truecolor()) {
 #if CONF_WITH_VDI_16BIT
         if (TRUECOLOR_MODE)
         {

--- a/vdi/vdi_text.c
+++ b/vdi/vdi_text.c
@@ -16,6 +16,7 @@
 #include "string.h"
 #include "aesext.h"
 #include "vdi_defs.h"
+#include "vdi_backend.h"
 #include "vdistub.h"
 #include "lineavars.h"
 #include "biosext.h"

--- a/vdi/vdi_text.c
+++ b/vdi/vdi_text.c
@@ -129,6 +129,12 @@ static BOOL ok_for_direct_blit(Vwk *vwk, WORD width, JUSTINFO *justified)
     const Fonthead *fnt_ptr;
     WORD xmin, xmax, ymin, ymax;
 
+#if CONF_WITH_VDI_BACKEND_TRUECOLOR
+    /* The direct path below writes planar screen bytes, not packed pixels. */
+    if (vdi_truecolor_screen())
+        return FALSE;
+#endif
+
     if (vwk->style | vwk->chup | vwk->h_align)
         return FALSE;
 


### PR DESCRIPTION
Fixes #280

## Summary

Prevent two upstream VDI shortcuts from treating packed truecolor framebuffers as planar memory:

- The direct-text speedup wrote planar framebuffer bytes, corrupting Pi RGB565 text and adjacent pixels.
- The vertical-line speedup wrote one bit into each of 16 adjacent RGB565 pixels.

Both shortcuts now fall through to the existing packed truecolor backend on truecolor screens. Planar and Falcon Videl-specific paths remain unchanged.

## Verification

- `gmake rpi1_defconfig && gmake && gmake test-hd`
- `gmake rpi2_defconfig && gmake && gmake test-hd`
- Both QEMU runs passed all 3 regression suites and produced clean post-test 1280x720 framebuffers.
- `gmake gitready`
- `git diff --check`