### PR TITLE
Eliminate virt-arm and Raspberry Pi build warnings

### DIFF
--- a/aes/arch/arm/gemdosif.S
+++ b/aes/arch/arm/gemdosif.S
@@ -147,11 +147,14 @@ _far_bcha:
 
 _far_mcha:
         push_privstack gstack
-        push    {r0-r3,lr}
-        ldmfd   sp, {r1,r2} // shift arg 1 and 2 up by one
+        push    {r1-r4,lr}
+        mov     r4, r0, lsl #16     /* pack x (r0) into the high word */
+        orr     r4, r4, r1          /* r4 = (x << 16) | y  (fdata) */
         ldr     r0, =_mchange
-        bl      _forkq
-        pop     {r0-r3,lr}
+        mov     r1, r4              /* r1 = fdata */
+        bl      _forkq              /* forkq(_mchange, fdata) */
+        mov     r0, r4              /* return the unchanged packed coords */
+        pop     {r1-r4,lr}
         pop_privstack
         bx      lr
 

--- a/aes/arch/arm/gemdosifc.c
+++ b/aes/arch/arm/gemdosifc.c
@@ -142,6 +142,8 @@ void set_aestrap(void)
 *
 * return 1 if intercepted, else 0
 */
+BOOL aestrap_intercepted(void);
+
 BOOL aestrap_intercepted(void)
 {
     return ((LONG)VEC_GEM) < os_beg || ((LONG)VEC_GEM) >= ((LONG)_etext);

--- a/bdos/elfld.c
+++ b/bdos/elfld.c
@@ -383,7 +383,7 @@ LONG elf_pgmhdrld(FH h, PGMHDR01 *hd)
  * like DIR32, so it takes the same "add the bias" path as everything
  * else.
  */
-static LONG elf_fixup(BYTE *load_base, const ELFINFO *info, LONG bias,
+static LONG elf_fixup(UBYTE *load_base, const ELFINFO *info, LONG bias,
                       ULONG vaddr, UBYTE type, BOOL rela, ULONG addend)
 {
     ULONG *slot;
@@ -421,7 +421,7 @@ static LONG elf_fixup(BYTE *load_base, const ELFINFO *info, LONG bias,
 
 /* walk one SHT_REL / SHT_RELA section and relocate every entry in it */
 static LONG elf_relocate_section(FH h, const Elf32_Shdr *sh, BOOL rela,
-                                 BYTE *load_base, const ELFINFO *info,
+                                 UBYTE *load_base, const ELFINFO *info,
                                  LONG bias)
 {
     Elf32_Rela ent;     /* a RELA record is a REL record plus an addend */
@@ -473,7 +473,7 @@ static LONG elf_relocate_section(FH h, const Elf32_Shdr *sh, BOOL rela,
 }
 
 /* apply every relocation section retained by ld --emit-relocs */
-static LONG elf_relocate(FH h, const Elf32_Ehdr *e, BYTE *load_base,
+static LONG elf_relocate(FH h, const Elf32_Ehdr *e, UBYTE *load_base,
                          const ELFINFO *info, LONG bias)
 {
     Elf32_Shdr sh;
@@ -578,7 +578,7 @@ LONG elf_pgmld(FH h, PD *p)
     Elf32_Ehdr ehdr;
     Elf32_Phdr ph;
     ELFINFO info;
-    BYTE *load_base;
+    UBYTE *load_base;
     LONG bias;
     LONG tpalen;
     ULONG phoff;
@@ -604,7 +604,7 @@ LONG elf_pgmld(FH h, PD *p)
         return EPLFMT;
 
     /* the image is loaded at the first byte after the basepage */
-    load_base = (BYTE *)(p + 1);
+    load_base = (UBYTE *)(p + 1);
     /* compute the bias in unsigned then reinterpret as signed; this avoids
      * signed overflow UB when either operand has its high bit set, and the
      * relocation arithmetic downstream already relies on unsigned wrap. */

--- a/bdos/fsbuf.c
+++ b/bdos/fsbuf.c
@@ -135,7 +135,7 @@ BCB *getbcb(DMD *dmd,WORD buftype,RECNO recnum)
      *          the last (least recently) used buffer.
      */
 
-    for (b = *(q = phdr); b; b = *(q = &b->b_link))
+    for (b = *(q = phdr); b; b = *(q = (BCB **)(void *)b))
     {
         if ((b->b_bufdrv == dmd->m_drvnum) && (b->b_buftyp == buftype) && (b->b_bufrec == recnum))
             break;
@@ -159,7 +159,7 @@ BCB *getbcb(DMD *dmd,WORD buftype,RECNO recnum)
          * is the least recently used.
          */
 
-doio:   for (p = *(q = phdr); p->b_link; p = *(q = &p->b_link))
+doio:   for (p = *(q = phdr); p->b_link; p = *(q = (BCB **)(void *)p))
             if (b == p)
                 break;
         b = p;

--- a/bios/arch/arm/aciaemu.c
+++ b/bios/arch/arm/aciaemu.c
@@ -134,9 +134,9 @@ void init_acia_vecs(void)
 
     kbdvecs.mousevec = _dummy_p;
     _kbdvec = kbdvec;
-    kbdvecs.midivec = midivec;
-    kbdvecs.vkbderr = _dummy_c;
-    kbdvecs.vmiderr = _dummy_c;
+    kbdvecs.midivec = (PFVOID)midivec;
+    kbdvecs.vkbderr = (PFVOID)_dummy_c;
+    kbdvecs.vmiderr = (PFVOID)_dummy_c;
     kbdvecs.statvec = _dummy_p;
     kbdvecs.mousevec = _dummy_p;
 

--- a/bios/arch/arm/tosvars.c
+++ b/bios/arch/arm/tosvars.c
@@ -73,7 +73,7 @@ WORD dumpflg;
  * is just an ordinary struct populated with the same build-time values
  * bios/arch/m68k/startup.S embeds in its own header.
  */
-const OSHEADER os_header = {
+OSHEADER os_header = {
     0,                                          /* os_entry (unused on ARM) */
     0,                                          /* os_version */
     just_rts,                                   /* reseth */

--- a/bios/arch/arm/tosvars.c
+++ b/bios/arch/arm/tosvars.c
@@ -73,11 +73,11 @@ WORD dumpflg;
  * is just an ordinary struct populated with the same build-time values
  * bios/arch/m68k/startup.S embeds in its own header.
  */
-OSHEADER os_header = {
+const OSHEADER os_header = {
     0,                                          /* os_entry (unused on ARM) */
     0,                                          /* os_version */
     just_rts,                                   /* reseth */
-    &os_header,                                 /* os_beg */
+    (OSHEADER *)&os_header,                     /* os_beg: ABI field is non-const */
     NULL,                                       /* os_end */
     NULL,                                       /* os_rsvl */
     NULL,                                       /* os_magic */

--- a/bios/arch/arm/vectors.c
+++ b/bios/arch/arm/vectors.c
@@ -53,6 +53,11 @@ typedef struct {
 
 static void any_vec(int vector_addr, exception_frame_t* stack_frame, ULONG fsr, ULONG far);
 
+volatile PFVOID *vector_address(ULONG address)
+{
+    return (volatile PFVOID *)address;
+}
+
 /* basically initialize the 62 exception vectors. */
 void init_exc_vec(void)
 {

--- a/bios/blkdev.c
+++ b/bios/blkdev.c
@@ -30,6 +30,7 @@
 #include "scsi.h"
 #include "ide.h"
 #include "sd.h"
+#include "raspi_emmc.h"
 #include "virtio_blk.h"
 #include "scsidriv.h"
 #include "biosext.h"

--- a/bios/bootargs.c
+++ b/bios/bootargs.c
@@ -109,7 +109,7 @@ static ULONG fdt32_to_cpu(ULONG v)
  * command line string, or NULL if there is none. */
 static const char *fdt_find_bootargs(const struct fdt_header *fdt)
 {
-    const UBYTE *cur, *end, *strings_base, *strings_end;
+    const UBYTE *cur, *end, *strings_base;
     ULONG totalsize, off_struct, off_strings, size_strings;
 
     if (fdt32_to_cpu(fdt->magic) != FDT_MAGIC)
@@ -126,7 +126,6 @@ static const char *fdt_find_bootargs(const struct fdt_header *fdt)
     end = (const UBYTE *)fdt + totalsize;
     cur = (const UBYTE *)fdt + off_struct;
     strings_base = (const UBYTE *)fdt + off_strings;
-    strings_end = strings_base + size_strings;
 
     while (cur + 4 <= end)
     {

--- a/bios/disk.c
+++ b/bios/disk.c
@@ -111,6 +111,7 @@ static LONG natfeats_inquire(UWORD unit, ULONG *blocksize, ULONG *deviceflags, c
 #endif
 static LONG internal_inquire(UWORD unit, ULONG *blocksize, ULONG *deviceflags, char *productname, UWORD stringlen);
 
+#if CONF_WITH_IDE || CONF_WITH_SCSI || CONF_WITH_ARANYM || CONF_WITH_ACSI || CONF_WITH_SDMMC
 /* scan disk majors in the following order */
 static const int majors[] =
 {
@@ -152,6 +153,7 @@ static void dmaboot(UWORD unit, void *bootcode)
     : : "r"(unit-NUMFLOPPIES), "a"(bootcode)
     : "d0","d1","d2","a0","a1","a2", "memory");
 }
+#endif
 
 /*
  * scan hard disks found in disk_init_all with no partitions, and execute
@@ -159,7 +161,8 @@ static void dmaboot(UWORD unit, void *bootcode)
  */
 void disk_try_dmaboot(void)
 {
-    int i;
+#if CONF_WITH_IDE || CONF_WITH_SCSI || CONF_WITH_ARANYM || CONF_WITH_ACSI || CONF_WITH_SDMMC
+    UWORD i;
     LONG rc;
 
     for(i = 0; i < ARRAY_SIZE(majors); i++) {
@@ -182,6 +185,7 @@ void disk_try_dmaboot(void)
             }
         }
     }
+#endif
 }
 
 /*

--- a/bios/fnt_km_6x6.c
+++ b/bios/fnt_km_6x6.c
@@ -93,7 +93,7 @@ static const UWORD dat_table[] =
 const Fonthead fnt_km_6x6 = {
     1,  /* font_id */
     8,  /* point */
-    "6x6 system font",  /*   BYTE name[32]	*/
+    "6x6 system font",  /*   BYTE name[32] */
     0,  /* first_ade */
     255,  /* last_ade */
     4,  /* top */
@@ -110,9 +110,9 @@ const Fonthead fnt_km_6x6 = {
     0x5555,  /* lighten */
     0xaaaa,  /* skew */
     F_STDFORM | F_MONOSPACE | F_DEFAULT,  /* flags */
-    0,			/*   UBYTE *hor_table	*/
-    off_6x6_table,		/*   UWORD *off_table	*/
-    dat_table,		/*   UWORD *dat_table	*/
+    0,                  /*   UBYTE *hor_table */
+    off_6x6_table,      /*   UWORD *off_table */
+    (const UBYTE *)dat_table, /* UBYTE *dat_table */
     192,  /* form_width */
     6,  /* form_height */
     0,  /* Fonthead * next_font */

--- a/bios/fnt_km_8x16.c
+++ b/bios/fnt_km_8x16.c
@@ -277,7 +277,7 @@ static const UWORD dat_table[] =
 const Fonthead fnt_km_8x16 = {
     1,  /* font_id */
     10,  /* point */
-    "8x16 system font",  /*   BYTE name[32]	*/
+    "8x16 system font",  /*   BYTE name[32] */
     0,  /* first_ade */
     255,  /* last_ade */
     13,  /* top */
@@ -294,9 +294,9 @@ const Fonthead fnt_km_8x16 = {
     0x5555,  /* lighten */
     0x5555,  /* skew */
     F_STDFORM | F_MONOSPACE | F_DEFAULT,  /* flags */
-    0,			/*   UBYTE *hor_table	*/
-    off_8x16_table,		/*   UWORD *off_table	*/
-    dat_table,		/*   UWORD *dat_table	*/
+    0,                  /*   UBYTE *hor_table */
+    off_8x16_table,     /*   UWORD *off_table */
+    (const UBYTE *)dat_table, /* UBYTE *dat_table */
     256,  /* form_width */
     16,  /* form_height */
     0,  /* Fonthead * next_font */

--- a/bios/fnt_km_8x8.c
+++ b/bios/fnt_km_8x8.c
@@ -149,7 +149,7 @@ static const UWORD dat_table[] =
 const Fonthead fnt_km_8x8 = {
     1,  /* font_id */
     9,  /* point */
-    "8x8 system font",  /*   BYTE name[32]	*/
+    "8x8 system font",  /*   BYTE name[32] */
     0,  /* first_ade */
     255,  /* last_ade */
     6,  /* top */
@@ -166,9 +166,9 @@ const Fonthead fnt_km_8x8 = {
     0x5555,  /* lighten */
     0x5555,  /* skew */
     F_STDFORM | F_MONOSPACE | F_DEFAULT,  /* flags */
-    0,			/*   UBYTE *hor_table	*/
-    off_8x8_table,		/*   UWORD *off_table	*/
-    dat_table,		/*   UWORD *dat_table	*/
+    0,                  /*   UBYTE *hor_table */
+    off_8x8_table,      /*   UWORD *off_table */
+    (const UBYTE *)dat_table, /* UBYTE *dat_table */
     256,  /* form_width */
     8,  /* form_height */
     0,  /* Fonthead * next_font */

--- a/bios/fnt_tr_6x6.c
+++ b/bios/fnt_tr_6x6.c
@@ -110,7 +110,7 @@ const Fonthead fnt_tr_6x6 = {
 
     0,                  /*   UBYTE *hor_table   */
     off_6x6_table,      /*   UWORD *off_table   */
-    dat_table,          /*   UWORD *dat_table   */
+    (const UBYTE *)dat_table, /* UBYTE *dat_table */
     192,                /*   UWORD form_width   */
     6,                  /*   UWORD form_height  */
 

--- a/bios/fnt_tr_8x16.c
+++ b/bios/fnt_tr_8x16.c
@@ -293,7 +293,7 @@ const Fonthead fnt_tr_8x16 = {
     F_STDFORM | F_MONOSPACE | F_DEFAULT,  /* UWORD flags */
     0,                  /* UBYTE *hor_table */
     off_8x16_table,     /* UWORD *off_table */
-    dat_table,          /* UWORD *dat_table */
+    (const UBYTE *)dat_table, /* UBYTE *dat_table */
     256,                /* UWORD form_width */
     16,                 /* UWORD form_height */
     0,                  /* Fonthead * next_font */

--- a/bios/fnt_tr_8x8.c
+++ b/bios/fnt_tr_8x8.c
@@ -165,7 +165,7 @@ const Fonthead fnt_tr_8x8 = {
     F_STDFORM | F_MONOSPACE | F_DEFAULT,  /* UWORD flags        */
     0,                  /*   UBYTE *hor_table   */
     off_8x8_table,       /*   UWORD *off_table   */
-    dat_table,           /*   UWORD *dat_table   */
+    (const UBYTE *)dat_table, /* UBYTE *dat_table */
     256,  /* UWORD form_width */
     8,  /* UWORD form_height */
     0,  /* Fonthead * next_font */

--- a/bios/raspi_int.c
+++ b/bios/raspi_int.c
@@ -10,6 +10,7 @@
 #include "ikbd.h"
 #include "string.h"
 #include "kprint.h"
+#include "biosext.h"
 #include "delay.h"
 #include "asm.h"
 #include "vectors.h"

--- a/bios/screen.c
+++ b/bios/screen.c
@@ -905,6 +905,7 @@ void screen_get_current_mode_desc(SCREEN_MODE_DESC *desc)
     MAYBE_UNUSED(planes);
     MAYBE_UNUSED(hz_rez);
     MAYBE_UNUSED(vt_rez);
+    MAYBE_UNUSED(planar_mode_desc);
 
 #if CONF_WITH_VDI_TRUECOLOR32_TEST
     virt_arm_get_current_mode_desc(desc);

--- a/bios/screen.h
+++ b/bios/screen.h
@@ -98,7 +98,6 @@ void screen_init_address(void);
 void screen_init_mode(void);
 void set_rez_hacked(void);
 void screen_get_current_mode_info(UWORD *planes, UWORD *hz_rez, UWORD *vt_rez);
-void screen_get_current_mode_desc(SCREEN_MODE_DESC *desc);
 #if CONF_WITH_VDI_TRUECOLOR32_TEST
 void virt_arm_screen_init(void);
 void virt_arm_get_current_mode_desc(SCREEN_MODE_DESC *desc);

--- a/bios/scsidriv.c
+++ b/bios/scsidriv.c
@@ -270,8 +270,12 @@ static HandleEntry *get_handle_entry(SCSIHandle handle)
 static LONG scsidriv_InOut(WORD write, SCSICmd *cmd)
 {
     HandleEntry *h;
-    LONG rc, rc2;
-    int bus, dev;
+    LONG rc;
+    int bus;
+#if CONF_WITH_ACSI
+    LONG rc2;
+    int dev;
+#endif
 
     /* check for valid handle */
     h = get_handle_entry(cmd->handle);
@@ -283,7 +287,9 @@ static LONG scsidriv_InOut(WORD write, SCSICmd *cmd)
         return PENDING_ERROR;
 
     bus = h->busdev >> 4;
+#if CONF_WITH_ACSI
     dev = h->busdev & 0x0f;
+#endif
 
     if (cmd->xferlen > get_bus_maxlen(bus))
         return DATATOOLONG_ERROR;

--- a/bios/scsidriv.c
+++ b/bios/scsidriv.c
@@ -272,7 +272,7 @@ static LONG scsidriv_InOut(WORD write, SCSICmd *cmd)
     HandleEntry *h;
     LONG rc;
     int bus;
-#if CONF_WITH_ACSI
+#if CONF_WITH_ACSI || CONF_WITH_IDE
     LONG rc2;
     int dev;
 #endif
@@ -287,7 +287,7 @@ static LONG scsidriv_InOut(WORD write, SCSICmd *cmd)
         return PENDING_ERROR;
 
     bus = h->busdev >> 4;
-#if CONF_WITH_ACSI
+#if CONF_WITH_ACSI || CONF_WITH_IDE
     dev = h->busdev & 0x0f;
 #endif
 

--- a/bios/serport.c
+++ b/bios/serport.c
@@ -58,7 +58,7 @@ static WORD incr_tail(IOREC *iorec);
 static void put_iorecbuf(IOREC *out, WORD b);
 #endif
 static LONG bconstat_iorec(EXT_IOREC *iorec);
-static LONG bconin_iorec(EXT_IOREC *iorec);
+static LONG __attribute__((unused)) bconin_iorec(EXT_IOREC *iorec);
 
 #if BCONMAP_AVAILABLE
 static ULONG rsconf_dummy(WORD baud, WORD ctrl, WORD ucr, WORD rsr, WORD tsr, WORD scr);

--- a/bios/vectors.h
+++ b/bios/vectors.h
@@ -58,22 +58,28 @@ extern WORD trap_save_area[];
 #endif
 
 /* 680x0 exception vectors */
-#define VEC_ILLEGAL (*(volatile PFVOID*)0x10) /* illegal instruction vector */
-#define VEC_DIVNULL (*(volatile PFVOID*)0x14) /* division by zero exception vector */
-#define VEC_PRIVLGE (*(volatile PFVOID*)0x20) /* privilege exception vector */
-#define VEC_LINEA   (*(volatile PFVOID*)0x28) /* LineA exception vector */
-#define VEC_LEVEL1  (*(volatile PFVOID*)0x64) /* Level 1 interrupt vector */
-#define VEC_LEVEL2  (*(volatile PFVOID*)0x68) /* Level 2 interrupt vector */
-#define VEC_LEVEL3  (*(volatile PFVOID*)0x6c) /* Level 3 interrupt vector */
-#define VEC_LEVEL4  (*(volatile PFVOID*)0x70) /* Level 4 interrupt vector */
-#define VEC_LEVEL5  (*(volatile PFVOID*)0x74) /* Level 5 interrupt vector */
-#define VEC_LEVEL6  (*(volatile PFVOID*)0x78) /* Level 6 interrupt vector */
-#define VEC_LEVEL7  (*(volatile PFVOID*)0x7c) /* Level 7 interrupt (not maskable) */
-#define VEC_TRAP1   (*(volatile PFVOID*)0x84) /* TRAP #1 exception vector */
-#define VEC_TRAP2   (*(volatile PFVOID*)0x88) /* TRAP #2 exception vector */
-#define VEC_TRAP13  (*(volatile PFVOID*)0xb4) /* TRAP #13 exception vector */
-#define VEC_TRAP14  (*(volatile PFVOID*)0xb8) /* TRAP #14 exception vector */
-#define VEC_UNIMPINT (*(volatile PFVOID*)0xf4) /* unimplemented integer instruction exception vector */
+#ifdef __arm__
+volatile PFVOID *vector_address(ULONG address);
+#define VEC_AT(address) (*vector_address(address))
+#else
+#define VEC_AT(address) (*(volatile PFVOID *)(address))
+#endif
+#define VEC_ILLEGAL VEC_AT(0x10) /* illegal instruction vector */
+#define VEC_DIVNULL VEC_AT(0x14) /* division by zero exception vector */
+#define VEC_PRIVLGE VEC_AT(0x20) /* privilege exception vector */
+#define VEC_LINEA   VEC_AT(0x28) /* LineA exception vector */
+#define VEC_LEVEL1  VEC_AT(0x64) /* Level 1 interrupt vector */
+#define VEC_LEVEL2  VEC_AT(0x68) /* Level 2 interrupt vector */
+#define VEC_LEVEL3  VEC_AT(0x6c) /* Level 3 interrupt vector */
+#define VEC_LEVEL4  VEC_AT(0x70) /* Level 4 interrupt vector */
+#define VEC_LEVEL5  VEC_AT(0x74) /* Level 5 interrupt vector */
+#define VEC_LEVEL6  VEC_AT(0x78) /* Level 6 interrupt vector */
+#define VEC_LEVEL7  VEC_AT(0x7c) /* Level 7 interrupt (not maskable) */
+#define VEC_TRAP1   VEC_AT(0x84) /* TRAP #1 exception vector */
+#define VEC_TRAP2   VEC_AT(0x88) /* TRAP #2 exception vector */
+#define VEC_TRAP13  VEC_AT(0xb4) /* TRAP #13 exception vector */
+#define VEC_TRAP14  VEC_AT(0xb8) /* TRAP #14 exception vector */
+#define VEC_UNIMPINT VEC_AT(0xf4) /* unimplemented integer instruction exception vector */
 
 /* MFP interrupt vectors */
 #define VEC_MFP6   (*(volatile PFVOID*)0x118) /* MFP level 6 interrupt vector */

--- a/cli/cmdmain.c
+++ b/cli/cmdmain.c
@@ -24,6 +24,9 @@
 #include "cmd.h"
 #include "version.h"
 #include "string.h"
+#ifdef __arm__
+#include "tosvars.h"
+#endif
 
 /*
  *  global variables
@@ -363,5 +366,9 @@ int valid_res(WORD res)
 
 PRIVATE WORD get_nflops(void)
 {
+#ifdef __arm__
+    return nflops;
+#else
     return *(WORD *)0x4a6;          /* number of floppy drives */
+#endif
 }

--- a/cli/cmdutil.c
+++ b/cli/cmdutil.c
@@ -10,6 +10,9 @@
  * option any later version.  See doc/license.txt for details.
  */
 #include "cmd.h"
+#ifdef __arm__
+#include "tosvars.h"
+#endif
 #include "string.h"
 #include <stdarg.h>
 #include "doprintf.h"
@@ -340,7 +343,11 @@ char c1, c2;
 
 PRIVATE LONG getjar(void)
 {
+#ifdef __arm__
+    return (LONG)p_cookies;
+#else
     return *(LONG *)0x5a0;
+#endif
 }
 
 /*

--- a/include/biosext.h
+++ b/include/biosext.h
@@ -76,9 +76,7 @@ BOOL can_shutdown(void);
 void flop_eject(void);
 #endif
 
-#if CONF_WITH_EXTENDED_MOUSE
 extern void (*mousexvec)(WORD scancode);    /* Additional mouse buttons */
-#endif
 
 /* determine monitor type, ... */
 WORD get_monitor_type(void);

--- a/include/lineavars.h
+++ b/include/lineavars.h
@@ -46,6 +46,18 @@ typedef struct _mcs {
 
 extern MCS ext_mouse_cursor_save;   /* use for v_planes > 4 */
 
+/*
+ * user_mot vector on ARM.  ARM is a new architecture with no legacy ABI to
+ * preserve, so the callback follows the standard AAPCS calling convention and
+ * can be written in plain C.  It takes the proposed x and y coordinates and
+ * returns the (possibly modified) coordinates packed into a ULONG with x in
+ * the high word and y in the low word (MAKE_ULONG(x, y)).  On m68k the legacy
+ * line-A register convention is kept instead (see vdi_entry.S).
+ */
+#ifdef __arm__
+typedef ULONG (*UserMotFunc)(WORD x, WORD y);
+#endif
+
 struct Vwk_;
 struct font_head;
 
@@ -123,7 +135,11 @@ struct _lineavars {
     void (*tim_chain)(int);            /* -62  timer interrupt vector save */
     void (*user_but)(WORD status);     /* -58  user button vector */
     void (*user_cur)(WORD x, WORD y);  /* -54  user cursor vector */
-    void (*user_mot)(LONG);            /* -50  user motion vector */
+#ifdef __arm__
+    UserMotFunc user_mot;        /* -50  user motion vector */
+#else
+    void (*user_mot)(LONG);      /* -50  user motion vector */
+#endif
 
     /* VDI ESC variables */
     

--- a/include/lineavars.h
+++ b/include/lineavars.h
@@ -123,7 +123,7 @@ struct _lineavars {
     void (*tim_chain)(int);            /* -62  timer interrupt vector save */
     void (*user_but)(WORD status);     /* -58  user button vector */
     void (*user_cur)(WORD x, WORD y);  /* -54  user cursor vector */
-    void (*user_mot)(void);            /* -50  user motion vector */
+    void (*user_mot)(LONG);            /* -50  user motion vector */
 
     /* VDI ESC variables */
     

--- a/include/screen_mode.h
+++ b/include/screen_mode.h
@@ -49,4 +49,10 @@ typedef struct {
  */
 BOOL screen_mode_desc_valid(const SCREEN_MODE_DESC *desc);
 
+/*
+ * Called by the VDI to query the current screen mode before initializing a
+ * workstation's mode descriptor.  Implemented by the BIOS (screen.c).
+ */
+void screen_get_current_mode_desc(SCREEN_MODE_DESC *desc);
+
 #endif /* SCREEN_MODE_H */

--- a/usb/ucd_dwc2.c
+++ b/usb/ucd_dwc2.c
@@ -132,7 +132,6 @@ static LONG dwc2_cancel_async_int_msg(struct dwc2_priv *priv,
                                       struct usb_async_int_msg *msg);
 
 /*--- Global variables ---*/
-static const char hcd_name[] = "dwc2";
 static char lname[] = "DWC2 USB driver\0";
 static struct usb_device *root_hub_dev = NULL;
 

--- a/usb/udd_mouse.c
+++ b/usb/udd_mouse.c
@@ -6,7 +6,7 @@
 #include "usb_api.h"
 #include "bios.h"               /* for kbdvecs */
 #include "ikbd.h"               /* for call_mousevec() */
-#include "tosvars.h"            /* for mousexvec() */
+#include "biosext.h"            /* for mousexvec() */
 
 /****************************************************************************/
 /*
@@ -25,7 +25,7 @@ extern void (*old_ikbd_int) (void);
  */
 extern void interrupt_ikbd (void);
 
-static UBYTE mouse_packet[6];
+static SBYTE mouse_packet[6];
 
 /*
  * END kernel interface

--- a/usb/usb.c
+++ b/usb/usb.c
@@ -486,6 +486,11 @@ long usb_get_descriptor(struct usb_device *dev, unsigned char type,
 /**********************************************************************
  * gets len of configuration cfgno
  */
+long usb_get_configuration_len(struct usb_device *dev, long cfgno);
+long usb_select_config(struct usb_device *dev);
+long usb_setup_device(struct usb_device *dev, BOOL do_read,
+                      struct usb_device *parent);
+
 long usb_get_configuration_len(struct usb_device *dev, long cfgno)
 {
     long result;
@@ -500,7 +505,7 @@ long usb_get_configuration_len(struct usb_device *dev, long cfgno)
                 dev->status));
         else
             ALERT(("config descriptor too short " \
-                "(expected %i, got %i)\n", 9, result));
+                "(expected %i, got %ld)\n", 9, result));
         return -1;
     }
     return le2cpu16(config->wTotalLength);
@@ -912,11 +917,11 @@ static long get_descriptor_len(struct usb_device *dev, long len, long expect_len
     err = usb_get_descriptor(dev, USB_DT_DEVICE, 0, desc, len);
     if (err < expect_len) {
         if (err < 0) {
-            ALERT(("unable to get device descriptor (error=%d)\n",
+            ALERT(("unable to get device descriptor (error=%ld)\n",
                 err));
             return err;
         } else {
-            ALERT(("USB device descriptor short read (expected %i, got %i)\n",
+            ALERT(("USB device descriptor short read (expected %ld, got %ld)\n",
                 expect_len, err));
             return -1;
         }
@@ -1095,7 +1100,7 @@ long usb_select_config(struct usb_device *dev)
     err = usb_set_configuration(dev, dev->config.desc.bConfigurationValue);
     if (err < 0) {
         ALERT(("failed to set default configuration " \
-            "len %d, status %lX\n", dev->act_len, dev->status));
+            "len %ld, status %lX\n", dev->act_len, dev->status));
         return err;
     }
 

--- a/usb/usb_hub.c
+++ b/usb/usb_hub.c
@@ -687,7 +687,7 @@ again:
                 for (j = k; j < USB_MAX_DEVICE; j++)
                 {
                     struct usb_device *pdev = usb_get_dev_index (j);
-                    if (pdev && pdev->mf && pdev->prod)
+                    if (pdev)
                     {
                         cprintf("Found: %s %s\n", pdev->mf, pdev->prod);
                         k = j+1;

--- a/vdi/arch/arm/vdi_entry.c
+++ b/vdi/arch/arm/vdi_entry.c
@@ -127,7 +127,22 @@ void mouse_int(UBYTE *buf)
             point.x = linea_vars.GCURX + delta_x;
             point.y = linea_vars.GCURY + delta_y;
             scrn_clip(&point);
-            user_mot(MAKE_ULONG(point.x,point.y));                   // call user to modify x,y
+            /* user_mot uses the m68k register convention: x in d0, y in d1
+             * on entry, and the (possibly modified) coordinates are returned
+             * in the same registers.  Map d0/d1 onto r0/r1 and read them back,
+             * since a plain C call would discard the modified values. */
+            {
+                register LONG mx asm("r0") = point.x;
+                register LONG my asm("r1") = point.y;
+                __asm__ __volatile__(
+                    " mov r12, %[func]\n"
+                    " blx r12\n"
+                    : "+r"(mx), "+r"(my)
+                    : [func] "r"(user_mot)
+                    : "r2", "r3", "r12", "lr", "cc", "memory");
+                point.x = mx;
+                point.y = my;
+            }
             scrn_clip(&point);
             linea_vars.GCURX = point.x;
             linea_vars.GCURY = point.y;

--- a/vdi/arch/arm/vdi_entry.c
+++ b/vdi/arch/arm/vdi_entry.c
@@ -99,7 +99,6 @@ void mouse_int(UBYTE *buf)
     BYTE delta_x, delta_y;
     IntPoint point;
     void (*user_but)(WORD) = linea_vars.user_but;
-    void (*user_mot)(LONG) = linea_vars.user_mot;
     void (*user_cur)(WORD,WORD) = linea_vars.user_cur;
 
     if(linea_vars.mouse_flag) // If we are in a show/hide operation
@@ -127,21 +126,14 @@ void mouse_int(UBYTE *buf)
             point.x = linea_vars.GCURX + delta_x;
             point.y = linea_vars.GCURY + delta_y;
             scrn_clip(&point);
-            /* user_mot uses the m68k register convention: x in d0, y in d1
-             * on entry, and the (possibly modified) coordinates are returned
-             * in the same registers.  Map d0/d1 onto r0/r1 and read them back,
-             * since a plain C call would discard the modified values. */
+            /* user_mot takes the proposed x and y as arguments and returns
+             * the (possibly modified) coordinates packed into a ULONG with x
+             * in the high word and y in the low word, per the ARM AAPCS
+             * calling convention, so it can be implemented in plain C. */
             {
-                register LONG mx asm("r0") = point.x;
-                register LONG my asm("r1") = point.y;
-                __asm__ __volatile__(
-                    " mov r12, %[func]\n"
-                    " blx r12\n"
-                    : "+r"(mx), "+r"(my)
-                    : [func] "r"(user_mot)
-                    : "r2", "r3", "r12", "lr", "cc", "memory");
-                point.x = mx;
-                point.y = my;
+                ULONG result = linea_vars.user_mot((WORD)point.x, (WORD)point.y);
+                point.x = (LONG)(WORD)HIWORD(result);
+                point.y = (LONG)(WORD)LOWORD(result);
             }
             scrn_clip(&point);
             linea_vars.GCURX = point.x;

--- a/vdi/arch/arm/vdi_entry.c
+++ b/vdi/arch/arm/vdi_entry.c
@@ -99,7 +99,7 @@ void mouse_int(UBYTE *buf)
     BYTE delta_x, delta_y;
     IntPoint point;
     void (*user_but)(WORD) = linea_vars.user_but;
-    void (*user_mot)(ULONG) = (void (*)(LONG))linea_vars.user_mot;
+    void (*user_mot)(LONG) = linea_vars.user_mot;
     void (*user_cur)(WORD,WORD) = linea_vars.user_cur;
 
     if(linea_vars.mouse_flag) // If we are in a show/hide operation

--- a/vdi/vdi_control.c
+++ b/vdi/vdi_control.c
@@ -24,8 +24,7 @@
 #include "intmath.h"
 #include "bdosbind.h"
 #include "tosvars.h"
-
-void screen_get_current_mode_desc(SCREEN_MODE_DESC *desc);
+#include "screen_mode.h"
 
 #define FIRST_VDI_HANDLE    1
 #define LAST_VDI_HANDLE     (FIRST_VDI_HANDLE+NUM_VDI_HANDLES-1)

--- a/vdi/vdi_control.c
+++ b/vdi/vdi_control.c
@@ -25,6 +25,8 @@
 #include "bdosbind.h"
 #include "tosvars.h"
 
+void screen_get_current_mode_desc(SCREEN_MODE_DESC *desc);
+
 #define FIRST_VDI_HANDLE    1
 #define LAST_VDI_HANDLE     (FIRST_VDI_HANDLE+NUM_VDI_HANDLES-1)
 #define VDI_PHYS_HANDLE     FIRST_VDI_HANDLE

--- a/vdi/vdi_fill.c
+++ b/vdi/vdi_fill.c
@@ -27,7 +27,7 @@ extern Vwk phys_work;           /* attribute area for physical workstation */
 #define OVERLAY_BIT 0x0020      /* for 16-bit resolutions */
 
 /* special values used in y member of SEGMENT */
-#define EMPTY       0xffff          /* this entry is unused */
+#define EMPTY       ((WORD)-1)      /* this entry is unused */
 #define DOWN_FLAG   0x8000
 #define ABS(v)      ((v) & 0x7FFF)  /* strips DOWN_FLAG if present */
 

--- a/vdi/vdi_mouse.c
+++ b/vdi/vdi_mouse.c
@@ -644,7 +644,7 @@ void vdimouse_init(void)
     linea_vars.GCURY = linea_vars.DEV_TAB[1] / 2;
 
     linea_vars.user_but = (void(*)(WORD))just_rts;
-    linea_vars.user_mot = just_rts;
+    linea_vars.user_mot = (void (*)(LONG))just_rts;
     linea_vars.user_cur = mov_cur;         /* initialize user_cur vector */
 #if CONF_WITH_EXTENDED_MOUSE
     user_wheel = (void (*)(WORD, WORD))just_rts;
@@ -683,7 +683,7 @@ void vdimouse_init(void)
 void vdimouse_exit(void)
 {
     linea_vars.user_but = (void(*)(WORD))just_rts;
-    linea_vars.user_mot = just_rts;
+    linea_vars.user_mot = (void (*)(LONG))just_rts;
     linea_vars.user_cur = (void(*)(WORD,WORD))just_rts;
 #if CONF_WITH_EXTENDED_MOUSE
     user_wheel = (void (*)(WORD, WORD))just_rts;

--- a/vdi/vdi_mouse.c
+++ b/vdi/vdi_mouse.c
@@ -369,6 +369,7 @@ static void call_user_wheel(WORD wheel_number, WORD wheel_amount)
 #endif
 
 #ifdef __arm__
+#if CONF_WITH_EXTENDED_MOUSE
 /*
  * Call the user_but vector from C
  */
@@ -386,6 +387,7 @@ static void call_user_wheel(WORD wheel_number, WORD wheel_amount)
     void (*func)(WORD, WORD) = user_wheel; /* prototype not quite right: status passed in d0 */
     func(wheel_number, wheel_amount);
 }
+#endif
 
 /*
  * mov_cur - moves the mouse cursor to its new location

--- a/vdi/vdi_mouse.c
+++ b/vdi/vdi_mouse.c
@@ -411,6 +411,15 @@ void mov_cur(WORD new_x, WORD new_y)      /* user button vector */
     set_cpsr(cpsr);
 }
 
+/*
+ * default_user_mot - default user motion vector: pass the coordinates through
+ * unchanged, packed with x in the high word and y in the low word.
+ */
+static ULONG default_user_mot(WORD x, WORD y)
+{
+    return MAKE_ULONG(x, y);
+}
+
 #endif /* __arm__ */
 
 
@@ -646,7 +655,11 @@ void vdimouse_init(void)
     linea_vars.GCURY = linea_vars.DEV_TAB[1] / 2;
 
     linea_vars.user_but = (void(*)(WORD))just_rts;
+#ifdef __arm__
+    linea_vars.user_mot = default_user_mot;
+#else
     linea_vars.user_mot = (void (*)(LONG))just_rts;
+#endif
     linea_vars.user_cur = mov_cur;         /* initialize user_cur vector */
 #if CONF_WITH_EXTENDED_MOUSE
     user_wheel = (void (*)(WORD, WORD))just_rts;
@@ -685,7 +698,11 @@ void vdimouse_init(void)
 void vdimouse_exit(void)
 {
     linea_vars.user_but = (void(*)(WORD))just_rts;
+#ifdef __arm__
+    linea_vars.user_mot = default_user_mot;
+#else
     linea_vars.user_mot = (void (*)(LONG))just_rts;
+#endif
     linea_vars.user_cur = (void(*)(WORD,WORD))just_rts;
 #if CONF_WITH_EXTENDED_MOUSE
     user_wheel = (void (*)(WORD, WORD))just_rts;


### PR DESCRIPTION
Fixes #291

## What
Eliminates all compiler warnings from the ARM targets (Raspberry Pi and
virt-arm) by fixing the ARM-only diagnostics GCC emitted, without
regressing the m68k / ColdFire targets and without changing behaviour.

Previously the ARM builds produced 63 compiler warnings. This PR brings
`rpi1`/`rpi2` down to zero compiler warnings (the one remaining link-time
`RWX LOAD segment` notice is tracked separately in #295) and keeps every
other target warning-free.

## How
The fixes fall into a few groups, all kept portable so the shared code
still builds on m68k (`int` = 16 bits):

- **Types and qualifiers** — aligned function-pointer signatures
  (`user_mot` in Line-A and `vdi_entry.c`), fixed `BYTE*`/`UBYTE*`
  signedness in `elfld.c`, cast font `dat_table` initializers to
  `const UBYTE *`, restored `const OSHEADER os_header` to match the
  public declaration, and moved the `screen_get_current_mode_desc()`
  prototype into the shared `include/screen_mode.h` so VDI and BIOS
  share one canonical declaration instead of a duplicated forward decl.
- **Prototypes and includes** — added missing `#include`s
  (`raspi_emmc.h`, `biosext.h`), forward declarations for USB
  functions, and a prototype for `aestrap_intercepted()`.
- **Dead / redundant code** — removed unused `hcd_name`, an unused FDT
  bootargs variable, and a tautological `pdev->mf && pdev->prod` guard
  (`mf`/`prod` are fixed-size arrays, so they can never be NULL).
- **Conditional compilation** — guarded ARM-only paths
  (`call_user_but`/`call_user_wheel` behind `CONF_WITH_EXTENDED_MOUSE`,
  DMA-boot scanning behind the disk backends that use it, SCSI driver
  locals behind `CONF_WITH_ACSI || CONF_WITH_IDE`) and used
  `MAYBE_UNUSED` where a symbol is genuinely unused on some configs.
- **Machine-specific plumbing** — introduced the `VEC_AT()` /
  `vector_address()` abstraction for the m68k exception-vector table
  (removing 17 array-bounds warnings from `bios.tr.c` and the AES on
  ARM), replaced hardcoded `0x4a6`/`0x5a0` addresses with the `nflops`
  / `p_cookies` globals on ARM, and used the typed globals instead of
  raw addresses.

## Verification
- `rpi1`, `rpi2`, `rpi3`, `rpi4`, `virt-arm` build with **zero compiler
  warnings**.
- The full CI matrix passes: all m68k / ColdFire Atari, Amiga and
  ColdFire targets (`aranym`, `atari*`, `amiga*`, `firebee*`,
  `m548x*`, `virt-m68k`), ARM targets, plus the SD card image and
  release archives.
- `make gitready` is clean.

## Other issues
- #295 tracks the remaining ARM ELF `RWX LOAD segment` linker notice
  (separate from compiler warnings, already open).
