### PR TITLE
m68k: add an optional -mfastcall kernel build (merged into #304)

### DIFF
--- a/.claude/skills/ptos-smoketest/SKILL.md
+++ b/.claude/skills/ptos-smoketest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ptos-smoketest
-description: Use when smoke-testing or verifying that a built pTOS (Portable EmuTOS) image boots under an emulator. Covers Hatari for m68k Atari targets (atari512/STE/Falcon/TT configs) and QEMU for the raspi1 (QEMU machine `raspi1ap`), raspi2 (QEMU machine `raspi2b`), virt-arm and virt-m68k machines, plus testing the flashable Raspberry Pi SD card disk image (`tools/mkraspi-image.sh`) by attaching it to QEMU as a raw `-drive if=sd`. Also covers running the regression test suite (`make test-hd`) on QEMU with the test HD image as an SD card and reading pass/fail output from the serial console. Use when asked to boot a pTOS build, check it reaches the GEM desktop, diagnose a slow/hung boot, verify the SD card image's MBR/FAT16 partition is readable by pTOS's own eMMC driver, run regression tests under QEMU, or when you need emulator invocations, --run-vbls/--avirecord/--trace flags, the Hatari debugger gotchas (spurious breakpoints, echo crash), the Falcon IDE 31s boot wait, the floppy motor/deselection timeouts (motor on/off 1.5-3s + deselect 5s = ~20s STE baseline), or QEMU's power-of-2 SD card image size requirement.
+description: Use when smoke-testing or verifying that a built pTOS (Portable EmuTOS) image boots under an emulator, OR when doing a difficult interactive debugging session on a m68k/Atari target (a crash, hang, or wrong-behavior bug that needs real breakpoints/single-stepping/register or memory inspection, not just a boot pass/fail check). Covers Hatari for m68k Atari targets (atari512/STE/Falcon/TT configs) and QEMU for the raspi1 (QEMU machine `raspi1ap`), raspi2 (QEMU machine `raspi2b`), virt-arm and virt-m68k machines, plus testing the flashable Raspberry Pi SD card disk image (`tools/mkraspi-image.sh`) by attaching it to QEMU as a raw `-drive if=sd`. Also covers running the regression test suite (`make test-hd`) on QEMU with the test HD image as an SD card and reading pass/fail output from the serial console. For interactive debugging: `tools/rdb.py` plus a patched, remote-debuggable Hatari fork (hrdb, see doc/debugging.txt) for real-Atari-hardware bugs, and QEMU+GDB (including `CONF_DEBUG_FORCE_MC68000` for reproducing genuine-68000, non-longframe code paths on virt-m68k) for boot-sequencing/ABI bugs. Use when asked to boot a pTOS build, check it reaches the GEM desktop, diagnose a slow/hung boot, debug a crash with breakpoints/register dumps, verify the SD card image's MBR/FAT16 partition is readable by pTOS's own eMMC driver, run regression tests under QEMU, or when you need emulator invocations, --run-vbls/--avirecord/--trace flags, the Hatari debugger gotchas (spurious breakpoints, echo crash) and the hrdb alternative, the Falcon IDE 31s boot wait, the floppy motor/deselection timeouts (motor on/off 1.5-3s + deselect 5s = ~20s STE baseline), or QEMU's power-of-2 SD card image size requirement.
 ---
 
 # pTOS Smoke Testing
@@ -187,6 +187,82 @@ time; e.g. the 31 s IDE wait polls `_hz_200` at `0x4ba`, `addq.l #1,$4ba` at
   's2 < s1'`, rc=134, core dump). Never use `echo` in debugger scripts.
 - No `info breakpoints` command; list breakpoints with bare `b`.
 - Trust only: `--run-vbls` + `--trace ...` output and AVI frames.
+
+## Interactive debugging: hrdb (a reliable alternative to the above)
+
+For anything beyond a boot pass/fail check — a crash needing register
+dumps, a breakpoint that must actually fire, single-stepping — use
+`tools/rdb.py` against a patched, remote-debuggable Hatari instead of
+stock Hatari's debugger above. Full protocol writeup, wire-format
+quirks and process-management gotchas: `doc/debugging.txt`. Quick
+reference:
+
+```sh
+# One-time: build the patched fork (needs libsdl2-dev)
+git clone --branch hrdb-main --depth 1 https://github.com/tattlemuss/hatari /tmp/hatari-hrdb
+cd /tmp/hatari-hrdb && mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release && make -j$(nproc)
+# binary: build/src/hatari -- same CLI as stock Hatari
+
+# Launch (setsid is required -- see doc/debugging.txt's process-management
+# gotchas; a plain '&'-backgrounded instance was observed to die when the
+# launching shell command finished, even with disown)
+ps aux | grep 'build/src/hatari' | grep -v grep   # kill any stale instance first (port 56001, one client)
+env SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy setsid /tmp/hatari-hrdb/build/src/hatari \
+  --tos ptos192us.img --machine st --memsize 4 --sound off --drive-a false --drive-b false \
+  > /tmp/hatari.log 2>&1 < /dev/null &
+disown
+```
+
+```python
+from rdb import RDB   # tools/rdb.py; run from tools/, or sys.path.insert it
+r = RDB()                          # connects to 127.0.0.1:56001
+r.bp("pc=$fc23d8")                 # standard Hatari breakpoint-expression syntax
+r.run()
+stop = r.wait_stopped()            # blocks until the breakpoint fires
+regs = r.regs()                    # {"D0": ..., "PC": ..., "SR": ..., ...}
+data, addr = r.mem(regs["A0"], 128)
+r.step(); r.regs()                 # single-step + re-read
+```
+
+`break`/`step`/`run`/`regs`/`mem`/`bp`/`bplist` all verified working,
+repeatedly, in one session — this is the tool to reach for on a real
+Atari-hardware-specific bug (see the "Which tool for which bug"
+section of `doc/debugging.txt` for when to prefer this over QEMU+GDB
+below).
+
+## Interactive debugging: QEMU + GDB for m68k (virt-m68k)
+
+For boot-sequencing or ABI/register-convention bugs that don't need
+real Atari hardware (MFP, floppy, ACSI, actual ROM size/memory map),
+QEMU's GDB stub on virt-m68k is faster to iterate than Hatari:
+
+```sh
+qemu-system-m68k -M virt -m 128 -cpu m68000 -kernel virt-m68k.elf \
+  -d guest_errors -serial /dev/null -display none -S -gdb tcp::1234 &
+gdb-multiarch -q -x script.gdb virt-m68k.elf
+```
+
+`virt-m68k_defconfig` always builds for `-cpu m68020` (see the
+`CPUFLAGS` comment there): QEMU's `-cpu m68000` model doesn't fault on
+"MOVE from CCR", the one instruction pTOS's own CPU auto-detection
+relies on to tell 68000 apart from 68010+, so a plain `-cpu m68000`
+run misdetects itself as 68010+ and corrupts every trap's argument
+frame. To actually test a genuine-68000 code path (e.g. what
+atari192/256 run), set `CONF_DEBUG_FORCE_MC68000=y` in `.config`
+(`Kconfig.debug`, debug-only, never for a real build) alongside
+`CPUFLAGS="-m68000"` — full details and the exact `.config` edits in
+`doc/debugging.txt`.
+
+GDB scripting reliability, verified in this environment: a single
+`target remote` / `break` / `continue` round-trip to the first stop is
+reliable; chaining several breakpoint-`commands`-block auto-continues
+in one long session was flaky (intermittent "Cannot execute this
+command while the target is running"). Prefer one `-x script.gdb` run
+per breakpoint hit, restarting QEMU fresh each time. `-d exec` full
+instruction traces are useful but enormous (millions of lines within
+seconds) — delete the log file immediately after grepping it out, or
+it can exhaust the session's disk quota.
 
 ## QEMU smoke test (raspi1 / raspi2 / virt-arm / virt-m68k)
 

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -15,6 +15,15 @@ inputs:
       Which cross toolchain to install: "m68k" for the Atari, Amiga and
       ColdFire targets, or "arm" for the Raspberry Pi ones.
     required: true
+  mfastcall:
+    description: >
+      "true" to additionally install Thorsten Otto's m68k-atari-mintelf
+      toolchain build ahead of the regular one on PATH, so that
+      CONF_WITH_MFASTCALL=y configs (which need -mfastcall support neither
+      of Vincent Riviere's toolchains has) can build. Ignored for arch:
+      arm. Defaults to "false", so existing jobs are unaffected.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -29,6 +38,14 @@ runs:
         m68k|arm) ;;
         *)
           echo "::error::unknown arch '${{ inputs.arch }}', expected 'm68k' or 'arm'"
+          exit 1
+          ;;
+        esac
+
+        case '${{ inputs.mfastcall }}' in
+        true|false) ;;
+        *)
+          echo "::error::mfastcall must be 'true' or 'false', got '${{ inputs.mfastcall }}'"
           exit 1
           ;;
         esac
@@ -62,6 +79,49 @@ runs:
         # packs each archive.  Both happen to be on the runner images already;
         # they are named here so that this action really is the whole list.
         sudo apt-get install -y cross-mint-essential cross-mintelf-essential dos2unix zip
+
+    # CONF_WITH_MFASTCALL needs a GCC built with -mfastcall support, which
+    # neither of Vincent Riviere's toolchains just installed above has (see
+    # Kconfig.machine's CONF_WITH_MFASTCALL help text). Thorsten Otto
+    # publishes a prebuilt m68k-atari-mintelf toolchain that does, at the
+    # same executable names (m68k-atari-mintelf-gcc, -as, -ld, ...) as
+    # Vincent Riviere's mintelf package above -- installed to its own
+    # directory and prepended to PATH here, it simply takes over those
+    # names for every later step in the job, no CROSS_COMPILE override
+    # needed. binutils is a separate download from GCC on that site; both
+    # extract a "usr/" tree, so unpacking them on top of each other merges
+    # into one complete toolchain.
+    #
+    # The download URLs are version- and build-date-stamped (Thorsten
+    # Otto's site keeps no "latest" alias), so a future toolchain update
+    # there needs this step's URLs and hashes bumped by hand; the sha256
+    # pin means a stale URL fails loudly here instead of silently building
+    # against whatever the site happens to serve.
+    - name: Install a -mfastcall capable m68k toolchain
+      if: inputs.arch == 'm68k' && inputs.mfastcall == 'true'
+      shell: bash
+      env:
+        GCC_URL: https://tho-otto.m68k.eu/download/mint/gcc-13.4.0-mintelf-20250702-bin-linux64.tar.xz
+        GCC_SHA256: 70ae7f69ec54484b805990ddef517af13fccc3744018dbca3cc0e61eec1c55b6
+        BINUTILS_URL: https://tho-otto.m68k.eu/download/mint/binutils-2.45-mintelf-20250812-bin-linux64.tar.xz
+        BINUTILS_SHA256: e37c22f84baaf8ffc890a11265d4369498f9bc4e68aaac21dcef887d3655f025
+      run: |
+        dest="$RUNNER_TEMP/th-otto-mintelf"
+        mkdir -p "$dest"
+
+        for spec in "$GCC_URL:$GCC_SHA256" "$BINUTILS_URL:$BINUTILS_SHA256"; do
+          url="${spec%:*}"
+          sha256="${spec##*:}"
+          archive="$RUNNER_TEMP/$(basename "$url")"
+
+          curl -sSL --fail --retry 3 -o "$archive" "$url"
+          echo "$sha256  $archive" | sha256sum -c -
+
+          tar -xJf "$archive" -C "$dest"
+          rm -f "$archive"
+        done
+
+        echo "$dest/usr/bin" >>"$GITHUB_PATH"
 
     # A plain bare metal arm-none-eabi toolchain is all the Raspberry Pi
     # targets need, and Ubuntu packages one.
@@ -105,7 +165,19 @@ runs:
         case '${{ inputs.arch }}' in
         m68k)
           first_line m68k-atari-mint-gcc --version
+          echo "m68k-atari-mintelf-gcc: $(command -v m68k-atari-mintelf-gcc)"
           first_line m68k-atari-mintelf-gcc --version
+
+          # Confirm the toolchain that just went first on PATH is the one
+          # actually running, rather than only finding out via a Kconfig
+          # capability-probe failure deep inside the real build.
+          if [ '${{ inputs.mfastcall }}' = 'true' ]; then
+            if ! echo 'void f(void){}' | m68k-atari-mintelf-gcc -mfastcall -x c -c - -o /dev/null 2>&1; then
+              echo "::error::m68k-atari-mintelf-gcc does not support -mfastcall"
+              exit 1
+            fi
+            echo "m68k-atari-mintelf-gcc supports -mfastcall"
+          fi
           ;;
         arm)  first_line arm-none-eabi-gcc --version ;;
         esac

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,9 +99,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Same idea as the architecture split above: a config that turns on
+      # CONF_WITH_MFASTCALL needs Thorsten Otto's toolchain instead of
+      # Vincent Riviere's (see setup-toolchain's own mfastcall input), and
+      # this makes that automatic for whichever configs need it, present or
+      # future, without this workflow having to list them.
+      - name: Check whether this config needs -mfastcall
+        id: check-mfastcall
+        run: |
+          if grep -qE '^CONF_WITH_MFASTCALL=y' "configs/${{ matrix.config }}_defconfig"; then
+            echo "mfastcall=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "mfastcall=false" >>"$GITHUB_OUTPUT"
+          fi
+
       - uses: ./.github/actions/setup-toolchain
         with:
           arch: m68k
+          mfastcall: ${{ steps.check-mfastcall.outputs.mfastcall }}
 
       - name: Build ${{ matrix.config }}
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,4 +163,7 @@ same object.
 - `doc/coding.txt` — coding style
 - `doc/country.txt`, `doc/nls.txt` — countries, keyboard layouts, translations
 - `doc/status.txt`, `doc/bugs.txt` — what works and what does not
+- `doc/debugging.txt` — interactive debugging under an emulator: hrdb (a
+  remote-debuggable Hatari fork) and QEMU+GDB for m68k, and when to reach for
+  each; see also the `ptos-smoketest` skill and `tools/rdb.py`
 - `readme.md` — what this fork is about and where it is going

--- a/Kconfig.debug
+++ b/Kconfig.debug
@@ -135,6 +135,27 @@ config CONF_DEBUG_DESK_STACK
 	depends on CONF_WITH_AES
 	default n
 
+config CONF_DEBUG_FORCE_MC68000
+	bool "Force CPU auto-detection to report a plain 68000"
+	depends on ARCH_M68K_CLASSIC
+	default n
+	help
+	  QEMU's m68k "m68000" CPU model does not fault on the "MOVE from
+	  CCR" instruction the way real 68000 silicon does, which is what
+	  detect_cpu() (bios/arch/m68k/processor.S) relies on to tell a
+	  68000 apart from a 68010 or later. Under that model, detection
+	  wrongly concludes 68010+, which sets longframe and breaks the
+	  BIOS/XBIOS/GEMDOS trap dispatch: it then expects the extra
+	  68010+ exception-frame format word that a real 68000 frame does
+	  not have, and every trap call misreads its arguments.
+
+	  Say y to override mcpu/longframe/fputype to the 68000 values
+	  right after auto-detection runs. This is a debugging aid for
+	  testing under QEMU only -- never enable it for a build that
+	  might run on real hardware or an accurate emulator (e.g.
+	  Hatari), since it will misidentify an actual 68010+ CPU as a
+	  68000.
+
 source "tests/Kconfig"
 
 endmenu

--- a/Kconfig.machine
+++ b/Kconfig.machine
@@ -382,6 +382,32 @@ config CPUFLAGS
 	  Passed to the compiler and to the linker to select the instruction
 	  set of the generated code.
 
+config CONF_WITH_MFASTCALL
+	bool "Use the -mfastcall calling convention (m68k only)"
+	depends on ARCH_M68K
+	default n
+	help
+	  Build the whole kernel with GCC's -mfastcall calling convention
+	  (arguments passed in d0-d2/a0-a1/fp0-fp2 where possible) instead
+	  of the default, stack-based one.
+
+	  This requires a GCC build with -mfastcall support, which neither
+	  of Vincent Riviere's toolchains (the ones normally installed for
+	  this project, see the choice above) has. Thorsten Otto's fork
+	  (https://github.com/th-otto/m68k-atari-mint-gcc, prebuilt at
+	  https://tho-otto.m68k.eu/crossmint.php) does. The build fails
+	  with a clear error at compile time if the configured compiler
+	  does not support the flag, rather than accepting this option and
+	  failing later with an unrecognised-option error.
+
+	  GEMDOS/BIOS/XBIOS/AES trap entry points are unaffected either
+	  way: they always explicitly construct the fixed TOS wire-format
+	  stack frame, on any ABI, rather than inheriting the C calling
+	  convention.
+
+	  Independent of -mshort: both can be selected together where the
+	  toolchain supports both.
+
 choice
 	prompt "Optimization level"
 	default OPTIMIZE_SIZE if TARGET_192 || TARGET_256 || TARGET_CART || TARGET_PRG || TARGET_FLOPPY || TARGET_AMIGA_ROM || TARGET_AMIGA_KICKDISK || TARGET_AMIGA_FLOPPY

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,16 @@ ifdef ARCH_ARM
 MULTILIBFLAGS = $(CPUFLAGS) -fsigned-char
 TOOLCHAIN_CFLAGS = -fleading-underscore -fno-reorder-functions -DELF_TOOLCHAIN
 else
-MULTILIBFLAGS = $(CPUFLAGS)
+# The kernel can never assume a real FPU is present -- processor.S detects
+# one at runtime, for userland's benefit, precisely because most m68k
+# targets this builds for don't have one. Every toolchain used here has
+# always defaulted to -msoft-float on its own, silently, so this was never
+# needed -- until Thorsten Otto's -mfastcall-patched GCC (Kconfig's
+# CONF_WITH_MFASTCALL help text), which defaults the other way once -m68020
+# or later is selected (-mhard-float/-m68881 enabled), freely emitting real
+# FPU instructions QEMU's -cpu m68020 (no FPU) can't execute. Pass it
+# explicitly so kernel codegen never depends on a toolchain's own default.
+MULTILIBFLAGS = $(CPUFLAGS) -msoft-float
 ifdef CONF_WITH_MFASTCALL
 MULTILIBFLAGS += -mfastcall
 endif

--- a/Makefile
+++ b/Makefile
@@ -192,9 +192,25 @@ MULTILIBFLAGS = $(CPUFLAGS) -fsigned-char
 TOOLCHAIN_CFLAGS = -fleading-underscore -fno-reorder-functions -DELF_TOOLCHAIN
 else
 MULTILIBFLAGS = $(CPUFLAGS)
+ifdef CONF_WITH_MFASTCALL
+MULTILIBFLAGS += -mfastcall
+endif
 ifdef BUILD_TOOLCHAIN_IS_ELF
 TOOLCHAIN_CFLAGS = -fleading-underscore -Wa,--register-prefix-optional \
                    -fno-reorder-functions -DELF_TOOLCHAIN
+endif
+endif
+
+# CONF_WITH_MFASTCALL selects -mfastcall above, but neither of the toolchains
+# offered in the "m68k toolchain" choice (Kconfig.machine) support it -- only
+# a patched GCC does (Thorsten Otto's fork, see the option's help text).  Fail
+# now with an actionable message instead of letting every compile fail later
+# with a generic "unrecognized command-line option '-mfastcall'".
+ifdef CONFIGURED
+ifdef CONF_WITH_MFASTCALL
+ifeq (,$(shell $(CC) -mfastcall -E - </dev/null >/dev/null 2>&1 && echo y))
+$(error $(CC) does not support -mfastcall. Install a patched toolchain (e.g. Thorsten Otto's m68k-atari-mint-gcc fork, https://tho-otto.m68k.eu/crossmint.php) and point CROSS_COMPILE at it, or disable CONF_WITH_MFASTCALL in "make menuconfig")
+endif
 endif
 endif
 

--- a/aes/arch/m68k/gemasm.S
+++ b/aes/arch/m68k/gemasm.S
@@ -55,9 +55,20 @@ _psetup:
         move    sr,savesr2
         ori     #0x0700,sr
 #endif
+        /*
+         * psetup(AESPD*, PFVOID) has two pointer arguments. Under
+         * -mfastcall they arrive in a0/a1 (p/codevalue), not on the
+         * stack -- unlike the plain stack ABI below, which is how this
+         * function read them before -mfastcall existed.
+         */
+#if CONF_WITH_MFASTCALL
+        move.l  a1,d0           // New process entry point
+        movea.l PD_UDA(a0),a0
+#else
         movea.l 4(sp),a0        // AESPD *
         move.l  8(sp),d0        // New process entry point
         movea.l PD_UDA(a0),a0
+#endif
         movea.l UDA_SPSUPER(a0),a1
         move.l  d0,-(a1)        // Push entry point on the process stack
         move.l  a1,UDA_SPSUPER(a0)
@@ -177,7 +188,16 @@ _switchto:
         ori     #0x0700,sr
 #endif
 
+        /*
+         * switchto(UDA *puda) has one pointer argument, which arrives
+         * in a0 under -mfastcall instead of on the stack (see the
+         * identical fix in this file's _psetup).
+         */
+#if CONF_WITH_MFASTCALL
+        movea.l a0,sp           // Use SP as pointer to UDA struct
+#else
         movea.l 4(sp),sp        // Use SP as pointer to UDA struct
+#endif
         movem.l UDA_REGS(sp),d0-a5
         movea.l UDA_SPUSER(sp),a6
         move.l  a6,usp

--- a/aes/arch/m68k/gemdosif.S
+++ b/aes/arch/m68k/gemdosif.S
@@ -231,6 +231,18 @@ trapaes:
         movea.l UDA_SPSUPER(a6),sp
         jbsr    _enable_interrupts      // restore interrupt mask
 
+#if CONF_WITH_MFASTCALL
+        /*
+         * Under -mfastcall, super(WORD cx, AESPB*) takes cx in d0 and
+         * pcrys_blk in a0. d0 already holds cx -- set at _aestrap's
+         * entry and untouched since; disable/enable_interrupts above
+         * are hand-written (bios/arch/m68k/intmask.S) and provably
+         * preserve every register but sr -- so only pcrys_blk needs to
+         * move from d1 into a0.
+         */
+        movea.l d1,a0                   // addr of parameter
+        jsr     _super                  // jump to supervisor entry point
+#else
         /*
          * Build the call frame GCC expects for super(WORD cx, AESPB*).
          * With -mshort no longer used for the kernel m68k build (#300),
@@ -245,6 +257,7 @@ trapaes:
         move.l  d0,-(sp)                // 200 or 201, in the low word
         jsr     _super                  // jump to supervisor entry point
         addq.l  #8,sp                   // restore stack pointer
+#endif
 
         jbsr    _disable_interrupts     // mask out interrupts
 

--- a/aes/arch/m68k/gemstart.S
+++ b/aes/arch/m68k/gemstart.S
@@ -164,6 +164,73 @@ _accdesk_start:
 // A wrapper around Pexec. We can't use the above function _gemdos for this
 // since _gemdos is not reentrant.
 //////////////////////////////////////////////////////////////////////////////
+#if CONF_WITH_MFASTCALL
+_dos_exec:
+        /*
+         * Under -mfastcall a call to
+         * dos_exec(WORD mode, const char*, const char*, const char*)
+         * arrives with mode in d0, pcspec in a0, pcmdln in a1, and only
+         * segenv (the 4th argument -- fastcall has just two address
+         * registers) spilled to the stack, at 4(sp) relative to our own
+         * entry sp. Unlike the non-fastcall path below, we can't defer
+         * reading these until after the disable/enable_interrupts calls
+         * further down: a jsr is free to clobber d0/a0/a1 like any
+         * caller-saved register, so save all four arguments to our own
+         * stack right now, before anything else touches it. Pushed in
+         * wire-frame order (mode, pcspec, pcmdln, segenv), they land
+         * contiguously and already read back with the exact same
+         * literal-offset trick as the tightly-packed re-push below --
+         * only the source (our own saved copy, not the caller's frame)
+         * differs.
+         */
+        move.l  4(sp),-(sp)             // segenv, from the caller's stack-spilled 4th arg
+        move.l  a1,-(sp)                // pcmdln
+        move.l  a0,-(sp)                // pcspec
+        move.w  d0,-(sp)                // mode, low word
+#ifdef __mcoldfire__
+        move.l  a2,-(sp)                // Save registers
+        move.l  d2,-(sp)
+#else
+        movem.l d2/a2,-(sp)             // Save registers
+#endif
+
+        // See the *** WARNING *** in the non-fastcall path below for why
+        // this stack adjustment exists. The saved-argument block above
+        // adds 14 bytes pushed before the reentrancy-guard snapshot
+        // taken here, which the constant below already accounts for.
+
+        jsr     _disable_interrupts
+        movea.l _rlr,a0
+        movea.l PD_UDA(a0),a0
+        move.l  UDA_SPSUPER(a0),-(sp)   // Save rlr->p_uda->u_spsuper
+        movea.l sp,a1
+        suba.l  #0x50,a1                // Adjust the stack (see above)
+        move.l  a1,UDA_SPSUPER(a0)
+        jsr     _enable_interrupts
+
+        move.l  22(sp),-(sp)            // Push parameters on the stack again...
+        move.l  22(sp),-(sp)
+        move.l  22(sp),-(sp)
+        move.w  24(sp),-(sp)
+        move.w  #0x4B,-(sp)
+        trap    #1                      // ... and execute the Pexec call!
+        lea     16(sp),sp
+
+        jsr     _disable_interrupts
+        movea.l _rlr,a0
+        movea.l PD_UDA(a0),a0
+        move.l  (sp)+,UDA_SPSUPER(a0)   // Restore rlr->p_uda->u_spsuper
+        jsr     _enable_interrupts
+
+#ifdef __mcoldfire__
+        move.l  (sp)+,d2
+        move.l  (sp)+,a2
+#else
+        movem.l (sp)+,d2/a2
+#endif
+        lea     14(sp),sp               // drop our saved mode/pcspec/pcmdln/segenv
+        rts
+#else
 _dos_exec:
         move.l  sp,d1
 #ifdef __mcoldfire__
@@ -254,6 +321,7 @@ _dos_exec:
         movem.l (sp)+,d2/a2
 #endif
         rts
+#endif
 
 .bss
 

--- a/aes/arch/m68k/gemstart.S
+++ b/aes/arch/m68k/gemstart.S
@@ -97,11 +97,17 @@ aes_restart:
 #endif
 
         // clear the 'global memory' zone
+#if CONF_WITH_MFASTCALL
+        movea.l #_D,a0
+        move.l  #SIZEOF_THEGLO,d0 // size in bytes
+        jsr     _bzero_nobuiltin    // clear it
+#else
         move.l  #SIZEOF_THEGLO, -(sp) // size in bytes
         movea.l #_D,a0
         move.l  a0,-(sp)        // address
         jsr     _bzero_nobuiltin    // clear it
         addq.l  #8,sp
+#endif
 
         // _drwaddr ??? set to just_rts
         lea     _just_rts,a0

--- a/bdos/bdosmain.c
+++ b/bdos/bdosmain.c
@@ -200,6 +200,24 @@ typedef struct
         long  (*wlp)(short, long, void*);
         long  (*wpl)(short, void*, long);
         long  (*wpp)(short, void*, void*);
+        /*
+         * Same mismatch as above, but on the *return* side: xmalloc(),
+         * srealloc() and xmxalloc() all return void* (a block address),
+         * not a scalar long, even though their arguments are plain
+         * longs/words. Under -mfastcall a function's return value comes
+         * back in a0 when its own declared return type is a pointer, but
+         * in d0 when it is a scalar long/int -- unlike the plain stack
+         * ABI, where every GEMDOS return value is read from d0 regardless
+         * of C type. Calling through a long-returning union member (l,
+         * lw, ...) would read the stale d0 left over from whatever ffit()
+         * or shrinkit() last did internally, instead of the a0 the callee
+         * actually returned its result in. rl/rlw are the pointer-
+         * returning twins of l/lw, used only for the functions whose real
+         * C signature returns void* -- xtermres, the other LW-shaped
+         * function, genuinely returns a scalar long and still uses lw.
+         */
+        void  *(*rl)(long);
+        void  *(*rlw)(long, short);
     } fncall;
     UBYTE stdio_typ;    /* Standard I/O channel (highest bit must be set, too) */
     UBYTE shape;        /* FSHAPE_* -- which fncall union member to use */
@@ -211,7 +229,8 @@ enum {
     FSHAPE_V, FSHAPE_W, FSHAPE_L, FSHAPE_WW, FSHAPE_LL,
     FSHAPE_LW, FSHAPE_LWW, FSHAPE_WLLL,
     FSHAPE_P, FSHAPE_PL, FSHAPE_PW, FSHAPE_PWW,
-    FSHAPE_WLP, FSHAPE_WPL, FSHAPE_WPP
+    FSHAPE_WLP, FSHAPE_WPL, FSHAPE_WPP,
+    FSHAPE_RL, FSHAPE_RLW
 };
 #endif
 
@@ -287,7 +306,7 @@ static const FND funcs[] =
 #endif
 
 #if CONF_WITH_VIDEL
-    { F(srealloc),  0, W_N(1,L) },     /* 0x15 */
+    { F(srealloc),  0, W_N(1,RL) },    /* 0x15 */
 #else
     { NI, 0, 0 },               /* 0x15 */
 #endif
@@ -350,11 +369,11 @@ static const FND funcs[] =
     { F(xunlink),  0, W_N(1,P) },      /* 0x41 */
     { F(xlseek),   0x81, W_N(3,LWW) }, /* 0x42 */
     { F(xchmod),   0, W_N(3,PWW) },    /* 0x43 */
-    { F(xmxalloc), 0, W_N(2,LW) },     /* 0x44 */
+    { F(xmxalloc), 0, W_N(2,RLW) },    /* 0x44 */
     { F(xdup),     0, W_N(1,W) },      /* 0x45 */
     { F(xforce),   0, W_N(2,WW) },     /* 0x46 */
     { F(xgetdir),  0, W_N(2,PW) },     /* 0x47 */
-    { F(xmalloc),  0, W_N(1,L) },      /* 0x48 */
+    { F(xmalloc),  0, W_N(1,RL) },     /* 0x48 */
     { F(xmfree),   0, W_N(1,P) },      /* 0x49 */
     { F(xsetblk),  0, W_N(3,WPL) },    /* 0x4A */
     { F(xexec),    0, W_N(4,WLLL) },   /* 0x4B */
@@ -884,6 +903,14 @@ restrt:
 
         case FSHAPE_WPP:
             rc = (*f->fncall.wpp)(pw[1],(void*)PWLONG(2),(void*)PWLONG(4));
+            break;
+
+        case FSHAPE_RL:
+            rc = (long)(*f->fncall.rl)(PWLONG(1));
+            break;
+
+        case FSHAPE_RLW:
+            rc = (long)(*f->fncall.rlw)(PWLONG(1),pw[3]);
             break;
 
         default:

--- a/bdos/bdosmain.c
+++ b/bdos/bdosmain.c
@@ -166,7 +166,6 @@ typedef struct
         long  (*ll)(long, long);
         long  (*lw)(long, short);
         long  (*lww)(long, short, short);
-        long  (*wll)(short, long, long);
         /*
          * xexec(WORD, char*, char*, char*) is the sole WLLL-shaped
          * function, and all three "L" slots are real pointers (path,
@@ -181,6 +180,26 @@ typedef struct
          * share the same stack layout there.
          */
         long  (*wlll)(short, void*, void*, void*);
+        /*
+         * The "L" letter in every shape above names a wire slot's
+         * *width* (32 bits), not its C type -- but under -mfastcall a
+         * pointer-typed argument and a scalar long-typed argument in
+         * that same slot go to different register classes (a0/a1 vs.
+         * d0-d2), unlike the plain stack ABI where both share the same
+         * 4-byte stack layout regardless of type (see the wlll comment
+         * above). Every shape below is the pointer-carrying twin of an
+         * existing long-shape, added because at least one function
+         * using that wire shape has a real pointer in an "L" slot;
+         * calling it through the long-typed union member would send
+         * that pointer to a data register instead of an address one.
+         */
+        long  (*p)(void*);
+        long  (*pl)(void*, long);
+        long  (*pw)(void*, short);
+        long  (*pww)(void*, short, short);
+        long  (*wlp)(short, long, void*);
+        long  (*wpl)(short, void*, long);
+        long  (*wpp)(short, void*, void*);
     } fncall;
     UBYTE stdio_typ;    /* Standard I/O channel (highest bit must be set, too) */
     UBYTE shape;        /* FSHAPE_* -- which fncall union member to use */
@@ -190,7 +209,9 @@ typedef struct
 #ifndef __arm__
 enum {
     FSHAPE_V, FSHAPE_W, FSHAPE_L, FSHAPE_WW, FSHAPE_LL,
-    FSHAPE_LW, FSHAPE_LWW, FSHAPE_WLL, FSHAPE_WLLL
+    FSHAPE_LW, FSHAPE_LWW, FSHAPE_WLLL,
+    FSHAPE_P, FSHAPE_PL, FSHAPE_PW, FSHAPE_PWW,
+    FSHAPE_WLP, FSHAPE_WPL, FSHAPE_WPP
 };
 #endif
 
@@ -229,8 +250,8 @@ static const FND funcs[] =
     { F(xrawio),   0,    W_N(1,W) },   /* 0x06 */
     { F(xrawcin),  0x80, W_N(0,V) },   /* 0x07 */
     { F(xnecin),   0x80, W_N(0,V) },   /* 0x08 */
-    { F(xconws),   0x81, W_N(1,L) },   /* 0x09 */
-    { F(xconrs),   0x80, W_N(1,L) },   /* 0x0A */
+    { F(xconws),   0x81, W_N(1,P) },   /* 0x09 */
+    { F(xconrs),   0x80, W_N(1,P) },   /* 0x0A */
     { F(xconstat), 0x80, W_N(0,V) },   /* 0x0B */
 
     /*
@@ -260,7 +281,7 @@ static const FND funcs[] =
     { F(xauxostat), 0x82, W_N(0,V) },  /* 0x13 */
 
 #if CONF_WITH_ALT_RAM
-    { F(xmaddalt),  0, W_N(2,LL) },    /* 0x14 */
+    { F(xmaddalt),  0, W_N(2,PL) },    /* 0x14 */
 #else
     { NI, 0, 0 },               /* 0x14 */
 #endif
@@ -276,7 +297,7 @@ static const FND funcs[] =
     { NI, 0, 0 },
 
     { F(xgetdrv),  0, W_N(0,V) },      /* 0x19 */
-    { F(xsetdta),  0, W_N(1,L) },      /* 0x1A */
+    { F(xsetdta),  0, W_N(1,P) },      /* 0x1A */
 
     { NI, 0, 0 },
     { NI, 0, 0 },
@@ -313,35 +334,35 @@ static const FND funcs[] =
     { NI, 0, 0 },
     { NI, 0, 0 },
 
-    { F(xgetfree), 0, W_N(2,LW) },     /* 0x36 */
+    { F(xgetfree), 0, W_N(2,PW) },     /* 0x36 */
 
     { NI, 0, 0 },
     { NI, 0, 0 },
 
-    { F(xmkdir),   0, W_N(1,L) },      /* 0x39 */
-    { F(xrmdir),   0, W_N(1,L) },      /* 0x3A */
-    { F(xchdir),   0, W_N(1,L) },      /* 0x3B */
-    { F(xcreat),   0, W_N(2,LW) },     /* 0x3C */
-    { F(xopen),    0, W_N(2,LW) },     /* 0x3D */
+    { F(xmkdir),   0, W_N(1,P) },      /* 0x39 */
+    { F(xrmdir),   0, W_N(1,P) },      /* 0x3A */
+    { F(xchdir),   0, W_N(1,P) },      /* 0x3B */
+    { F(xcreat),   0, W_N(2,PW) },     /* 0x3C */
+    { F(xopen),    0, W_N(2,PW) },     /* 0x3D */
     { F(xclose),   0, W_N(1,W) },      /* 0x3E - will handle its own redirection */
-    { F(xread),    0x82, W_N(3,WLL) }, /* 0x3F */
-    { F(xwrite),   0x82, W_N(3,WLL) }, /* 0x40 */
-    { F(xunlink),  0, W_N(1,L) },      /* 0x41 */
+    { F(xread),    0x82, W_N(3,WLP) }, /* 0x3F */
+    { F(xwrite),   0x82, W_N(3,WLP) }, /* 0x40 */
+    { F(xunlink),  0, W_N(1,P) },      /* 0x41 */
     { F(xlseek),   0x81, W_N(3,LWW) }, /* 0x42 */
-    { F(xchmod),   0, W_N(3,LWW) },    /* 0x43 */
+    { F(xchmod),   0, W_N(3,PWW) },    /* 0x43 */
     { F(xmxalloc), 0, W_N(2,LW) },     /* 0x44 */
     { F(xdup),     0, W_N(1,W) },      /* 0x45 */
     { F(xforce),   0, W_N(2,WW) },     /* 0x46 */
-    { F(xgetdir),  0, W_N(2,LW) },     /* 0x47 */
+    { F(xgetdir),  0, W_N(2,PW) },     /* 0x47 */
     { F(xmalloc),  0, W_N(1,L) },      /* 0x48 */
-    { F(xmfree),   0, W_N(1,L) },      /* 0x49 */
-    { F(xsetblk),  0, W_N(3,WLL) },    /* 0x4A */
+    { F(xmfree),   0, W_N(1,P) },      /* 0x49 */
+    { F(xsetblk),  0, W_N(3,WPL) },    /* 0x4A */
     { F(xexec),    0, W_N(4,WLLL) },   /* 0x4B */
     { F(xterm),    0, W_N(1,W) },      /* 0x4C */
 
     { NI, 0, 0 },
 
-    { F(xsfirst),  0, W_N(2,LW) },     /* 0x4E */
+    { F(xsfirst),  0, W_N(2,PW) },     /* 0x4E */
     { F(xsnext),   0, W_N(0,V) },      /* 0x4F */
 
     { NI, 0, 0 },               /* 0x50 */
@@ -351,8 +372,8 @@ static const FND funcs[] =
     { NI, 0, 0 },
     { NI, 0, 0 },
 
-    { F(xrename),  0, W_N(3,WLL) },    /* 0x56 */
-    { F(xgsdtof),  0, W_N(3,LWW) }     /* 0x57 */
+    { F(xrename),  0, W_N(3,WPP) },    /* 0x56 */
+    { F(xgsdtof),  0, W_N(3,PWW) }     /* 0x57 */
 #undef F
 #undef NI
 #undef W_N
@@ -833,12 +854,36 @@ restrt:
             rc = (*f->fncall.lww)(PWLONG(1),pw[3],pw[4]);
             break;
 
-        case FSHAPE_WLL:
-            rc = (*f->fncall.wll)(pw[1],PWLONG(2),PWLONG(4));
-            break;
-
         case FSHAPE_WLLL:
             rc = (*f->fncall.wlll)(pw[1],(void*)PWLONG(2),(void*)PWLONG(4),(void*)PWLONG(6));
+            break;
+
+        case FSHAPE_P:
+            rc = (*f->fncall.p)((void*)PWLONG(1));
+            break;
+
+        case FSHAPE_PL:
+            rc = (*f->fncall.pl)((void*)PWLONG(1),PWLONG(3));
+            break;
+
+        case FSHAPE_PW:
+            rc = (*f->fncall.pw)((void*)PWLONG(1),pw[3]);
+            break;
+
+        case FSHAPE_PWW:
+            rc = (*f->fncall.pww)((void*)PWLONG(1),pw[3],pw[4]);
+            break;
+
+        case FSHAPE_WLP:
+            rc = (*f->fncall.wlp)(pw[1],PWLONG(2),(void*)PWLONG(4));
+            break;
+
+        case FSHAPE_WPL:
+            rc = (*f->fncall.wpl)(pw[1],(void*)PWLONG(2),PWLONG(4));
+            break;
+
+        case FSHAPE_WPP:
+            rc = (*f->fncall.wpp)(pw[1],(void*)PWLONG(2),(void*)PWLONG(4));
             break;
 
         default:

--- a/bdos/bdosmain.c
+++ b/bdos/bdosmain.c
@@ -167,7 +167,20 @@ typedef struct
         long  (*lw)(long, short);
         long  (*lww)(long, short, short);
         long  (*wll)(short, long, long);
-        long  (*wlll)(short, long, long, long);
+        /*
+         * xexec(WORD, char*, char*, char*) is the sole WLLL-shaped
+         * function, and all three "L" slots are real pointers (path,
+         * tail, env) -- not scalar longs. Under the plain stack ABI
+         * that made no difference (every argument gets an identically
+         * positioned 4-byte stack slot regardless of type), but under
+         * -mfastcall pointer- and long-typed arguments go to different
+         * register classes (a0/a1 vs d1/d2), so calling through a
+         * long-typed union member here would send xexec's path/tail
+         * pointers to the wrong registers. Use void* to match its real
+         * signature; harmless on the plain ABI since void* and long
+         * share the same stack layout there.
+         */
+        long  (*wlll)(short, void*, void*, void*);
     } fncall;
     UBYTE stdio_typ;    /* Standard I/O channel (highest bit must be set, too) */
     UBYTE shape;        /* FSHAPE_* -- which fncall union member to use */
@@ -825,7 +838,7 @@ restrt:
             break;
 
         case FSHAPE_WLLL:
-            rc = (*f->fncall.wlll)(pw[1],PWLONG(2),PWLONG(4),PWLONG(6));
+            rc = (*f->fncall.wlll)(pw[1],(void*)PWLONG(2),(void*)PWLONG(4),(void*)PWLONG(6));
             break;
 
         default:

--- a/bios/arch/m68k/aciavecs.S
+++ b/bios/arch/m68k/aciavecs.S
@@ -195,11 +195,18 @@ _init_acia_vecs:
 #endif /* CONF_WITH_IKBD_ACIA */
 
         // initialize the iorecs
+#if CONF_WITH_MFASTCALL
+        lea     _ikbdiorec,a0
+        lea     iorec_table,a1
+        move.l  #iorec_table_end-iorec_table,d0
+        jsr     _memmove
+#else
         pea     iorec_table_end-iorec_table
         pea     iorec_table
         pea     _ikbdiorec
         jsr     _memmove
         lea     12(sp),sp
+#endif
 
         // initialize IKBD-related variables
         moveq.l #0,d0

--- a/bios/arch/m68k/linea.S
+++ b/bios/arch/m68k/linea.S
@@ -168,25 +168,52 @@ hide_mouse:
         move.l  (sp)+,d0
         rts
 
+/*
+ * undraw_sprite/draw_sprite/linea_blit call cur_replace(MCS*),
+ * cur_display(Mcdb*,MCS*,WORD,WORD) and linea_blit(struct blit_frame*)
+ * with their arguments already in the fixed registers the Line-A
+ * hardware convention puts them in (see the comment above), which
+ * happens to line up with plain cdecl stack order but NOT with
+ * -mfastcall: there pointer arguments go in a0, then a1, not on the
+ * stack. Route them through those registers instead of pushing under
+ * -mfastcall; the plain-ABI push sequence is kept for other targets.
+ */
 undraw_sprite:
+#if CONF_WITH_MFASTCALL
+        movea.l a2,a0            /* save area ptr */
+        jsr     _cur_replace
+#else
         move.l  a2,-(sp)        /* save area ptr */
         jsr     _cur_replace
         addq.l  #4,sp
+#endif
         rts
 
 draw_sprite:
+#if CONF_WITH_MFASTCALL
+        movea.l a2,a1            /* save area ptr; a0 (new sprite), d0 (x)
+                                  * and d1 (y) are already where fastcall
+                                  * wants them */
+        jsr     _cur_display
+#else
         move.w  d1,-(sp)        /* y coord of hotspot */
         move.w  d0,-(sp)        /* x coord */
         move.l  a2,-(sp)        /* save area ptr */
         move.l  a0,-(sp)        /* new sprite */
         jsr     _cur_display
         lea     12(sp),sp
+#endif
         rts
 
 linea_blit:
+#if CONF_WITH_MFASTCALL
+        movea.l a6,a0                   // blit frame structure addr
+        jsr     _linea_blit
+#else
         move.l  a6,-(sp)                // blit frame structure addr
         jsr     _linea_blit
         addq.l  #4,sp
+#endif
         rts
 
         SECTION_RODATA

--- a/bios/arch/m68k/memory.S
+++ b/bios/arch/m68k/memory.S
@@ -448,9 +448,15 @@ detect_extra_stram:
 
         lea     5*1024*1024-1,a0        // start at the end of 5 MB
 loop_extra_stram:
+#if CONF_WITH_MFASTCALL
+        move.l  a0,d0                   // single scalar arg goes in d0
+#else
         pea     (a0)
+#endif
         jsr     _check_read_byte        // test the last byte
+#if !CONF_WITH_MFASTCALL
         addq.l  #4,sp
+#endif
         tst.w   d0                      // readable ?
         jeq     detect_extra_stram_end  // no, stop here
 

--- a/bios/arch/m68k/memory.S
+++ b/bios/arch/m68k/memory.S
@@ -625,10 +625,15 @@ any_boot:
 // Clear memory from a0 to a1
 call_bzero_a0_a1:
         sub.l   a0,a1
+#if CONF_WITH_MFASTCALL
+        move.l  a1,d0       // size
+        jsr     _bzero_nobuiltin
+#else
         move.l  a1,-(sp)    // size
         move.l  a0,-(sp)    // start
         jsr     _bzero_nobuiltin
         addq.l  #8,sp
+#endif
         rts
 
 #if CONF_WITH_ADVANCED_CPU

--- a/bios/arch/m68k/vectors.S
+++ b/bios/arch/m68k/vectors.S
@@ -122,6 +122,21 @@ buggy_jit_save_registers_before_bus_error:
  * On a warm boot, only the first 64 vectors are reinitialized.
  * This avoids overwriting crash dumps starting at address 0x380.
  */
+#if CONF_WITH_MFASTCALL
+_init_user_vec:
+        // under -mfastcall, the caller passes first_boot in d0 (not on the
+        // stack), and we need d0 free for the loop count below -- so decide
+        // the count into d1 first, then move it into d0 for the shared loop.
+        lea     user_vec, a0
+        lea     256, a1
+        moveq   #63, d1
+        tst.w   d0              // check FIRST_BOOT
+        jeq     set_uvec_fc
+        move.w  #191, d1
+set_uvec_fc:
+        move.l  d1, d0
+        jra     set_uvec
+#else
 _init_user_vec:
         lea     user_vec, a0
         lea     256, a1
@@ -129,6 +144,7 @@ _init_user_vec:
         tst.w   4(sp)           // check FIRST_BOOT
         jeq     set_uvec
         move.w  #191, d0
+#endif
 set_uvec:
         move.l  a0, (a1)+
 #ifdef __mcoldfire__

--- a/bios/arch/m68k/vectors.S
+++ b/bios/arch/m68k/vectors.S
@@ -1470,10 +1470,16 @@ _check_read_byte:
         move.l  (8).w,a1
         lea     berr.w(pc),a0
         move.l  a0,(8).w
+#if CONF_WITH_MFASTCALL
+        // the single scalar argument arrives in d0, not on the stack --
+        // move it to a0 before the moveq below clobbers d0
+        movea.l d0,a0
+#else
+        move.l  4(sp),a0
+#endif
         moveq   #0,d0
         nop                                     // flush pipeline
 
-        move.l  4(sp),a0
         jbsr    buggy_jit_save_registers_before_bus_error
         tst.b   (a0)            // this may cause a Bus Error
         nop                                     // flush pipeline

--- a/bios/arch/m68k/vectors.S
+++ b/bios/arch/m68k/vectors.S
@@ -560,10 +560,21 @@ _int_timerc:
         jsr     _int_vbl
 #endif
 
+        // etv_timer is void(*)(int): under -mfastcall the one scalar
+        // argument goes in d0, sign-extended to a full LONG the way a
+        // C caller would promote a WORD to int -- not pushed on the
+        // stack as the plain ABI below does.
+#if CONF_WITH_MFASTCALL
+        move.w  _timer_ms.w, d0
+        ext.l   d0
+        move.l  _etv_timer.w, a0
+        jsr     (a0)                    // jump to etv_timer routine
+#else
         move.w  _timer_ms.w, -(sp)
         move.l  _etv_timer.w, a0
         jsr     (a0)                    // jump to etv_timer routine
         addq.l  #2, sp                  // correct stack
+#endif
 
 #ifdef __mcoldfire__
         // On ColdFire, d0 and a0 will be restored later
@@ -1427,10 +1438,23 @@ _xbios_unimpl:
 /*
  * Supexec() function handler
  * See xbios.c for more information.
+ *
+ * LONG supexec(PFLONG) is called as a plain C function, tail-jumping
+ * (not jsr) to the caller's codeptr so it adds no stack frame of its
+ * own. Under -mfastcall its one pointer argument arrives in a0
+ * already, not on the stack -- reading 4(a7) here overwrote that
+ * correct a0 with whatever the fastcall-compiled caller's own stack
+ * happened to hold (since nothing was pushed for this call), turning
+ * every supexec() call into a wild jump to an unrelated address.
  */
+#if CONF_WITH_MFASTCALL
+_supexec:
+        jmp     (a0)
+#else
 _supexec:
         movea.l 4(a7),a0
         jmp     (a0)
+#endif
 
 #if CONF_WITH_BUS_ERROR
 

--- a/bios/arch/m68k/vectors.S
+++ b/bios/arch/m68k/vectors.S
@@ -1334,6 +1334,19 @@ bx_sp_ok:
         add.l   d1,d1           // indirection function table is 1 LW per
         add.l   d1,d1           // so multiply function number by 4
         add.l   d1,a0           // add to the base address of lookup table
+#if CONF_WITH_MFASTCALL
+        /*
+         * Under -mfastcall, a single-pointer-argument function like
+         * wrap_*(WORD *pw) takes that pointer in a0 -- which conflicts
+         * with using a0 as the jsr target register below, so load the
+         * handler address into a2 instead (free here: not part of the
+         * d3-d7/a3-a7 register-save set above), and put the argument
+         * pointer in a0.
+         */
+        move.l  (a0),a2         // a2 = the procedure's address
+        move.l  sp,a0           // a0 = pointer to the raw argument words
+        jsr     (a2)            // go do it and then come back
+#else
         move.l  (a0),a0         // get the procedures address
         /*
          * Pass a pointer to the raw, tightly-packed argument words as
@@ -1355,6 +1368,7 @@ bx_sp_ok:
         move.l  a1,-(sp)        // pass it as the callee's one argument
         jsr     (a0)            // go do it and then come back
         addq.l  #4,sp           // drop the pointer argument pushed above
+#endif
 
 bx_ret_exc:
         move.l  _savptr.w, a1

--- a/bios/bios.c
+++ b/bios/bios.c
@@ -371,6 +371,13 @@ static void bios_init(void)
     KDEBUG(("processor_init()\n"));
     processor_init();   /* Set CPU type, longframe and FPU type */
 
+#if CONF_DEBUG_FORCE_MC68000
+    /* see CONF_DEBUG_FORCE_MC68000's help */
+    mcpu = 0;
+    longframe = 0;
+    fputype = 0;
+#endif
+
 #if CONF_WITH_ADVANCED_CPU
     is_bus32 = (UBYTE)detect_32bit_address_bus();
 #endif

--- a/bios/machine/virt-m68k/goldfish_pic_isr.S
+++ b/bios/machine/virt-m68k/goldfish_pic_isr.S
@@ -9,6 +9,19 @@
  * int_timerc: virtio interrupts have nothing to do with EmuTOS's system
  * timer tick, so a plain register-save / dispatch / restore / rte is
  * enough.
+ *
+ * void goldfish_pic_dispatch(WORD pic_index) takes one scalar argument.
+ * Under -mfastcall that goes in d0, not on the stack: pushing it and
+ * calling through a plain jsr (the pre-fastcall convention below) left
+ * the compiled dispatch() reading pic_index out of d0 -- whatever the
+ * interrupted code happened to leave there -- since d0's incoming value
+ * here is only ever the interrupted code's own, never touched by this
+ * ISR before the call. dispatch() then uses that garbage index into
+ * pic_handlers[pic_index][bit] and calls whatever pointer it finds
+ * there: a wild call, firing asynchronously and unpredictably depending
+ * on what the interrupted code was doing with d0. Set d0 to the real
+ * pic_index (after saving the caller's own d0 alongside d1/a0-a1, so it
+ * comes back unchanged on return) instead of pushing it.
  */
 
 #include "asmdefs.h"
@@ -23,32 +36,52 @@
 
 _goldfish_pic_isr1:
         movem.l d0-d1/a0-a1,-(sp)
+#if CONF_WITH_MFASTCALL
+        moveq   #1,d0
+        jsr     _goldfish_pic_dispatch
+#else
         move.w  #1,-(sp)
         jsr     _goldfish_pic_dispatch
         addq.l  #2,sp
+#endif
         movem.l (sp)+,d0-d1/a0-a1
         rte
 
 _goldfish_pic_isr2:
         movem.l d0-d1/a0-a1,-(sp)
+#if CONF_WITH_MFASTCALL
+        moveq   #2,d0
+        jsr     _goldfish_pic_dispatch
+#else
         move.w  #2,-(sp)
         jsr     _goldfish_pic_dispatch
         addq.l  #2,sp
+#endif
         movem.l (sp)+,d0-d1/a0-a1
         rte
 
 _goldfish_pic_isr3:
         movem.l d0-d1/a0-a1,-(sp)
+#if CONF_WITH_MFASTCALL
+        moveq   #3,d0
+        jsr     _goldfish_pic_dispatch
+#else
         move.w  #3,-(sp)
         jsr     _goldfish_pic_dispatch
         addq.l  #2,sp
+#endif
         movem.l (sp)+,d0-d1/a0-a1
         rte
 
 _goldfish_pic_isr4:
         movem.l d0-d1/a0-a1,-(sp)
+#if CONF_WITH_MFASTCALL
+        moveq   #4,d0
+        jsr     _goldfish_pic_dispatch
+#else
         move.w  #4,-(sp)
         jsr     _goldfish_pic_dispatch
         addq.l  #2,sp
+#endif
         movem.l (sp)+,d0-d1/a0-a1
         rte

--- a/bios/machine/virt-m68k/goldfish_rtc_isr.S
+++ b/bios/machine/virt-m68k/goldfish_rtc_isr.S
@@ -16,6 +16,7 @@
         .globl  _goldfish_rtc_isr
         .extern _goldfish_rtc_service
         .extern _vector_5ms
+        .extern _longframe
 
         .text
 
@@ -44,13 +45,19 @@ _goldfish_rtc_isr:
         // directly at the interrupted code; only then do we restore the
         // real saved registers and issue our own RTE, which finally pops
         // the original frame. Same technique as bios/arch/m68k/amiga2.S's
-        // _amiga_int_ciaa_timer_b, simplified: that routine supports real
-        // 68000s and so must branch on _longframe; this board is always
-        // 68020+ (see startup.S), so the frame is unconditionally the
-        // 8-byte 68010+ format (SR, PC, format/vector word) -- format 0,
-        // vector 0, so RTE treats it as the plain/no-extra-data case.
+        // _amiga_int_ciaa_timer_b: this board's shipped configs are always
+        // 68020+ (see startup.S), but CONF_DEBUG_FORCE_MC68000 can force a
+        // plain-68000 identity for QEMU testing (see Kconfig.debug), so
+        // this still has to branch on _longframe like amiga2.S does --
+        // hardcoding the 68010+ 8-byte frame (SR, PC, format/vector word)
+        // left a real 68000's RTE popping only the 6-byte SR+PC frame it
+        // actually understands, leaving the format word on the stack to
+        // corrupt whatever the interrupted code finds there next.
         move.l  _vector_5ms,a0
-        clr.w   -(sp)                   // format/vector word
+        tst.w   _longframe
+        jeq     rtc_nolong
+        clr.w   -(sp)                   // format/vector word (68010+ only)
+rtc_nolong:
         pea     restore(pc)             // synthetic "return PC"
         move.w  sr,-(sp)                // synthetic SR
         jmp     (a0)

--- a/configs/atari192_defconfig
+++ b/configs/atari192_defconfig
@@ -1,2 +1,7 @@
 # 192 KB Atari ROM image
 TARGET_192=y
+# Doesn't fit in 192K without -mfastcall's code-size savings; needs
+# Thorsten Otto's toolchain (see CONF_WITH_MFASTCALL's help), which CI's
+# setup-toolchain action installs automatically for any config that sets
+# this.
+CONF_WITH_MFASTCALL=y

--- a/configs/atari256_defconfig
+++ b/configs/atari256_defconfig
@@ -1,2 +1,7 @@
 # 256 KB Atari ROM image
 TARGET_256=y
+# Doesn't fit in 256K without -mfastcall's code-size savings; needs
+# Thorsten Otto's toolchain (see CONF_WITH_MFASTCALL's help), which CI's
+# setup-toolchain action installs automatically for any config that sets
+# this.
+CONF_WITH_MFASTCALL=y

--- a/doc/debugging.txt
+++ b/doc/debugging.txt
@@ -1,0 +1,192 @@
+Interactive debugging under an emulator
+========================================
+
+This documents interactive debugging tools and techniques verified
+against this tree, as a companion to doc/install.txt (building) and
+the `ptos-smoketest` Claude skill (automated boot verification, pass
+signals, timing tables).
+
+
+Hatari's own built-in debugger
+-------------------------------
+
+Unreliable, and should not be trusted for anything beyond casual use:
+breakpoints (`b pc = <addr>`, `b VBL = <n>`) fire spuriously at reset
+with `cpureg` showing the all-zero reset state; memory reads can lie
+(a value the instruction trace shows being stored reads back as 0);
+`echo` in a debugger `.ini` crashes Hatari outright
+(`Str_UnEscape: Assertion 's2 < s1'`). See the `ptos-smoketest` skill
+for the full list of verified gotchas. Prefer one of the two tools
+below instead.
+
+
+hrdb: a reliable remote debugger for Hatari
+---------------------------------------------
+
+Stock Hatari (https://github.com/hatari/hatari) has no network-
+accessible debugger. A actively maintained fork,
+https://github.com/tattlemuss/hatari (branch `hrdb-main`), adds one:
+a TCP remote-debug protocol (`src/debug/remotedebug.c`) plus a Qt GUI
+called hrdb (`tools/hrdb/`) that talks to it. Project page:
+https://clarets.org/steve/projects/hrdb.html.
+
+The Qt GUI needs Qt 5.11+/6, generally unavailable in a headless
+container -- but the protocol itself is plain text over TCP and needs
+no GUI at all. `tools/rdb.py` in this repo is a minimal scripted
+client for it (see its module docstring for the API); use that
+instead of building the Qt frontend.
+
+### Building the patched Hatari
+
+    git clone --branch hrdb-main --depth 1 https://github.com/tattlemuss/hatari
+    cd hatari && mkdir build && cd build
+    cmake .. -DCMAKE_BUILD_TYPE=Release && make -j$(nproc)
+    # binary: build/src/hatari -- run it exactly like stock Hatari,
+    # same CLI flags as documented for the atari512/atari192/atari256
+    # targets in the ptos-smoketest skill
+
+Needs `libsdl2-dev` (`apt-get install -y libsdl2-dev`); cmake reports
+anything else missing. Verified against hrdb-main commit `21aa4cb`,
+building as Hatari v2.6.1.
+
+### The protocol
+
+Always active once Hatari is running -- no CLI flag needed. Listens
+on TCP port 56001, one client at a time. The emulator runs freely
+until a client sends "break"; the debug port is polled from the main
+event loop so it doesn't otherwise block emulation.
+
+Wire format (`src/debug/remotedebug.c`):
+  - Commands and replies are plain ASCII text, NUL-terminated (0x00).
+  - Multi-value replies separate fields with 0x01.
+  - Unsolicited notifications can arrive at any time and start with
+    "!" (e.g. "!status" when a breakpoint fires, "!symbols" when a
+    program loads) -- a client must be prepared to see these
+    interleaved with command replies, not just right after
+    connecting.
+  - On connect, the server immediately pushes four notifications, in
+    order: `!connected <protocol_id>`, `!config`, `!status`,
+    `!symbols`.
+  - Known quirk: every command reply is followed by a second, EMPTY
+    NUL-terminated message. `RemoteDebug_ProcessBuffer()` in the
+    server unconditionally calls `send_term()` after the command
+    handler has already sent its own terminator. Harmless if a client
+    skips empty messages; a client that reads exactly one message per
+    command instead misreads the *next* command's reply as this
+    phantom empty one. `tools/rdb.py` filters it out.
+  - Commands exercised so far: `status`, `break`, `step`, `run`,
+    `regs`, `mem`, `bp`, `bplist`. `bp`/`dbp` take a plain Hatari
+    breakpoint-condition expression (e.g. `pc=$fc23d8`) -- the same
+    syntax the interactive debugger's own `b` command uses. `mem`'s
+    reply payload is neither hex nor base64: it's a uuencode-like
+    scheme, 3 bytes packed into 4 characters each offset by 32 (see
+    `RemoteDebug_mem()` in the server source to extend the client to
+    other commands).
+
+### Process-management gotchas (observed in a sandboxed container)
+
+  - Launch with `setsid`, then `disown` it from the calling shell --
+    a plain `&`-backgrounded Hatari process was repeatedly observed
+    to die when the Bash tool call that started it returned, even
+    with `disown`; a `setsid`-detached one survives across separate
+    tool calls.
+  - Only one client is accepted at a time, and a stale process still
+    listening on port 56001 makes a newly launched Hatari fail to
+    start (`Failed to bind socket (bind() error: 98)`). Always check
+    `ps aux | grep 'build/src/hatari'` and kill any leftover PID
+    before relaunching.
+
+
+QEMU + GDB for m68k (virt-m68k)
+----------------------------------
+
+QEMU exposes a standard GDB remote-serial-protocol stub
+(`-S -gdb tcp::1234`), and `gdb-multiarch` connects to it reliably.
+This is the general recommended path for reproducing 68000-specific
+control-flow bugs (register/ABI mismatches, boot-sequencing issues)
+with real breakpoints and single-stepping -- much faster to iterate
+than Hatari, since virt-m68k boots in seconds under QEMU rather than
+tens of seconds.
+
+### Testing genuine-68000 code paths on virt-m68k
+
+`virt-m68k_defconfig` always uses `-cpu m68020` (see the `CPUFLAGS`
+comment in that file) because QEMU's `-cpu m68000` model has a real
+fidelity gap: it does not fault on "MOVE from CCR" (opcode 0x42C0),
+which is illegal on real 68000 silicon and is the *only* signal
+`bios/arch/m68k/processor.S`'s `_detect_cpu` has for telling a 68000
+apart from a 68010+. Confirmed by injecting the raw opcode into guest
+RAM and single-stepping over it under `-cpu m68000`: it executes as a
+normal instruction (PC advances by 2, D0 gets the CCR value) instead
+of trapping. Under `-cpu m68000`, pTOS's own detection therefore
+wrongly concludes 68010+, sets `longframe`, and every BIOS/XBIOS/
+GEMDOS trap misparses its argument frame from that point on.
+
+`CONF_DEBUG_FORCE_MC68000` (`Kconfig.debug`, `ARCH_M68K_CLASSIC` only,
+default `n`) works around this for testing: it forces
+`mcpu`/`longframe`/`fputype` to the real-68000 values right after
+`processor_init()` runs, regardless of what the (QEMU-fooled)
+auto-detection concluded. Never build a real target, or ship a config,
+with this on -- it will misidentify an actual 68010+ CPU as a 68000.
+Use it only on a throwaway virt-m68k debug build:
+
+    make virt-m68k_defconfig
+    # then edit .config:
+    #   CPUFLAGS="-m68000"
+    #   CONF_DEBUG_FORCE_MC68000=y
+    #   CONF_WITH_MFASTCALL=y                    (if testing fastcall)
+    #   CONF_WITH_LEGACY_RSC_LOAD=y               (TARGET_192/256 default
+    #   # CONF_WITH_PORTABLE_RSC_LOAD is not set    to legacy; match what
+    #                                               you're trying to repro)
+    make
+    qemu-system-m68k -M virt -m 128 -cpu m68000 -kernel virt-m68k.elf \
+      -d guest_errors -serial /dev/null -display none -S -gdb tcp::1234 &
+    gdb-multiarch -q -x script.gdb virt-m68k.elf
+
+### GDB scripting reliability notes
+
+  - `target remote` / `break *ADDR` / `continue` works reliably for
+    reaching the first stop. Repeated commands mixing breakpoint
+    `commands` blocks (which auto-`continue`) with further script
+    lines were flaky in this environment (intermittent "Cannot
+    execute this command while the target is running" on a later
+    step). Most reliable pattern: one `-x script.gdb` invocation per
+    breakpoint hit you actually need to inspect, restarting QEMU
+    fresh each time, rather than one long interactive session with
+    several breakpoints and continues chained together.
+  - Symbol addresses shift with every code-size change, so re-derive
+    them after any rebuild:
+    `m68k-atari-mintelf-nm virt-m68k.elf | grep ' _foo$'`.
+  - `-d exec` (full instruction trace) is invaluable for finding what
+    looped or crashed when setting up a breakpoint is too slow or the
+    crash site is unknown, but the output is enormous (millions of
+    lines within seconds of boot) -- redirect to a scratch file and
+    delete it immediately after grepping out what's needed, or it can
+    exhaust the session's disk quota.
+  - A raw opcode can be tested in isolation without booting pTOS at
+    all: connect to a freshly `-S`-paused QEMU (before any guest code
+    has run), then in gdb:
+    `set *(unsigned short*)0x2000 = 0xNNNN`,
+    `set $pc = 0x2000`, `set $sp = 0x3000`, `stepi`, and check `$pc`
+    (advanced normally by 2 = no fault; jumped elsewhere = it
+    trapped) plus any relevant registers. This is how the QEMU
+    `-cpu m68000` CCR gap above was confirmed.
+
+
+Which tool for which bug
+---------------------------
+
+  - A boot-sequencing or ABI/register-convention bug that's fully
+    reproducible on virt-m68k (no machine-specific hardware
+    involved): QEMU + GDB. Faster iteration, reliable scripting once
+    the "one script per breakpoint" pattern above is followed.
+  - A bug that depends on real Atari hardware behaviour (actual
+    memory map, actual TOS version, floppy/ACSI/MFP timing, or
+    anything that doesn't reproduce identically on virt-m68k): hrdb
+    against real Hatari. This is what found the actual root cause of
+    the atari192/atari256 `-mfastcall` boot crash (issue tracked on
+    the `feature/301-mfastcall-kernel-build` branch) -- a bug in
+    `memcpy`/`memmove`'s fastcall pointer-return convention that
+    virt-m68k's shorter, differently-timed boot never happened to
+    trigger, but that a full Hatari boot to a rendered desktop
+    reliably did.

--- a/tools/rdb.py
+++ b/tools/rdb.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+#
+# rdb.py - client for Hatari's hrdb remote-debug protocol
+#
+# This file is distributed under the GPL, version 2 or at your
+# option any later version.  See doc/license.txt for details.
+#
+"""Talks to a patched Hatari's remote-debug TCP port (56001) directly,
+without the hrdb Qt GUI. Useful for scripted/automated debugging of pTOS's
+m68k targets, and far more reliable than Hatari's own built-in debugger
+(unreliable breakpoints, memory reads that lie -- see the "Hatari v2.5.0
+debugger gotchas" section of .claude/skills/ptos-smoketest/SKILL.md).
+
+Requires a Hatari build from the "hrdb-main" branch of
+https://github.com/tattlemuss/hatari (a small, actively-maintained fork
+adding this protocol; upstream/stock Hatari does not have it):
+
+    git clone --branch hrdb-main --depth 1 https://github.com/tattlemuss/hatari
+    cd hatari && mkdir build && cd build
+    cmake .. -DCMAKE_BUILD_TYPE=Release && make -j$(nproc)
+    # binary at build/src/hatari -- run it exactly like stock Hatari
+
+The remote-debug port is always active once Hatari is running (no flag
+needed); the emulator runs freely until a client connects and sends
+"break". Protocol source: src/debug/remotedebug.c in that repo -- plain
+text, NUL-terminated commands/replies, 0x01-separated fields within a
+reply, unsolicited notifications prefixed with "!" (e.g. "!status" when
+a breakpoint is hit).
+
+Usage:
+    from rdb import RDB
+    r = RDB()                    # connect to 127.0.0.1:56001
+    r.bp("pc=$fc23d8")           # standard Hatari breakpoint expression
+    r.run()
+    stop = r.wait_stopped()      # blocks until the breakpoint fires
+    regs = r.regs()              # {"D0": ..., "PC": ..., "SR": ..., ...}
+    data, addr = r.mem(regs["A0"], 128)
+
+Run this file directly for a quick connectivity smoke test against an
+already-running Hatari instance.
+"""
+import socket
+import time
+
+SEP = b"\x01"
+
+
+class RDB:
+    def __init__(self, host="127.0.0.1", port=56001, timeout=10):
+        self.sock = socket.create_connection((host, port), timeout=timeout)
+        self.buf = b""
+        # Drain the initial handshake + notifications (!connected, !config, !status, !symbols)
+        self.notifications = []
+        self._drain_notifications()
+
+    def _read_msg(self):
+        while b"\x00" not in self.buf:
+            data = self.sock.recv(65536)
+            if not data:
+                raise ConnectionError("socket closed")
+            self.buf += data
+        msg, self.buf = self.buf.split(b"\x00", 1)
+        return msg
+
+    def _drain_notifications(self, timeout=5):
+        # RemoteDebugState_TryAccept() always sends exactly these four on
+        # connect, in this order (see remotedebug.c): !connected, !config,
+        # !status, !symbols. Read until the last one, rather than an idle
+        # timeout, since the whole burst can take a while to arrive.
+        self.sock.settimeout(timeout)
+        try:
+            while True:
+                msg = self._read_msg()
+                self.notifications.append(msg)
+                if msg.startswith(b"!symbols"):
+                    return
+        finally:
+            self.sock.settimeout(10)
+
+    def send_cmd(self, cmd):
+        """Send one command, return its reply (any '!' notifications seen
+        while waiting are stashed in self.notifications instead).
+
+        RemoteDebug_ProcessBuffer() unconditionally sends a second, empty
+        NUL-terminated message after every real reply (the command handler
+        already sent its own terminator, then the dispatcher sends one more)
+        -- skip those too, since a real reply is never empty."""
+        self.sock.sendall(cmd.encode() + b"\x00")
+        while True:
+            msg = self._read_msg()
+            if not msg or msg.startswith(b"!"):
+                if msg:
+                    self.notifications.append(msg)
+                continue
+            return msg
+
+    def parts(self, msg):
+        return msg.split(SEP)
+
+    # --- convenience wrappers -------------------------------------------------
+    def status(self):
+        p = self.parts(self.send_cmd("status"))
+        return {"ok": p[0] == b"OK", "running": int(p[1], 16), "pc": int(p[2], 16)}
+
+    def regs(self):
+        p = self.parts(self.send_cmd("regs"))
+        assert p[0] == b"OK", p[:3]
+        d = {}
+        i = 2  # p[1] is an empty field (send_key_value's own leading separator)
+        while i + 1 < len(p):
+            d[p[i].decode()] = int(p[i + 1], 16)
+            i += 2
+        return d
+
+    def mem(self, addr, count):
+        """Returns (bytes, actual_start_addr). Server encodes 3 bytes as 4
+        chars offset by 32 (a uuencode-like scheme), not base64/hex."""
+        msg = self.send_cmd(f"mem {addr:x} {count:x}")
+        p = msg.split(SEP, 3)
+        assert p[0] == b"OK", msg
+        raddr = int(p[1], 16)
+        rcount = int(p[2], 16)
+        enc = p[3]
+        out = bytearray()
+        for i in range(0, len(enc), 4):
+            chunk = enc[i:i + 4]
+            if len(chunk) < 4:
+                break
+            accum = 0
+            for c in chunk:
+                accum = (accum << 6) | ((c - 32) & 0x3F)
+            out += bytes([(accum >> 16) & 0xFF, (accum >> 8) & 0xFF, accum & 0xFF])
+        return bytes(out[:rcount]), raddr
+
+    def bp(self, expr):
+        """expr uses Hatari's standard breakpoint-condition syntax, e.g.
+        "pc=$fc23d8" or "pc=$fc23d8 && d0=0"."""
+        return self.send_cmd(f"bp {expr}")
+
+    def bplist(self):
+        return self.send_cmd("bplist")
+
+    def bpdel(self, idx):
+        return self.send_cmd(f"bpdel {idx:x}")
+
+    def step(self):
+        return self.send_cmd("step")
+
+    def run(self):
+        return self.send_cmd("run")
+
+    def break_(self):
+        return self.send_cmd("break")
+
+    def wait_stopped(self, timeout=60):
+        """Block until a "!status" notification reports execution stopped
+        (e.g. a breakpoint fired), and return {"pc": ...}."""
+        deadline = time.time() + timeout
+        self.sock.settimeout(1)
+        try:
+            while time.time() < deadline:
+                try:
+                    msg = self._read_msg()
+                except socket.timeout:
+                    continue
+                if msg.startswith(b"!status"):
+                    p = self.parts(msg)
+                    running = int(p[1], 16)
+                    if running == 0:
+                        return {"pc": int(p[2], 16)}
+                else:
+                    self.notifications.append(msg)
+        finally:
+            self.sock.settimeout(10)
+        raise TimeoutError("timed out waiting for stop")
+
+
+if __name__ == "__main__":
+    r = RDB()
+    print("notifications on connect:")
+    for n in r.notifications:
+        print(" ", n)
+    print("status:", r.status())
+    regs = r.regs()
+    print("PC=%08X SR=%04X D0=%08X A0=%08X" % (regs["PC"], regs["SR"], regs["D0"], regs["A0"]))

--- a/util/arch/m68k/memmove.S
+++ b/util/arch/m68k/memmove.S
@@ -90,6 +90,12 @@ _memcpy:
         move.l  a0,-(sp)         // dst
         bsr     memcpy_stackbody
         lea     12(sp),sp        // drop the frame built above
+        moveal  d0,a0            // pointer return goes in a0 under fastcall;
+                                  // the body below still only sets d0 (see
+                                  // its own "return destination pointer"
+                                  // comments -- that was correct for the
+                                  // pre-fastcall convention, and is now also
+                                  // needed by any non-fastcall caller left)
         rts
 
 _memmove:
@@ -98,6 +104,7 @@ _memmove:
         move.l  a0,-(sp)         // dst
         bsr     memmove_stackbody
         lea     12(sp),sp        // drop the frame built above
+        moveal  d0,a0            // see _memcpy above
         rts
 
 memcpy_stackbody:

--- a/util/arch/m68k/memmove.S
+++ b/util/arch/m68k/memmove.S
@@ -66,7 +66,44 @@
 // moves length bytes from src to dst. returns dst as passed.
 // the behaviour is undefined if the two regions overlap.
 
+/*
+ * Under -mfastcall, both entry points below take (dst, src, length) in
+ * a0/a1/d0 instead of on the stack -- but every exit point throughout the
+ * rest of this file (there are many: "end", "end1", "end4", ..., plus the
+ * simple loop below) reads them back off a classic cdecl frame at fixed
+ * offsets (4(sp)/8(sp)/12(sp)), and memcpy/memmove share most of that code
+ * via internal jumps. Rewriting every one of those offsets in place would
+ * be needlessly invasive and easy to get subtly wrong. Instead, build that
+ * exact frame from the incoming registers and bsr into the unchanged body:
+ * the frame this pushes (dst, src, length, in that order, right below the
+ * bsr's own return address) is byte-for-byte what a cdecl caller would
+ * have pushed before "jsr _memcpy", so the body needs no other change.
+ * Its own rts pops only the bsr's return address (matching plain cdecl
+ * callee behaviour: the *caller* pops arguments, not the callee), landing
+ * back here with the pushed frame still on the stack, in generic cdecl code
+ * as much as a real caller's, so we drop it as generic cdecl code would.
+ */
+#if CONF_WITH_MFASTCALL
 _memcpy:
+        move.l  d0,-(sp)         // length
+        move.l  a1,-(sp)         // src
+        move.l  a0,-(sp)         // dst
+        bsr     memcpy_stackbody
+        lea     12(sp),sp        // drop the frame built above
+        rts
+
+_memmove:
+        move.l  d0,-(sp)         // length
+        move.l  a1,-(sp)         // src
+        move.l  a0,-(sp)         // dst
+        bsr     memmove_stackbody
+        lea     12(sp),sp        // drop the frame built above
+        rts
+
+memcpy_stackbody:
+#else
+_memcpy:
+#endif
 #ifndef __mcoldfire__
         move.l   8(sp),a0        // load source pointer
         move.l   4(sp),a1        // load destination pointer
@@ -81,7 +118,11 @@ sdecr:
         move.l   4(sp),d0        // return destination pointer
         rts
 #endif
+#if CONF_WITH_MFASTCALL
+memmove_stackbody:
+#else
 _memmove:
+#endif
         move.l   8(sp),a0        // load source pointer
         move.l   4(sp),a1        // load destination pointer
 memmove:

--- a/util/arch/m68k/memset.S
+++ b/util/arch/m68k/memset.S
@@ -23,13 +23,33 @@
         .globl  _bzero_nobuiltin
 
         .text
+
+/*
+ * Under -mfastcall both entry points below take their arguments in
+ * registers (a0/d0/d1) instead of on the stack. Rather than rewrite every
+ * stack offset in the shared body (see the many "end"/"end1"/.../"zero4"
+ * exits below), build the equivalent cdecl stack frame from the incoming
+ * registers and bsr into the unchanged body -- same technique used in
+ * memmove.S, see the comment there for the full correctness argument.
+ */
 //
 // void bzero_nobuiltin(void *address, unsigned long size)
 //
 // the obscure name is to circumvent GCC converting a call to bzero()
 // to a call to memset()
 //
+#if CONF_WITH_MFASTCALL
 _bzero_nobuiltin:
+        move.l  d0,-(sp)         // size
+        move.l  a0,-(sp)         // address
+        bsr     bzero_stackbody
+        lea     8(sp),sp         // drop the frame built above
+        rts
+
+bzero_stackbody:
+#else
+_bzero_nobuiltin:
+#endif
         move.l   4(sp),a0
         move.l   8(sp),d0
         move.l   d7,-(sp)
@@ -39,7 +59,19 @@ _bzero_nobuiltin:
 // void *memset(void *address, int c, unsigned long size)
 // fills with byte c, returns the given address.
 
+#if CONF_WITH_MFASTCALL
 _memset:
+        move.l  d1,-(sp)         // size
+        move.l  d0,-(sp)         // c
+        move.l  a0,-(sp)         // address
+        bsr     memset_stackbody
+        lea     12(sp),sp        // drop the frame built above
+        rts
+
+memset_stackbody:
+#else
+_memset:
+#endif
         move.l   4(sp),a0
         move.l   d7,-(sp)
         move.w   14(sp),d0      // low word of c (int, 4 bytes since #300)

--- a/util/arch/m68k/miscasm.S
+++ b/util/arch/m68k/miscasm.S
@@ -234,8 +234,40 @@ mdrminus:
 
 /*
  * LONG protect_v(LONG (*func)(void));
+ *
+ * These four wrappers weren't wired up for -mfastcall at all: their
+ * bodies unconditionally read every argument off a plain-ABI stack
+ * frame, but a -mfastcall caller passes func in a0 and the scalar
+ * arguments in d0/d1/d2, spilling only what doesn't fit to the stack
+ * (confirmed against this GCC fork's own -mfastcall codegen for these
+ * exact argument shapes). Left as-is, every argument read here would
+ * come from wherever the caller's own stack happened to have -- e.g.
+ * a stale value from an earlier call, which is not a hypothetical: this
+ * is what let a garbled "func" pointer through protect_wlwwwl's caller
+ * (bios.c's hard-disk read/write path, hdv_rw) into a wild jsr.
+ *
+ * Fix: under -mfastcall, build the exact same plain-ABI frame each
+ * body already expects (func/args at the same fixed offsets, one full
+ * 4-byte slot each, matching how a plain-ABI caller pads WORD args --
+ * verified against this compiler's own non-fastcall codegen for the
+ * same signatures) by pushing the incoming registers, then bsr into
+ * the unchanged body under a new label. Only pop what this wrapper
+ * itself pushed before returning: any argument that didn't fit in
+ * a0/d0/d1/d2 arrived spilled on our own caller's stack (caller-cleanup,
+ * same convention as this file's other -mfastcall fixes), and must be
+ * left there for the caller to pop after we return, not touched here.
  */
+#if CONF_WITH_MFASTCALL
 _protect_v:
+        move.l   a0,-(sp)                // func
+        bsr      protect_v_stackbody
+        lea      4(sp),sp                // drop func pushed above (no caller stack args)
+        rts
+
+protect_v_stackbody:
+#else
+_protect_v:
+#endif
         move.l   4(sp),a0
         move.l   a2,-(sp)
         move.l   d2,-(sp)
@@ -247,7 +279,19 @@ _protect_v:
 /*
  * LONG protect_w(LONG (*func)(WORD), WORD);
  */
+#if CONF_WITH_MFASTCALL
 _protect_w:
+        ext.l    d0                      // a, sign-extended to a full slot
+        move.l   d0,-(sp)                // a
+        move.l   a0,-(sp)                // func
+        bsr      protect_w_stackbody
+        lea      8(sp),sp                // drop func/a pushed above (no caller stack args)
+        rts
+
+protect_w_stackbody:
+#else
+_protect_w:
+#endif
         move.l   4(sp),a0
         move.w   8(sp),d0
         move.l   a2,-(sp)
@@ -262,7 +306,21 @@ _protect_w:
 /*
  * LONG protect_ww(LONG (*func)(WORD), WORD, WORD);
  */
+#if CONF_WITH_MFASTCALL
 _protect_ww:
+        ext.l    d1                      // b, sign-extended to a full slot
+        move.l   d1,-(sp)                // b
+        ext.l    d0                      // a, sign-extended to a full slot
+        move.l   d0,-(sp)                // a
+        move.l   a0,-(sp)                // func
+        bsr      protect_ww_stackbody
+        lea      12(sp),sp               // drop func/a/b pushed above (no caller stack args)
+        rts
+
+protect_ww_stackbody:
+#else
+_protect_ww:
+#endif
         move.l   4(sp),a0
         move.l   8(sp),d0
         move.l   a2,-(sp)
@@ -276,8 +334,34 @@ _protect_ww:
 
 /*
  * LONG protect_wlwwwl(LONG (*func)(), WORD, LONG, WORD, WORD, WORD, LONG);
+ *
+ * Only the first 3 scalar args (a, b, c) fit in d0/d1/d2 alongside func
+ * in a0; d, e and f spill to our caller's stack, each already sign-
+ * extended to a full 4-byte slot by the caller (same convention as
+ * every other -mfastcall stack-spill fix in this tree), at 4(sp)/8(sp)/
+ * 12(sp) relative to our own entry sp.
  */
+#if CONF_WITH_MFASTCALL
 _protect_wlwwwl:
+        move.l   12(sp),-(sp)            // f, copied from our caller's spilled arg
+        move.l   12(sp),-(sp)            // e, ditto (offset shifted by the f push above)
+        move.l   12(sp),-(sp)            // d, ditto (offset shifted twice now)
+        ext.l    d2                      // c, sign-extended to a full slot
+        move.l   d2,-(sp)                // c
+        move.l   d1,-(sp)                // b (already a full LONG)
+        ext.l    d0                      // a, sign-extended to a full slot
+        move.l   d0,-(sp)                // a
+        move.l   a0,-(sp)                // func
+        bsr      protect_wlwwwl_stackbody
+        lea      28(sp),sp               // drop func/a/b/c/d/e/f pushed above; the
+                                          // caller's own spilled d/e/f are untouched
+                                          // and remain its to pop
+        rts
+
+protect_wlwwwl_stackbody:
+#else
+_protect_wlwwwl:
+#endif
         movem.l  8(sp),d0-d1/a0-a1
         move.l   a2,-(sp)
         move.l   d2,-(sp)

--- a/util/arch/m68k/miscasm.S
+++ b/util/arch/m68k/miscasm.S
@@ -23,6 +23,40 @@
  */
         .globl  _trap1_pexec    // Reentrant Pexec call
 _trap1_pexec:
+#if CONF_WITH_MFASTCALL
+        /*
+         * Build the GEMDOS wire frame trap #1 expects (opcode, mode,
+         * path, tail, env). Under -mfastcall a call to
+         * trap1_pexec(WORD mode, const char*, const char*, const char*)
+         * arrives with mode in d0, path in a0, tail in a1, and only env
+         * (the 4th argument -- fastcall has just two address registers)
+         * spilled to the stack, at 4(sp) relative to our own entry sp.
+         * Read env into a scratch register (d1, otherwise unused by
+         * this signature) before the d2/a2 save below touches the
+         * stack and shifts that offset, then build the frame directly
+         * against sp so it stays contiguous for the trap.
+         */
+        move.l  4(sp),d1        // env, from the caller's stack-spilled 4th arg
+#ifdef __mcoldfire__
+        move.l  a2,-(sp)
+        move.l  d2,-(sp)
+#else
+        movem.l d2/a2,-(sp)
+#endif
+        move.l  d1,-(sp)        // env
+        move.l  a1,-(sp)        // tail
+        move.l  a0,-(sp)        // path
+        move.w  d0,-(sp)        // mode, low word
+        move.w  #0x4b,-(sp)
+        trap    #1              // Pexec
+        lea     16(sp),sp
+#ifdef __mcoldfire__
+        move.l  (sp)+,d2
+        move.l  (sp)+,a2
+#else
+        movem.l (sp)+,d2/a2
+#endif
+#else
 #ifdef __mcoldfire__
         move.l  a2,-(sp)
         move.l  d2,-(sp)
@@ -56,6 +90,7 @@ _trap1_pexec:
         move.l  (sp)+,a2
 #else
         movem.l (sp)+,d2/a2
+#endif
 #endif
         rts
 

--- a/util/arch/m68k/optimopt.S
+++ b/util/arch/m68k/optimopt.S
@@ -25,8 +25,19 @@
  */
 
 _scasb:
+        /*
+         * scasb(char *p, char b) takes one pointer argument and one
+         * scalar argument. Under -mfastcall p arrives in a0 (already
+         * where this code needs it) and b arrives in d0, not on the
+         * stack; move it to d1, which is what the loop below reads (see
+         * the identical fix in this file's _strchr in stringasm.S).
+         */
+#if CONF_WITH_MFASTCALL
+        move.l  d0,d1
+#else
         move.l  4(sp),a0
         move.w  8(sp),d1
+#endif
 scasb_loop:
         move.b  (a0)+,d0
         jeq     scasb_end
@@ -47,8 +58,19 @@ scasb_end:
  */
 
 _expand_string:
+        /*
+         * expand_string(WORD *dest, BYTE *src) takes two pointer
+         * arguments. Under -mfastcall dest arrives in a0 and src in a1
+         * (the reverse of what this code's registers mean below), not
+         * on the stack; swap them into the a0=source/a1=dest convention
+         * the loop expects.
+         */
+#if CONF_WITH_MFASTCALL
+        exg     a0,a1            // a0 -> source, a1 -> dest
+#else
         movea.l 8(sp),a0        // a0 -> source
         movea.l 4(sp),a1        // a1 -> dest
+#endif
         move.l  a0,d0           // remember source start
         clr.w   d1              // work reg
 copy_loop:

--- a/util/arch/m68k/setjmp.S
+++ b/util/arch/m68k/setjmp.S
@@ -26,6 +26,28 @@
 
         .text
 
+#if CONF_WITH_MFASTCALL
+/*
+ * Under -mfastcall, setjmp(jmp_buf) and longjmp(jmp_buf, int) receive
+ * their arguments in a0 and a0/d0 respectively -- no stack read needed,
+ * unlike the plain stack-based ABI below.
+ */
+_setjmp:
+        move.l  (sp),(a0)+              // save setjmp() return address
+        movem.l d2-d7/a2-a7,(a0)        // save setjmp() caller registers
+        moveq   #0,d0                   // return from setjmp()
+        rts
+
+_longjmp:
+        tst.w   d0                      // requested setjmp() return value
+        jne     nonzero
+        moveq   #1,d0                   // if was 0, force it to 1
+nonzero:
+        move.l  (a0)+,d1                // get setjmp() return address
+        movem.l (a0),d2-d7/a2-a7        // restore setjmp() caller registers
+        move.l  d1,(sp)                 // force return address
+        rts                             // return to setjmp() caller
+#else
 _setjmp:
         move.l  4(sp),a0                // jmp_buf
         move.l  (sp),(a0)+              // save setjmp() return address
@@ -43,3 +65,4 @@ nonzero:
         movem.l (a0),d2-d7/a2-a7        // restore setjmp() caller registers
         move.l  d1,(sp)                 // force return address
         rts                             // return to setjmp() caller
+#endif

--- a/util/arch/m68k/stringasm.S
+++ b/util/arch/m68k/stringasm.S
@@ -21,8 +21,18 @@
  */
 
 _strlencpy:
+        /*
+         * strlencpy(char *RESTRICT dest, const char *RESTRICT src) has two
+         * pointer arguments. Under -mfastcall they already arrive exactly
+         * where this code needs them -- dest in a0, src in a1 -- so no
+         * register setup is needed at all; only the plain stack ABI below
+         * needs to read them off the caller's frame (see the identical
+         * fix in aes/arch/m68k/gemasm.S's _psetup/_switchto).
+         */
+#if !CONF_WITH_MFASTCALL
         movea.l 8(sp),a0
         movea.l 4(sp),a1
+#endif
         moveq   #0,d0
 lstcpy_loop:
 #ifdef __mcoldfire__
@@ -46,8 +56,19 @@ lstcpy_loop:
  */
 
 _strchr:
+        /*
+         * strchr(const char *s, int c) takes one pointer argument and one
+         * int argument. Under -mfastcall s arrives in a0 (already where
+         * this code needs it -- no setup needed) and c arrives in d0, not
+         * on the stack; move it to d1, which is what the loop below reads
+         * (see the identical fix in this file's _strlencpy).
+         */
+#if CONF_WITH_MFASTCALL
+        move.l  d0,d1
+#else
         move.l  4(sp),a0
         move.w  8(sp),d1
+#endif
 strchr_loop:
         move.b  (a0)+,d0
         jeq     strchr_null

--- a/vdi/arch/m68k/vdi_blit.S
+++ b/vdi/arch/m68k/vdi_blit.S
@@ -794,7 +794,23 @@ f2op_15:
 // It emulates the link opcode by setting a6 to FRAME_LEN plus the passed
 // address.  That way the rest of the assembler stuff can stay as
 // it is for now - some of it is also used for text blitting.
+//
+// Under -mfastcall, void fast_bit_blt(struct blit_frame*) passes its one
+// pointer argument in a0 instead of on the stack. Build the equivalent
+// cdecl stack frame from a0 and bsr into the unchanged body -- same
+// technique used in memset.S/memmove.S, see the comment there for the
+// full correctness argument.
+#if CONF_WITH_MFASTCALL
 _fast_bit_blt:
+        move.l  a0,-(sp)                 // start of frame
+        bsr     fast_bit_blt_stackbody
+        lea     4(sp),sp                 // drop the frame built above
+        rts
+
+fast_bit_blt_stackbody:
+#else
+_fast_bit_blt:
+#endif
         // A wrapper, so save and set up registers
         movea.l 4(sp),a0                // a0 -> start of frame
         movem.l d2-d7/a2-a6,-(sp)

--- a/vdi/arch/m68k/vdi_tblit.S
+++ b/vdi/arch/m68k/vdi_tblit.S
@@ -232,23 +232,27 @@
 // void normal_blit(LOCALVARS *vars, UBYTE *src, UBYTE *dst) has three
 // pointer arguments; under -mfastcall only the first two (vars, src) go
 // to address registers (a0, a1) -- the third (dst) is passed on the
-// stack, same as the plain ABI. Pop the real return address into d7:
-// the body's own movem.l d2-d7/a2-a6 below saves d7 on entry and
-// restores it on exit, so d7 comes back unchanged even though norm_blt
-// freely clobbers it as scratch in between -- d0/d1/a0/a1 do NOT have
-// this property (norm_blt uses them directly, e.g. norm_blt's own
-// "movew d1,d0" in do_rot), so stashing the return address in one of
-// those would lose it. Push vars/src above the already-stacked dst so
-// the unchanged body sees the same three-slot cdecl frame it always
-// has, then return through d7 manually since the real return address
-// no longer sits where a plain rts would find it.
+// stack, same as the plain ABI. Like the plain ABI, the STACK argument
+// is caller-cleanup: our caller (compiled under -mfastcall) pushes dst
+// before the call and pops it itself afterwards, so this wrapper must
+// leave dst on the stack for it -- only drop the vars/src slots pushed
+// below, not dst. Pop the real return address into d7: the body's own
+// movem.l d2-d7/a2-a6 below saves d7 on entry and restores it on exit,
+// so d7 comes back unchanged even though norm_blt freely clobbers it as
+// scratch in between -- d0/d1/a0/a1 do NOT have this property (norm_blt
+// uses them directly, e.g. norm_blt's own "movew d1,d0" in do_rot), so
+// stashing the return address in one of those would lose it. Push
+// vars/src above the already-stacked dst so the unchanged body sees the
+// same three-slot cdecl frame it always has, then return through d7
+// manually since the real return address no longer sits where a plain
+// rts would find it.
 #if CONF_WITH_MFASTCALL
 _normal_blit:
         move.l  (sp)+,d7                // d7 = real return address
         move.l  a1,-(sp)                 // src
         move.l  a0,-(sp)                 // vars
         bsr     normal_blit_stackbody
-        lea     12(sp),sp               // drop vars/src/dst built above
+        lea     8(sp),sp                // drop vars/src pushed above; dst is our caller's to pop
         movea.l d7,a0
         jmp     (a0)
 

--- a/vdi/arch/m68k/vdi_tblit.S
+++ b/vdi/arch/m68k/vdi_tblit.S
@@ -228,7 +228,30 @@
 /////////////////////////////////////////////////////////////////////////
 
 //  interface to 'norm_blt'
+//
+// void normal_blit(LOCALVARS *vars, UBYTE *src, UBYTE *dst) has three
+// pointer arguments; under -mfastcall only the first two (vars, src) go
+// to address registers (a0, a1) -- the third (dst) is passed on the
+// stack, same as the plain ABI. Pop the real return address into d0 (a
+// data register survives the movem.l d2-d7/a2-a6 below untouched, since
+// it only saves/restores that set), then push vars/src above the
+// already-stacked dst so the unchanged body sees the same three-slot
+// cdecl frame it always has, and return through d0 manually since the
+// real return address no longer sits where a plain rts would find it.
+#if CONF_WITH_MFASTCALL
 _normal_blit:
+        move.l  (sp)+,d0                // d0 = real return address
+        move.l  a1,-(sp)                 // src
+        move.l  a0,-(sp)                 // vars
+        bsr     normal_blit_stackbody
+        lea     12(sp),sp               // drop vars/src/dst built above
+        movea.l d0,a0
+        jmp     (a0)
+
+normal_blit_stackbody:
+#else
+_normal_blit:
+#endif
         movem.l d2-d7/a2-a6,-(sp)       // save registers that GCC expects unchanged
         move.l  44+4(sp),a6             // load ptr to end of vars
         move.l  44+8(sp),a0             // a0 & a1 must also be set

--- a/vdi/arch/m68k/vdi_tblit.S
+++ b/vdi/arch/m68k/vdi_tblit.S
@@ -232,20 +232,24 @@
 // void normal_blit(LOCALVARS *vars, UBYTE *src, UBYTE *dst) has three
 // pointer arguments; under -mfastcall only the first two (vars, src) go
 // to address registers (a0, a1) -- the third (dst) is passed on the
-// stack, same as the plain ABI. Pop the real return address into d0 (a
-// data register survives the movem.l d2-d7/a2-a6 below untouched, since
-// it only saves/restores that set), then push vars/src above the
-// already-stacked dst so the unchanged body sees the same three-slot
-// cdecl frame it always has, and return through d0 manually since the
-// real return address no longer sits where a plain rts would find it.
+// stack, same as the plain ABI. Pop the real return address into d7:
+// the body's own movem.l d2-d7/a2-a6 below saves d7 on entry and
+// restores it on exit, so d7 comes back unchanged even though norm_blt
+// freely clobbers it as scratch in between -- d0/d1/a0/a1 do NOT have
+// this property (norm_blt uses them directly, e.g. norm_blt's own
+// "movew d1,d0" in do_rot), so stashing the return address in one of
+// those would lose it. Push vars/src above the already-stacked dst so
+// the unchanged body sees the same three-slot cdecl frame it always
+// has, then return through d7 manually since the real return address
+// no longer sits where a plain rts would find it.
 #if CONF_WITH_MFASTCALL
 _normal_blit:
-        move.l  (sp)+,d0                // d0 = real return address
+        move.l  (sp)+,d7                // d7 = real return address
         move.l  a1,-(sp)                 // src
         move.l  a0,-(sp)                 // vars
         bsr     normal_blit_stackbody
         lea     12(sp),sp               // drop vars/src/dst built above
-        movea.l d0,a0
+        movea.l d7,a0
         jmp     (a0)
 
 normal_blit_stackbody:


### PR DESCRIPTION
Fixes #301.

**Stacked on #304** (issue #300) — this branch is based on `claude/issue-300-48pvhm`, not `master`, because #301 explicitly depends on #300's typed GEMDOS/BIOS/XBIOS trap bindings. This PR's base should be retargeted to `master` once #304 merges. (No CI has run on this branch yet for the same reason — the workflow doesn't trigger against a non-`master`-based PR.)

## Status: atari192/256 now boot to a stable, rendered desktop under `-mfastcall`

The original motivation for this PR (see the ROM-size table below) was fitting `atari192`/`atari256` back under their size budget. That's now actually verified end-to-end, not just measured at link time: both boot to a fully rendered, stable, idling GEM desktop in Hatari with `CONF_WITH_MFASTCALL=y`, over 1200+ VBLs with no unexpected bus errors.

## ROM-size case: proven

Static/link-time measurement, same `-Os -fomit-frame-pointer` flags both ways, only `-mfastcall` differs:

| Config | budget | non-fastcall | over/under | fastcall | over/under | savings |
|---|---|---|---|---|---|---|
| `atari192` | 196,608 B | 201,334 B | over by 4,726 | 188,838 B | under by 7,770 | **12,496 B (6.2%)** |
| `atari256` | 262,144 B | 268,414 B | over by 6,270 | 251,938 B | under by 10,206 | **16,476 B (6.1%)** |

The overflow numbers match #304's CI failures exactly. `-mfastcall` clears the overflow with real margin (~2.6x the needed savings on `atari192`, ~1.6x on `atari256`).

## Toolchain

Neither this repo's pinned toolchain (Vincent Rivière's `vriviere/mintelf` PPA) nor CI's had `-mfastcall` support. Verified against Thorsten Otto's fork (https://github.com/th-otto/m68k-atari-mint-gcc, prebuilt at https://tho-otto.m68k.eu/crossmint.php).

CI now installs it too: `setup-toolchain` gained an opt-in `mfastcall` input that downloads Thorsten Otto's prebuilt m68k-atari-mintelf toolchain (pinned by URL and sha256) and prepends it to `PATH`, with a compile-time `-mfastcall` probe that fails the job immediately if the resolved compiler doesn't actually support the flag. The `m68k` build job detects `CONF_WITH_MFASTCALL=y` per config the same way it already tells m68k from arm configs, so any current or future fastcall config in `configs/` picks the right toolchain automatically with no further workflow changes. No fastcall config exists in `configs/` yet, so this doesn't change what CI builds today — it's a standing follow-up for whenever one is added.

## What this does

- **Kconfig option** `CONF_WITH_MFASTCALL` (m68k only), with a build-time capability probe.
- `-msoft-float` passed explicitly on m68k (Thorsten Otto's GCC defaults to hard float once `-m68020`+ is selected).
- **A full audit and fix of every hand-written asm / mismatched-dispatch call site** that assumed the plain stack-based calling convention instead of `-mfastcall`'s register-based one (pointers in `a0`/`a1`, scalars in `d0`-`d2`, pointer returns in `a0`). Roughly three dozen fixes across:
  - **Hand-written asm entry points reading arguments off the stack instead of registers**: `trap1_pexec()`, `_dos_exec`, `trapaes`→`super()`, the `biosxbios` dispatcher, `memmove.S`/`memset.S`'s `_memcpy`/`_memmove`/`_memset`/`_bzero_nobuiltin`, `init_user_vec()`, `setjmp()`/`longjmp()`, `_fast_bit_blt`, `_normal_blit`, `Supexec()`, the `etv_timer` vector call, `goldfish_pic_isr.S`'s four PIC ISRs, `goldfish_rtc_isr.S`'s synthetic-frame `int_timerc` tail-jump, `linea.S`'s `undraw_sprite`/`draw_sprite`/`linea_blit`, `gemasm.S`'s `psetup()`/`switchto()`, `stringasm.S`/`optimopt.S`'s `strlencpy()`/`strchr()`/`scasb()`/`expand_string()`, and `check_read_byte()` (used by every hardware-presence probe in the tree — blitter, TT-RAM sizing, DSP, IDE, SCC, ...).
  - **Stale stack-push call sites** still calling now-fastcall-aware routines the old way: `memory.S`'s `call_bzero_a0_a1` and `detect_extra_stram`'s `check_read_byte` call, `aciavecs.S`'s `_init_acia_vecs`, `gemstart.S`'s `aes_restart`.
  - **A whole class of register-class mismatches in `bdosmain.c`'s GEMDOS dispatch table**: the table dispatches through a union of function pointers typed generically by argument *width*, which is safe under the plain stack ABI but not under `-mfastcall`, where pointer- and long-typed arguments of the same width go to different register classes. Split every shape into pointer-aware variants (`P`, `PL`, `PW`, `PWW`, `WLP`, `WPL`, `WPP`, `RL`, `RLW`) matching each function's real C signature — this affected most GEMDOS file and console I/O (`Cconws`, `Fopen`, `Fread`/`Fwrite`, `Mxalloc`/`Malloc`, and more).
  - **`memcpy`/`memmove`'s fastcall pointer-return convention** (`util/arch/m68k/memmove.S`) — the actual root cause of the atari192/atari256 boot crash (see below). Both take `(dst, src, length)` correctly in `a0`/`a1`/`d0` on entry, but every exit point in the shared copy body only ever set **d0** with the returned pointer, the pre-fastcall convention; under `-mfastcall` a pointer return belongs in **a0**. Any caller that relies on the ABI-correct return register — including ones that never explicitly assign it, like `desk/deskapp.c`'s `setup_iconblks()`, where GCC trusted the return register to already hold the advancing copy destination across a loop — got garbage.
  - A double stack-cleanup bug in `_normal_blit`'s fastcall wrapper specifically (see "How the deterministic crash was found" below) — the first of two root causes behind crashes this PR/issue #301 was tracking.
  - `protect_v`/`protect_w`/`protect_ww`/`protect_wlwwwl` in `miscasm.S` had no `-mfastcall` handling at all, discovered during soak-testing after the fix above.
- **Verified zero impact on the default (non-fastcall) path** throughout — every fix is `#if CONF_WITH_MFASTCALL`-guarded, and `atari512_defconfig` (non-fastcall m68k) and `rpi2_defconfig` (ARM) were rebuilt to confirm no regressions.

## Verified working

- **`virt-m68k-cli_defconfig`** boots completely: `coma_start`/`cmdmain` launch correctly, and the system settles into `cli/cmdedit.c`'s `read_line()` polling loop via repeated BIOS `Bconin` traps, the same idle state a normal boot reaches waiting for keyboard input.
- **`virt-m68k_defconfig`** (AES/desktop) boots completely. The crash first tracked down was 100% deterministic (crashed on AES `Super()` call #321 every time) and traced to a double stack-cleanup in `_normal_blit`'s `-mfastcall` wrapper (`vdi/arch/m68k/vdi_tblit.S`): `normal_blit(LOCALVARS*, UBYTE*, UBYTE*)` has three pointer args; only two (`vars`, `src`) fit in `a0`/`a1` under fastcall, so `dst` is spilled to the caller's stack under caller-cleanup, same as the plain ABI — but the wrapper's own `lea 12(sp),sp` popped that caller-owned `dst` slot *itself*, on top of the `vars`/`src` it had pushed, over-cleaning the stack by 4 bytes on every call and eventually returning through a stale stack slot. Fixed by only dropping the 8 bytes the wrapper itself pushed. **Verified with 2000+ successful AES `Super()` calls and no panic**, vs. a hard, 100%-reproducible crash at call #321 before the fix.
- **`atari192`/`atari256` in Hatari** (the actual production configs this PR exists for): boot to a fully rendered, stable, idling GEM desktop (menu bar, cursor, trash/printer icons) with `--machine st` (forced 68000, matching real atari192/256 hardware) — over 1200+ VBLs, zero unexpected bus errors. Root cause was the `memcpy`/`memmove` fastcall pointer-return bug above, surfaced through `desk/deskapp.c`'s `setup_iconblks()`: each icon's destination pointer drifted further off with every loop iteration (since it was implicitly tracked via the wrong return register), eventually landing back inside the ROM's own icon bitmap data and bus-faulting a few icons in — the actual mechanism behind the crash this PR/issue #301 was created for. A second, related bug (`check_read_byte()` reading its argument off the stack instead of `d0`, so every hardware-presence probe in the tree read essentially random addresses) was found immediately after: it surfaced as `has_blitter` wrongly reading true on plain ST, crashing VDI's rectangle fill when it tried to use non-existent blitter hardware.

## Debugging infrastructure added along the way

Finding the atari192/256 root cause needed better tooling than was available at the start of this branch — both additions are debug-only / dev-only, no effect on any shipped build:

- **`CONF_DEBUG_FORCE_MC68000`** (`Kconfig.debug`, off by default, `ARCH_M68K_CLASSIC` only): QEMU's `virt-m68k` machine normally has to run `-cpu m68020` (see the `CPUFLAGS` comment in `virt-m68k_defconfig`) because QEMU's `-cpu m68000` model doesn't fault on "MOVE from CCR", the one instruction pTOS's own CPU auto-detection relies on to tell a 68000 apart from a 68010+ — confirmed by injecting the raw opcode and single-stepping over it under `-cpu m68000` (it executes normally instead of trapping). That made virt-m68k useless for testing the actual 68000/non-longframe code path atari192/256 run. This option forces `mcpu`/`longframe`/`fputype` to the real-68000 values after auto-detection runs, so virt-m68k can stand in for real-68000 testing under QEMU+GDB — which is how `goldfish_rtc_isr.S`'s synthetic-frame bug (listed above) was found once this was in place.
- **`tools/rdb.py`**: a scripted client for a patched, remote-debuggable Hatari fork ([hrdb](https://clarets.org/steve/projects/hrdb.html), https://github.com/tattlemuss/hatari, `hrdb-main` branch) — real breakpoints, single-stepping, register/memory reads over a plain TCP protocol, without needing the fork's Qt GUI. This is what let the atari192/256 crash actually get root-caused directly against the real target, replacing much less reliable workarounds (stock Hatari's own debugger is known-unreliable; AVI-frame screen captures and deliberately-injected illegal instructions were used before this existed). Full writeup: `doc/debugging.txt` (new), plus two new sections in the `ptos-smoketest` Claude skill.

## Separately filed: #306 (not an ABI bug, not fixed here)

Extended soak-testing turned up a second, non-deterministic issue on `virt-m68k`: roughly 1 in 2-3 boots, the kernel runs off into a wild pointer walk that never traps. Root-caused to a **pre-existing race in `bios/virtio_gpu.c`'s `gpu_wait()`**, which polls for the GPU's display-info response with a fixed 100,000-iteration count instead of a time bound. This reproduces (less often) without `-mfastcall` too, so it predates this branch; full writeup and evidence in #306 (already has its own fix PR, #307). Not folded into this PR since it's a different bug in a different subsystem, specific to virt-m68k (no virtio-gpu on real Atari hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaMTgCtd14oqY17zsA7G36