### PR TITLE
bios: consolidate block-device bus numbers

### DIFF
--- a/.claude/skills/ptos-upstream-merge/SKILL.md
+++ b/.claude/skills/ptos-upstream-merge/SKILL.md
@@ -133,10 +133,11 @@ independently grew the same enumeration for its own reasons, the merge can
 silently resolve to whichever side's version "won" the conflict — leaving
 either pTOS's addition dropped, or upstream's count/table sized for a
 smaller set than pTOS actually needs. Two known instances from this
-merge's lineage: a `MAX_BUS`-style bound that upstream sizes for its own
-known bus types (ACSI/SCSI/IDE/SDMMC) without accounting for pTOS's
-VirtIO addition, and an `EXTENDED_PALETTE`-shaped enum with the same shape
-of gap.
+merge's lineage: `MAX_BUS`, where upstream knows only ACSI/SCSI/IDE/SDMMC
+but pTOS adds VirtIO, and an `EXTENDED_PALETTE`-shaped enum with the same
+shape of gap. `bios/disk.h` now owns the fixed ABI bus-number enum and its
+final `MAX_BUS` member; preserve both when merging upstream changes to
+`bios/machine.h` or disk-driver bounds.
 
 This rarely produces a build error — both sides' definitions compile fine
 in isolation, and the merged value is *a* valid number, just not

--- a/bios/disk.c
+++ b/bios/disk.c
@@ -314,11 +314,24 @@ void disk_init_all(void)
 {
     /* scan disk majors in the following order */
     static const int majors[] =
-        {16, 18, 17, 19, 20, 22, 21, 23,    /* IDE primary/secondary */
+        {
+#if CONF_WITH_IDE
+         16, 18, 17, 19, 20, 22, 21, 23,    /* IDE primary/secondary */
+#endif
+#if CONF_WITH_SCSI
          8, 9, 10, 11, 12, 13, 14, 15,      /* SCSI */
+#endif
+#if CONF_WITH_ACSI
          0, 1, 2, 3, 4, 5, 6, 7,            /* ACSI */
+#endif
+#if CONF_WITH_SDMMC || CONF_WITH_RASPI_EMMC
          24, 25, 26, 27, 28, 29, 30, 31,    /* SD/MMC */
-         32, 33, 34, 35, 36, 37, 38, 39};   /* virtio-blk */
+#endif
+#if CONF_WITH_VIRTIO_BLK
+         32, 33, 34, 35, 36, 37, 38, 39,    /* virtio-blk */
+#endif
+         -1                                  /* terminates diskless builds */
+        };
     int i;
     LONG devices_available = 0L;
     LONG bitmask;
@@ -337,7 +350,7 @@ void disk_init_all(void)
         devices_available |= bitmask;
 
     /* scan for attached harddrives and their partitions */
-    for(i = 0; i < ARRAY_SIZE(majors); i++) {
+    for(i = 0; majors[i] >= 0; i++) {
         UWORD unit = NUMFLOPPIES + majors[i];
         disk_init_one(unit,&devices_available);
         if (!devices_available) {

--- a/bios/disk.h
+++ b/bios/disk.h
@@ -17,17 +17,25 @@
 
 #define NUMFLOPPIES     2   /* max number of floppies supported */
 
-#define ACSI_BUS            0
-#define SCSI_BUS            1
-#define IDE_BUS             2
-#define SDMMC_BUS           3
-#define VIRTIO_BUS          4
+/*
+ * Bus numbers form part of the device-major ABI: major = bus * 8 + device.
+ * Keep their values fixed even if an intervening bus driver is disabled.
+ */
+enum bus_number {
+    ACSI_BUS = 0,
+    SCSI_BUS = 1,
+    IDE_BUS = 2,
+    SDMMC_BUS = 3,
+    VIRTIO_BUS = 4
+};
 
-/* disk_init_all() probes every defined bus, including disabled drivers */
-#define DISK_MAX_BUS        VIRTIO_BUS
+#define MAX_BUS             (CONF_WITH_VIRTIO_BLK ? VIRTIO_BUS : \
+                             (CONF_WITH_SDMMC || CONF_WITH_RASPI_EMMC) ? SDMMC_BUS : \
+                             CONF_WITH_IDE ? IDE_BUS : \
+                             CONF_WITH_SCSI ? SCSI_BUS : ACSI_BUS)
 #define DEVICES_PER_BUS     8
 
-#define UNITSNUM            (NUMFLOPPIES+(DEVICES_PER_BUS*(DISK_MAX_BUS+1)))
+#define UNITSNUM            (NUMFLOPPIES+(DEVICES_PER_BUS*(MAX_BUS+1)))
 
 #define GET_BUS(major)          ((major)/DEVICES_PER_BUS)
 #define IS_ACSI_DEVICE(major)   (GET_BUS(major) == ACSI_BUS)

--- a/bios/disk.h
+++ b/bios/disk.h
@@ -13,6 +13,8 @@
 #ifndef DISK_H
 #define DISK_H
 
+#include "config.h"
+
 /* defines */
 
 #define NUMFLOPPIES     2   /* max number of floppies supported */

--- a/bios/disk.h
+++ b/bios/disk.h
@@ -26,13 +26,13 @@ enum bus_number {
     SCSI_BUS = 1,
     IDE_BUS = 2,
     SDMMC_BUS = 3,
-    VIRTIO_BUS = 4
+    VIRTIO_BUS = 4,
+    MAX_BUS = CONF_WITH_VIRTIO_BLK ? VIRTIO_BUS :
+              (CONF_WITH_SDMMC || CONF_WITH_RASPI_EMMC) ? SDMMC_BUS :
+              CONF_WITH_IDE ? IDE_BUS :
+              CONF_WITH_SCSI ? SCSI_BUS : ACSI_BUS
 };
 
-#define MAX_BUS             (CONF_WITH_VIRTIO_BLK ? VIRTIO_BUS : \
-                             (CONF_WITH_SDMMC || CONF_WITH_RASPI_EMMC) ? SDMMC_BUS : \
-                             CONF_WITH_IDE ? IDE_BUS : \
-                             CONF_WITH_SCSI ? SCSI_BUS : ACSI_BUS)
 #define DEVICES_PER_BUS     8
 
 #define UNITSNUM            (NUMFLOPPIES+(DEVICES_PER_BUS*(MAX_BUS+1)))

--- a/bios/machine.c
+++ b/bios/machine.c
@@ -15,6 +15,7 @@
 #include "emutos.h"
 #include "cookie.h"
 #include "machine.h"
+#include "disk.h"
 #include "has.h"
 #include "processor.h"
 #include "biosmem.h"

--- a/bios/machine.h
+++ b/bios/machine.h
@@ -33,6 +33,11 @@
 #define DIP_SWITCHES        0xffff9200UL
 #define MONSTER_REG         0xfffffe00UL
 
+/*
+ * Block-device bus numbers belong in disk.h. When merging upstream changes
+ * that add them here, move the definitions to disk.h instead.
+ */
+
 extern ULONG detected_busses;
 
 /*

--- a/bios/machine.h
+++ b/bios/machine.h
@@ -33,24 +33,6 @@
 #define DIP_SWITCHES        0xffff9200UL
 #define MONSTER_REG         0xfffffe00UL
 
-/*
- * standard bus numbers
- */
-#define ACSI_BUS            0
-#define SCSI_BUS            1
-#define IDE_BUS             2
-#define SDMMC_BUS           3
-
-#if CONF_WITH_SDMMC
-# define MAX_BUS            SDMMC_BUS
-#elif CONF_WITH_IDE
-# define MAX_BUS            IDE_BUS
-#elif CONF_WITH_SCSI
-# define MAX_BUS            SCSI_BUS
-#else
-# define MAX_BUS            ACSI_BUS
-#endif
-
 extern ULONG detected_busses;
 
 /*


### PR DESCRIPTION
Fixes #292

## Summary

- Replace duplicate block-device bus-number macros with one ABI-stable enum in bios/disk.h.
- Keep fixed bus values so device major numbers continue to map as major = bus * 8 + device, including holes for disabled buses.
- Define MAX_BUS as the enum final member, selecting the highest enabled bus. Both generic SD/MMC and Raspberry Pi EMMC select SDMMC_BUS.
- Use MAX_BUS to size disk units and SCSI-driver bus state.
- Gate disk_init_all() major scans by their configured drivers, so no disabled bus is probed and units[] remains safely configuration-sized.
- Let disk.h include config.h directly, and remove duplicate definitions from bios/machine.h.

## Verification

- gmake atari512_defconfig && gmake
- gmake rpi2_defconfig && gmake
- gmake virt-arm_defconfig && gmake
- gmake gitready